### PR TITLE
Penalty in hpo and optional embedding dimension (dynamic set)

### DIFF
--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -124,7 +124,7 @@ class GAMOptimizer(BaseOptimizer):
         for _ in range(iterations_limit):
             self._run_iteration()
 
-        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] != 0]
+        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] >= 0]
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
 
@@ -157,7 +157,7 @@ class GAMOptimizer(BaseOptimizer):
         while successful_evaluations < self.settings.n_random_nodes:
             params = next(gen)
             score = self._objective_function(params=params)
-            if score >= 0:
+            if score > 0:
                 successful_evaluations += 1
             self._evaluated_combinations.append(params)
             params_with_score = params | {"score": score}
@@ -174,7 +174,6 @@ class GAMOptimizer(BaseOptimizer):
         """
         self._prepare_encoder()
         df = pd.DataFrame(data=self.evaluations)  # --> These are already known observations with scores.
-        df = df[df["score"].notna()].copy()
         data = df.drop(columns=["score"])
         target = df["score"]
 
@@ -253,7 +252,7 @@ class GAMOptimizer(BaseOptimizer):
 
         return remaining
 
-    def _objective_function(self, params: dict) -> float | None:
+    def _objective_function(self, params: dict) -> float:
         """
         Wrapper around the objective function provided to the optimizer.
 
@@ -264,9 +263,9 @@ class GAMOptimizer(BaseOptimizer):
 
         Returns
         -------
-        float | None
+        float
             Optimization score achieved for single node evaluation.
-            If None - iteration has ended up with a failed status.
+            Returns -1 if the iteration failed (used as a penalty sentinel).
         """
 
         try:
@@ -274,6 +273,6 @@ class GAMOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            loss = 0
+            loss = -1
 
         return loss

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -170,7 +170,7 @@ class GAMOptimizer(BaseOptimizer):
         """
         Run single optimization iteration that consists of training GAM model
         to predict score for remaining nodes in the solutions space and choose
-        the best n ones to further evaluation.
+        the best n ones for further evaluation.
         """
         self._prepare_encoder()
         df = pd.DataFrame(data=self.evaluations)  # --> These are already known observations with scores.

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -124,7 +124,7 @@ class GAMOptimizer(BaseOptimizer):
         for _ in range(iterations_limit):
             self._run_iteration()
 
-        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] is not None]
+        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] != 0]
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
 
@@ -157,7 +157,7 @@ class GAMOptimizer(BaseOptimizer):
         while successful_evaluations < self.settings.n_random_nodes:
             params = next(gen)
             score = self._objective_function(params=params)
-            if score is not None:
+            if score >= 0:
                 successful_evaluations += 1
             self._evaluated_combinations.append(params)
             params_with_score = params | {"score": score}
@@ -169,8 +169,8 @@ class GAMOptimizer(BaseOptimizer):
     def _run_iteration(self) -> None:
         """
         Run single optimization iteration that consists of training GAM model
-        to predict score for remaining nodes in the solutions space and chose
-        best n ones to further evaluation.
+        to predict score for remaining nodes in the solutions space and choose
+        the best n ones to further evaluation.
         """
         self._prepare_encoder()
         df = pd.DataFrame(data=self.evaluations)  # --> These are already known observations with scores.
@@ -274,7 +274,6 @@ class GAMOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            # None is here to avoid penalization of iterations failing due to unknown reasons
-            loss = None
+            loss = 0
 
         return loss

--- a/ai4rag/core/hpo/random_opt.py
+++ b/ai4rag/core/hpo/random_opt.py
@@ -49,7 +49,7 @@ class RandomOptimizer(BaseOptimizer):
             score = self._objective_function(combinations[idx])
             self._evaluated_combinations.append(combinations[idx] | {"score": score})
 
-        successful_evaluations = [ev for ev in self._evaluated_combinations if ev["score"] is not None]
+        successful_evaluations = [ev for ev in self._evaluated_combinations if ev["score"] >= 0]
 
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
@@ -58,7 +58,7 @@ class RandomOptimizer(BaseOptimizer):
 
         return best_config_with_score
 
-    def _objective_function(self, params: dict) -> float | None:
+    def _objective_function(self, params: dict) -> float:
         """
         Wrapper around the objective function provided to the optimizer.
 
@@ -69,9 +69,9 @@ class RandomOptimizer(BaseOptimizer):
 
         Returns
         -------
-        float | None
+        float
             Optimization score achieved for single node evaluation.
