### PR TITLE
`run_ai4rag.ipynb` notebook fix - point `kfp_components` installation to `rhoai_autorag` branch

### DIFF
--- a/samples/run_ai4rag.ipynb
+++ b/samples/run_ai4rag.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "code",
    "source": [
     "!pip install boto3 | tail -n 1\n",
-    "!pip install -U --no-cache-dir git+https://github.com/LukaszCmielowski/pipelines-components.git | tail -n 1\n",
+    "!pip install -U --no-cache-dir git+https://github.com/LukaszCmielowski/pipelines-components.git@rhoai_autorag | tail -n 1\n",
     "!pip install docling | tail -n 1\n",
     "!pip install \"ai4rag==0.2.1\" | tail -n 1"
    ],


### PR DESCRIPTION
Currentlly all autorag components are implemented on `rhoai_autorag` branch: https://github.com/LukaszCmielowski/pipelines-components/tree/rhoai_autorag

Temporary solution to run notebook.