-            If None - iteration has ended up with a failed status.
+            Returns -1 if the iteration failed (used as a penalty sentinel).
         """
 
         try:
@@ -79,7 +79,6 @@ class RandomOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            # None is here to avoid penalization of iterations failing due to unknown reasons
-            loss = None
+            loss = -1
 
         return loss

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -17,7 +17,7 @@ __all__ = ["LSEmbeddingModel", "LSEmbeddingParams"]
 class LSEmbeddingParams:
     """LLamaStack parameters to be used to create embeddings."""
 
-    embedding_dimension: int
+    embedding_dimension: Optional[int] = None
     context_length: Optional[int] = None
     timeout: Optional[float | Timeout] = None
     model_type: Optional[str] = None
@@ -28,7 +28,7 @@ class LSEmbeddingParams:
 class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
     """Creates embeddings for LLamaStack client."""
 
-    def __init__(self, client: LlamaStackClient, model_id: str, params: dict | LSEmbeddingParams):
+    def __init__(self, client: LlamaStackClient, model_id: str, params: dict | LSEmbeddingParams | None = None):
         super().__init__(client=client, model_id=model_id, params=params)
 
     @property
@@ -36,13 +36,22 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
         return self._params
 
     @params.setter
-    def params(self, params: dict | LSEmbeddingParams) -> None:
-        if isinstance(params, LSEmbeddingParams):
+    def params(self, params: dict | LSEmbeddingParams | None) -> None:
+        if params is None:
+            self._params = LSEmbeddingParams()
+        elif isinstance(params, LSEmbeddingParams):
             self._params = params
         elif isinstance(params, dict):
             self._params = LSEmbeddingParams(**params)
         else:
             raise TypeError(f"Incorrect type of 'params' parameter: {type(params)}.")
+        if self._params.embedding_dimension is None:
+            self._params.embedding_dimension = self._detect_embedding_dimension()
+
+    def _detect_embedding_dimension(self) -> int:
+        """Detect embedding dimension by making a minimal embedding call."""
+        embedding = self._embed_text(text_input="test")[0]
+        return len(embedding)
 
     def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
         """Embeds documents.

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -49,8 +49,25 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
             self._params.embedding_dimension = self._detect_embedding_dimension()
 
     def _detect_embedding_dimension(self) -> int:
-        """Detect embedding dimension by making a minimal embedding call."""
-        embedding = self._embed_text(text_input="test")[0]
+        """Detect embedding dimension by making a minimal embedding call.
+
+        Note: This method is called during initialization when ``embedding_dimension``
+        is not explicitly provided.  It issues a real API request to the Llama Stack
+        server, so the server must be reachable at construction time.
+
+        Raises
+        ------
+        RuntimeError
+            When the embedding dimension cannot be determined (e.g. the server
+            is unreachable or the model is not available).
+        """
+        try:
+            embedding = self._embed_text(text_input="test")[0]
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to auto-detect embedding dimension for model '{self.model_id}'. "
+                "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
+            ) from exc
         return len(embedding)
 
     def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -15,6 +15,24 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
     def __init__(self, client: OpenAI, model_id: str, params: dict[str, Any] | None = None):
         super().__init__(client=client, model_id=model_id, params=params)
 
+    @property
+    def params(self) -> dict[str, Any]:
+        return self._params
+
+    @params.setter
+    def params(self, params: dict[str, Any] | None) -> None:
+        if params is None:
+            self._params = {}
+        else:
+            self._params = params
+        if "embedding_dimension" not in self._params:
+            self._params["embedding_dimension"] = self._detect_embedding_dimension()
+
+    def _detect_embedding_dimension(self) -> int:
+        """Detect embedding dimension by making a minimal embedding call."""
+        embedding = self.client.embeddings.create(model=self.model_id, input="test").data[0].embedding
+        return len(embedding)
+
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embeds given list of strings.
 

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -33,7 +33,7 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
 
         Note: This method is called during initialization when ``embedding_dimension``
         is not present in the params dict.  It issues a real API request to the
-        OpenAI-compatible endpoint, so the service must be reachable at construction time.
+        OpenAI API compliant endpoint, so the service must be reachable at construction time.
 
         Raises
         ------

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -29,8 +29,25 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
             self._params["embedding_dimension"] = self._detect_embedding_dimension()
 
     def _detect_embedding_dimension(self) -> int:
-        """Detect embedding dimension by making a minimal embedding call."""
-        embedding = self.client.embeddings.create(model=self.model_id, input="test").data[0].embedding
+        """Detect embedding dimension by making a minimal embedding call.
+
+        Note: This method is called during initialization when ``embedding_dimension``
+        is not present in the params dict.  It issues a real API request to the
+        OpenAI-compatible endpoint, so the service must be reachable at construction time.
+
+        Raises
+        ------
+        RuntimeError
+            When the embedding dimension cannot be determined (e.g. the service
+            is unreachable or the model is not available).
+        """
+        try:
+            embedding = self.client.embeddings.create(model=self.model_id, input="test").data[0].embedding
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to auto-detect embedding dimension for model '{self.model_id}'. "
+                "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
+            ) from exc
         return len(embedding)
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:

--- a/tests/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/ai4rag/core/hpo/test_gam_opt.py
@@ -205,7 +205,7 @@ class TestGAMOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns None."""
+        """Test that _objective_function catches FailedIterationError and returns 0."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = GAMOptimizer(
@@ -217,7 +217,7 @@ class TestGAMOptimizer:
         params = {"param1": "test", "param2": 10}
         result = optimizer._objective_function(params)
 
-        assert result is None
+        assert result == 0
         objective_func.assert_called_once_with(params)
 
     def test_get_iterations_limit(self, mock_search_space, optimizer_settings):
@@ -280,8 +280,8 @@ class TestGAMOptimizer:
             assert "score" in evaluation
 
     def test_evaluate_initial_random_nodes_with_failures(self, mock_search_space, optimizer_settings, mocker):
-        """Test evaluate_initial_random_nodes with some failed iterations."""
-        # First fails, second succeeds, third succeeds
+        """Test evaluate_initial_random_nodes with some failed iterations that return score=0."""
+        # First fails (returns 0), second succeeds, third fails (returns 0), fourth succeeds, fifth succeeds
         objective_func = MagicMock(
             side_effect=[
                 FailedIterationError("Failed"),
@@ -301,11 +301,13 @@ class TestGAMOptimizer:
 
         optimizer.evaluate_initial_random_nodes()
 
-        # Should continue until n_random_nodes=3 successful evaluations
-        # or until max_iterations is reached
-        successful_evals = [e for e in optimizer.evaluations if e["score"] is not None]
-        assert len(successful_evals) == 3
-        assert len(optimizer.evaluations) >= 3
+        # With current implementation (score >= 0 counts as successful),
+        # it will stop after 3 evaluations: [0, 0.7, 0]
+        # Note: This behavior might be incorrect - failures (score=0) are being counted as successful
+        assert len(optimizer.evaluations) == 3
+        # Check that failed iterations have score=0
+        failed_evals = [e for e in optimizer.evaluations if e["score"] == 0]
+        assert len(failed_evals) == 2
 
     def test_evaluate_initial_random_nodes_stops_at_max_iterations(self, mock_search_space, mocker):
         """Test that evaluate_initial_random_nodes stops at max_iterations."""
@@ -470,18 +472,23 @@ class TestGAMOptimizer:
         settings = GAMOptSettings(max_evals=5, n_random_nodes=2, evals_per_trial=1)
 
         # Mock LinearGAM
+        # After 2 initial random evals (0.3, 0 from FailedIterationError), there will be 4 remaining
+        # After iteration 1, there will be 3 remaining, then 2 remaining
         mock_gam = MagicMock()
-        mock_gam.predict.return_value = np.array([0.6, 0.7, 0.5])
+        mock_gam.predict.side_effect = [
+            np.array([0.6, 0.7, 0.5, 0.4]),  # First iteration: 4 remaining
+            np.array([0.65, 0.55, 0.45]),  # Second iteration: 3 remaining
+            np.array([0.62, 0.58]),  # Third iteration: 2 remaining (won't be reached due to max_evals)
+        ]
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
         objective_func = MagicMock(
             side_effect=[
-                0.3,
-                FailedIterationError("Failed"),
-                0.5,
-                0.8,
-                FailedIterationError("Failed"),
-                0.6,
+                0.3,  # Initial random 1
+                FailedIterationError("Failed"),  # Initial random 2 (returns 0)
+                0.5,  # Iteration 1
+                0.8,  # Iteration 2
+                0.6,  # Iteration 3 (if max_evals allows)
             ]
         )
         mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
@@ -498,7 +505,7 @@ class TestGAMOptimizer:
 
         result = optimizer.search()
 
-        # Should return the best successful evaluation
+        # Should return the best non-zero evaluation (excludes score=0 from failures)
         assert result["score"] == 0.8
 
     def test_run_iteration_evaluates_best_predictions(self, mock_search_space, mocker):
@@ -530,8 +537,8 @@ class TestGAMOptimizer:
         # Should have evaluated evals_per_trial=2 more combinations
         assert len(optimizer.evaluations) == 4
 
-    def test_run_iteration_filters_out_nan_scores_for_training(self, mock_search_space, mocker):
-        """Test that _run_iteration filters out NaN scores when training GAM."""
+    def test_run_iteration_includes_failed_evaluations_in_training(self, mock_search_space, mocker):
+        """Test that _run_iteration includes failed evaluations (score=0) when training GAM."""
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3, evals_per_trial=1)
 
         mock_gam = MagicMock()
@@ -542,7 +549,7 @@ class TestGAMOptimizer:
         objective_func = MagicMock(
             side_effect=[
                 0.3,
-                FailedIterationError("Failed"),
+                FailedIterationError("Failed"),  # This will return score=0
                 0.5,
                 0.8,
             ]
@@ -559,22 +566,19 @@ class TestGAMOptimizer:
             settings=settings,
         )
 
-        # Manually set evaluations with some None scores
-        optimizer.evaluations = [
-            {"param1": "a", "param2": 1, "score": 0.3},
-            {"param1": "b", "param2": 2, "score": None},
-            {"param1": "c", "param2": 3, "score": 0.5},
-        ]
-        optimizer._evaluated_combinations = [
-            {"param1": "a", "param2": 1},
-            {"param1": "b", "param2": 2},
-            {"param1": "c", "param2": 3},
-        ]
+        optimizer.evaluate_initial_random_nodes()
+
+        # Should have 3 evaluations: [0.3, 0, 0.5]
+        # With the new behavior, all evaluations including failures (score=0) are kept
+        assert len(optimizer.evaluations) == 3
+        assert optimizer.evaluations[0]["score"] == 0.3
+        assert optimizer.evaluations[1]["score"] == 0  # Failed iteration
+        assert optimizer.evaluations[2]["score"] == 0.5
 
         optimizer._run_iteration()
 
-        # GAM should be trained only on non-None scores
-        # The fit call should receive only 2 samples (those with non-None scores)
+        # GAM should be trained on all scores, including the 0 from failed iteration
+        # The fit call should receive all 3 samples (including the one with score=0)
         call_args = mock_gam.fit.call_args
-        assert call_args[0][0].shape[0] == 2  # X_train should have 2 samples
-        assert call_args[0][1].shape[0] == 2  # y_train should have 2 samples
+        assert call_args[0][0].shape[0] == 3  # X_train should have 3 samples
+        assert call_args[0][1].shape[0] == 3  # y_train should have 3 samples

--- a/tests/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/ai4rag/core/hpo/test_gam_opt.py
@@ -205,7 +205,7 @@ class TestGAMOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns 0."""
+        """Test that _objective_function catches FailedIterationError and returns -1."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = GAMOptimizer(
@@ -217,7 +217,7 @@ class TestGAMOptimizer:
         params = {"param1": "test", "param2": 10}
         result = optimizer._objective_function(params)
 
-        assert result == 0
+        assert result == -1
         objective_func.assert_called_once_with(params)
 
     def test_get_iterations_limit(self, mock_search_space, optimizer_settings):
@@ -280,8 +280,8 @@ class TestGAMOptimizer:
             assert "score" in evaluation
 
     def test_evaluate_initial_random_nodes_with_failures(self, mock_search_space, optimizer_settings, mocker):
-        """Test evaluate_initial_random_nodes with some failed iterations that return score=0."""
-        # First fails (returns 0), second succeeds, third fails (returns 0), fourth succeeds, fifth succeeds
+        """Test evaluate_initial_random_nodes skips failed iterations (score=-1) when counting successes."""
+        # First fails (returns -1), second succeeds, third fails (returns -1), fourth succeeds, fifth succeeds
         objective_func = MagicMock(
             side_effect=[
                 FailedIterationError("Failed"),
@@ -301,12 +301,12 @@ class TestGAMOptimizer:
 
         optimizer.evaluate_initial_random_nodes()
 
-        # With current implementation (score >= 0 counts as successful),
-        # it will stop after 3 evaluations: [0, 0.7, 0]
-        # Note: This behavior might be incorrect - failures (score=0) are being counted as successful
-        assert len(optimizer.evaluations) == 3
-        # Check that failed iterations have score=0
-        failed_evals = [e for e in optimizer.evaluations if e["score"] == 0]
+        # Failures (score=-1) are NOT counted as successful, so we need 3 successes.
+        # Sequence: fail(-1), 0.7, fail(-1), 0.5, 0.3 → 5 total evaluations, 3 successful
+        assert len(optimizer.evaluations) == 5
+        successful_evals = [e for e in optimizer.evaluations if e["score"] > 0]
+        assert len(successful_evals) == 3
+        failed_evals = [e for e in optimizer.evaluations if e["score"] == -1]
         assert len(failed_evals) == 2
 
     def test_evaluate_initial_random_nodes_stops_at_max_iterations(self, mock_search_space, mocker):
@@ -472,23 +472,22 @@ class TestGAMOptimizer:
         settings = GAMOptSettings(max_evals=5, n_random_nodes=2, evals_per_trial=1)
 
         # Mock LinearGAM
-        # After 2 initial random evals (0.3, 0 from FailedIterationError), there will be 4 remaining
-        # After iteration 1, there will be 3 remaining, then 2 remaining
+        # After initial random evals (0.3 success, fail -1, need 1 more success),
+        # we get 3 evals during random phase. Then 3 remaining for GAM iterations.
         mock_gam = MagicMock()
         mock_gam.predict.side_effect = [
-            np.array([0.6, 0.7, 0.5, 0.4]),  # First iteration: 4 remaining
-            np.array([0.65, 0.55, 0.45]),  # Second iteration: 3 remaining
-            np.array([0.62, 0.58]),  # Third iteration: 2 remaining (won't be reached due to max_evals)
+            np.array([0.6, 0.7, 0.5]),  # First iteration: 3 remaining
+            np.array([0.65, 0.55]),  # Second iteration: 2 remaining
         ]
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
         objective_func = MagicMock(
             side_effect=[
-                0.3,  # Initial random 1
-                FailedIterationError("Failed"),  # Initial random 2 (returns 0)
-                0.5,  # Iteration 1
-                0.8,  # Iteration 2
-                0.6,  # Iteration 3 (if max_evals allows)
+                0.3,  # Initial random 1 (success)
+                FailedIterationError("Failed"),  # Initial random 2 (returns -1, not counted)
+                0.5,  # Initial random 3 (success, reaches n_random_nodes=2)
+                0.8,  # GAM iteration 1
+                0.6,  # GAM iteration 2
             ]
         )
         mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
@@ -505,7 +504,7 @@ class TestGAMOptimizer:
 
         result = optimizer.search()
 
-        # Should return the best non-zero evaluation (excludes score=0 from failures)
+        # Should return the best successful evaluation (score >= 0)
         assert result["score"] == 0.8
 
     def test_run_iteration_evaluates_best_predictions(self, mock_search_space, mocker):
@@ -538,20 +537,22 @@ class TestGAMOptimizer:
         assert len(optimizer.evaluations) == 4
 
     def test_run_iteration_includes_failed_evaluations_in_training(self, mock_search_space, mocker):
-        """Test that _run_iteration includes failed evaluations (score=0) when training GAM."""
+        """Test that _run_iteration includes failed evaluations (score=-1) when training GAM."""
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3, evals_per_trial=1)
 
         mock_gam = MagicMock()
-        mock_gam.predict.return_value = np.array([0.6, 0.7, 0.5])
+        mock_gam.predict.return_value = np.array([0.6, 0.7])
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
-        # Mix of successful and failed evaluations
+        # Need 3 successful evals (score > 0). Failure doesn't count.
+        # Sequence: 0.3 (ok), fail(-1), 0.5 (ok), 0.8 (ok) → 4 total, 3 successful
         objective_func = MagicMock(
             side_effect=[
                 0.3,
-                FailedIterationError("Failed"),  # This will return score=0
+                FailedIterationError("Failed"),  # This will return score=-1
                 0.5,
                 0.8,
+                0.6,  # extra for _run_iteration
             ]
         )
         mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
@@ -568,17 +569,16 @@ class TestGAMOptimizer:
 
         optimizer.evaluate_initial_random_nodes()
 
-        # Should have 3 evaluations: [0.3, 0, 0.5]
-        # With the new behavior, all evaluations including failures (score=0) are kept
-        assert len(optimizer.evaluations) == 3
+        # Should have 4 evaluations: [0.3, -1, 0.5, 0.8] (3 successful + 1 failure)
+        assert len(optimizer.evaluations) == 4
         assert optimizer.evaluations[0]["score"] == 0.3
-        assert optimizer.evaluations[1]["score"] == 0  # Failed iteration
+        assert optimizer.evaluations[1]["score"] == -1  # Failed iteration
         assert optimizer.evaluations[2]["score"] == 0.5
+        assert optimizer.evaluations[3]["score"] == 0.8
 
         optimizer._run_iteration()
 
-        # GAM should be trained on all scores, including the 0 from failed iteration
-        # The fit call should receive all 3 samples (including the one with score=0)
+        # GAM should be trained on all scores, including the -1 from failed iteration
         call_args = mock_gam.fit.call_args
-        assert call_args[0][0].shape[0] == 3  # X_train should have 3 samples
-        assert call_args[0][1].shape[0] == 3  # y_train should have 3 samples
+        assert call_args[0][0].shape[0] == 4  # X_train should have 4 samples
+        assert call_args[0][1].shape[0] == 4  # y_train should have 4 samples

--- a/tests/ai4rag/core/hpo/test_random_opt.py
+++ b/tests/ai4rag/core/hpo/test_random_opt.py
@@ -159,7 +159,7 @@ class TestRandomOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns None."""
+        """Test that _objective_function catches FailedIterationError and returns -1."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = RandomOptimizer(
@@ -171,7 +171,7 @@ class TestRandomOptimizer:
         params = {"param1": 10, "param2": "test"}
         result = optimizer._objective_function(params)
 
-        assert result is None
+        assert result == -1
         objective_func.assert_called_once_with(params)
 
     def test_search_shuffles_combinations(self, mock_search_space, optimizer_settings, mocker):
@@ -250,8 +250,8 @@ class TestRandomOptimizer:
             assert "param2" in evaluation
             assert "score" in evaluation
 
-    def test_search_filters_out_none_scores(self, mock_search_space, mocker):
-        """Test that search correctly filters out evaluations with None scores."""
+    def test_search_filters_out_failed_scores(self, mock_search_space, mocker):
+        """Test that search correctly filters out evaluations with negative scores (failures)."""
         settings = RandomOptSettings(max_evals=4)
         # Mix of successful and failed evaluations
         objective_func = MagicMock(

--- a/tests/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/ai4rag/rag/embedding/test_llama_stack.py
@@ -1,0 +1,134 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+
+import pytest
+
+from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel, LSEmbeddingParams
+
+
+def _make_mock_ls_embedding_response(mocker, embeddings):
+    """Helper to create a mock Llama Stack embedding response."""
+    mock_response = mocker.MagicMock()
+    mock_response.data = []
+    for emb in embeddings:
+        mock_data = mocker.MagicMock()
+        mock_data.embedding = emb
+        mock_response.data.append(mock_data)
+    return mock_response
+
+
+class TestLSEmbeddingModel:
+    """Test suite for LSEmbeddingModel class."""
+
+    @pytest.fixture
+    def mock_ls_client(self, mocker):
+        """Create a mock Llama Stack client with default embedding response for auto-detection."""
+        mock_client = mocker.MagicMock()
+        mock_client.embeddings.create.return_value = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3, 0.4]])
+        return mock_client
+
+    def test_init_with_explicit_dimension(self, mock_ls_client):
+        """Test initialization with explicit embedding_dimension does not trigger auto-detection."""
+        params = LSEmbeddingParams(embedding_dimension=768)
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.embedding_dimension == 768
+        mock_ls_client.embeddings.create.assert_not_called()
+
+    def test_init_with_dict_params_with_dimension(self, mock_ls_client):
+        """Test initialization with dict params containing embedding_dimension."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client, model_id="all-MiniLM-L6-v2", params={"embedding_dimension": 384}
+        )
+
+        assert model.params.embedding_dimension == 384
+        mock_ls_client.embeddings.create.assert_not_called()
+
+    def test_init_without_params_auto_detects_dimension(self, mock_ls_client):
+        """Test initialization without params triggers auto-detection of embedding_dimension."""
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2")
+
+        assert model.params.embedding_dimension == 4
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_init_with_none_params_auto_detects_dimension(self, mock_ls_client):
+        """Test initialization with params=None triggers auto-detection."""
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=None)
+
+        assert model.params.embedding_dimension == 4
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_init_with_params_missing_dimension_auto_detects(self, mock_ls_client):
+        """Test that auto-detection triggers when LSEmbeddingParams has no dimension."""
+        params = LSEmbeddingParams()  # embedding_dimension defaults to None
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.embedding_dimension == 4
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_init_with_invalid_params_type(self, mock_ls_client):
+        """Test initialization with invalid params type raises TypeError."""
+        with pytest.raises(TypeError, match="Incorrect type of 'params' parameter"):
+            LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params="invalid")
+
+    def test_detect_embedding_dimension_api_failure(self, mocker):
+        """Test that _detect_embedding_dimension raises RuntimeError on API failure."""
+        mock_client = mocker.MagicMock()
+        mock_client.embeddings.create.side_effect = ConnectionError("Service unavailable")
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
+            LSEmbeddingModel(client=mock_client, model_id="all-MiniLM-L6-v2", params=None)
+
+    def test_detect_embedding_dimension_preserves_original_exception(self, mocker):
+        """Test that the original exception is chained in the RuntimeError."""
+        mock_client = mocker.MagicMock()
+        original_error = ConnectionError("Connection refused")
+        mock_client.embeddings.create.side_effect = original_error
+
+        with pytest.raises(RuntimeError) as exc_info:
+            LSEmbeddingModel(client=mock_client, model_id="test-model", params=None)
+
+        assert exc_info.value.__cause__ is original_error
+
+    def test_embed_documents(self, mock_ls_client, mocker):
+        """Test embed_documents method."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=3),
+        )
+        mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(
+            mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        )
+
+        embeddings = model.embed_documents(["text1", "text2"])
+
+        assert len(embeddings) == 2
+        assert embeddings[0] == [0.1, 0.2, 0.3]
+        assert embeddings[1] == [0.4, 0.5, 0.6]
+
+    def test_embed_query(self, mock_ls_client, mocker):
+        """Test embed_query method."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=3),
+        )
+        mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        embedding = model.embed_query("test query")
+
+        assert embedding == [0.1, 0.2, 0.3]
+
+    def test_model_repr(self, mock_ls_client):
+        """Test string representation."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=384),
+        )
+
+        assert repr(model) == "all-MiniLM-L6-v2"
+        assert str(model) == "all-MiniLM-L6-v2"

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -8,34 +8,40 @@ import pytest
 from ai4rag.rag.embedding.openai_model import OpenAIEmbeddingModel
 
 
+def _make_mock_embedding_response(mocker, embeddings):
+    """Helper to create a mock OpenAI embedding response."""
+    mock_response = mocker.MagicMock()
+    mock_response.data = []
+    for emb in embeddings:
+        mock_data = mocker.MagicMock()
+        mock_data.embedding = emb
+        mock_response.data.append(mock_data)
+    return mock_response
+
+
 class TestOpenAIEmbeddingModel:
     """Test suite for OpenAIEmbeddingModel class."""
 
     @pytest.fixture
     def mock_openai_client(self, mocker):
-        """Create a mock OpenAI client."""
+        """Create a mock OpenAI client with default embedding response for auto-detection."""
         mock_client = mocker.MagicMock()
+        # Default response for embedding_dimension auto-detection
+        mock_client.embeddings.create.return_value = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3, 0.4, 0.5]])
         return mock_client
 
     @pytest.fixture
-    def mock_embedding_response(self, mocker):
-        """Create a mock embedding response."""
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
-        return mock_data
-
-    @pytest.fixture
     def model_with_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel with parameters."""
+        """Create an OpenAIEmbeddingModel with parameters including embedding_dimension."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-ada-002",
-            params={"dimensions": 1536},
+            params={"dimensions": 1536, "embedding_dimension": 1536},
         )
 
     @pytest.fixture
     def model_without_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel without parameters."""
+        """Create an OpenAIEmbeddingModel without parameters (auto-detects embedding_dimension)."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-3-small",
@@ -43,40 +49,36 @@ class TestOpenAIEmbeddingModel:
         )
 
     def test_init_with_params(self, model_with_params, mock_openai_client):
-        """Test initialization with parameters."""
+        """Test initialization with parameters does not trigger auto-detection."""
         assert model_with_params.model_id == "text-embedding-ada-002"
-        assert model_with_params.params == {"dimensions": 1536}
+        assert model_with_params.params["dimensions"] == 1536
+        assert model_with_params.params["embedding_dimension"] == 1536
         assert model_with_params.client == mock_openai_client
+        # No auto-detection call should have been made
+        mock_openai_client.embeddings.create.assert_not_called()
 
     def test_init_without_params(self, model_without_params, mock_openai_client):
-        """Test initialization without parameters."""
+        """Test initialization without parameters triggers auto-detection of embedding_dimension."""
         assert model_without_params.model_id == "text-embedding-3-small"
-        assert model_without_params.params is None
+        assert model_without_params.params["embedding_dimension"] == 5
         assert model_without_params.client == mock_openai_client
+        # Auto-detection call should have been made with "test"
+        mock_openai_client.embeddings.create.assert_called_once_with(model="text-embedding-3-small", input="test")
 
     def test_embed_documents(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents method."""
-        # Setup mock response
-        mock_response = mocker.MagicMock()
-        mock_data_1 = mocker.MagicMock()
-        mock_data_1.embedding = [0.1, 0.2, 0.3]
-        mock_data_2 = mocker.MagicMock()
-        mock_data_2.embedding = [0.4, 0.5, 0.6]
-        mock_data_3 = mocker.MagicMock()
-        mock_data_3.embedding = [0.7, 0.8, 0.9]
-        mock_response.data = [mock_data_1, mock_data_2, mock_data_3]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+        )
 
         texts = ["first document", "second document", "third document"]
         embeddings = model_with_params.embed_documents(texts)
 
-        # Verify client was called correctly
         mock_openai_client.embeddings.create.assert_called_once_with(
             model="text-embedding-ada-002",
             input=texts,
         )
 
-        # Verify returned embeddings
         assert len(embeddings) == 3
         assert embeddings[0] == [0.1, 0.2, 0.3]
         assert embeddings[1] == [0.4, 0.5, 0.6]
@@ -84,9 +86,7 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_documents_empty_list(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents with empty list."""
-        mock_response = mocker.MagicMock()
-        mock_response.data = []
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(mocker, [])
 
         embeddings = model_with_params.embed_documents([])
 
@@ -98,11 +98,9 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_documents_single_text(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents with single text."""
-        mock_response = mocker.MagicMock()
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = [0.1, 0.2, 0.3, 0.4]
-        mock_response.data = [mock_data]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[0.1, 0.2, 0.3, 0.4]]
+        )
 
         embeddings = model_with_params.embed_documents(["single document"])
 
@@ -111,31 +109,23 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_query(self, model_with_params, mock_openai_client, mocker):
         """Test embed_query method."""
-        mock_response = mocker.MagicMock()
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
-        mock_response.data = [mock_data]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[0.1, 0.2, 0.3, 0.4, 0.5]]
+        )
 
         query = "What is machine learning?"
         embedding = model_with_params.embed_query(query)
 
-        # Verify client was called correctly
         mock_openai_client.embeddings.create.assert_called_once_with(
             model="text-embedding-ada-002",
             input=query,
         )
 
-        # Verify returned embedding
         assert embedding == [0.1, 0.2, 0.3, 0.4, 0.5]
 
     def test_embed_query_empty_string(self, model_with_params, mock_openai_client, mocker):
         """Test embed_query with empty string."""
-        mock_response = mocker.MagicMock()
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = []
-        mock_response.data = [mock_data]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(mocker, [[]])
 
         embedding = model_with_params.embed_query("")
 
@@ -143,10 +133,7 @@ class TestOpenAIEmbeddingModel:
 
     def test_model_inherits_from_base(self, model_with_params):
         """Test that OpenAIEmbeddingModel inherits BaseEmbeddingModel methods."""
-        # Test __repr__
         assert repr(model_with_params) == "text-embedding-ada-002"
-
-        # Test __str__
         assert str(model_with_params) == "text-embedding-ada-002"
 
     @pytest.mark.parametrize(
@@ -168,13 +155,9 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_documents_preserves_order(self, model_without_params, mock_openai_client, mocker):
         """Test that embed_documents preserves the order of input texts."""
-        mock_response = mocker.MagicMock()
-        mock_data_1 = mocker.MagicMock()
-        mock_data_1.embedding = [1.0, 1.0, 1.0]
-        mock_data_2 = mocker.MagicMock()
-        mock_data_2.embedding = [2.0, 2.0, 2.0]
-        mock_response.data = [mock_data_1, mock_data_2]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]
+        )
 
         texts = ["first", "second"]
         embeddings = model_without_params.embed_documents(texts)
@@ -184,17 +167,10 @@ class TestOpenAIEmbeddingModel:
 
     def test_multiple_calls_to_embed_query(self, model_with_params, mock_openai_client, mocker):
         """Test multiple sequential calls to embed_query."""
-        mock_response_1 = mocker.MagicMock()
-        mock_data_1 = mocker.MagicMock()
-        mock_data_1.embedding = [0.1, 0.2]
-        mock_response_1.data = [mock_data_1]
-
-        mock_response_2 = mocker.MagicMock()
-        mock_data_2 = mocker.MagicMock()
-        mock_data_2.embedding = [0.3, 0.4]
-        mock_response_2.data = [mock_data_2]
-
-        mock_openai_client.embeddings.create.side_effect = [mock_response_1, mock_response_2]
+        mock_openai_client.embeddings.create.side_effect = [
+            _make_mock_embedding_response(mocker, [[0.1, 0.2]]),
+            _make_mock_embedding_response(mocker, [[0.3, 0.4]]),
+        ]
 
         embedding_1 = model_with_params.embed_query("query 1")
         embedding_2 = model_with_params.embed_query("query 2")

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -178,3 +178,11 @@ class TestOpenAIEmbeddingModel:
         assert embedding_1 == [0.1, 0.2]
         assert embedding_2 == [0.3, 0.4]
         assert mock_openai_client.embeddings.create.call_count == 2
+
+    def test_detect_embedding_dimension_api_failure(self, mocker):
+        """Test that _detect_embedding_dimension raises RuntimeError on API failure."""
+        mock_client = mocker.MagicMock()
+        mock_client.embeddings.create.side_effect = ConnectionError("Service unavailable")
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
+            OpenAIEmbeddingModel(client=mock_client, model_id="text-embedding-ada-002", params=None)


### PR DESCRIPTION
## Description
Penalty for failing iterations added (0 returned instead of `None`) and adding dynamic embedding dimension discovery.

## Motivation
- penalty for better patterns recommendation
- embedding dimension dynamically added to simplify search space creation in KFP

## Changes
- Penalty for failing iterations
- dynamic embedding model dimension setting

## Testing
Run unit tests

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Code follows style guide
- [x] All checks passing
