### PR TITLE
Dynamic `context_length` adjustment

### DIFF
--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -73,25 +73,31 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
         return len(embedding)
 
     def _detect_context_length(self) -> int:
-        """Detect maximum context length by probing with increasing input sizes.
+        """Detect maximum context length via binary search over probe sizes.
 
-        Sends probe texts of descending token counts and returns the largest
-        that the model accepts.  Each probe consists of repeated words so that
-        one word ≈ one token.
+        Performs a binary search between 256 and 8192 tokens to find the
+        largest input the model accepts.  Each probe consists of repeated
+        words so that one word ≈ one token.  The search stops when the
+        remaining interval is smaller than 256 tokens, keeping the number
+        of API calls to roughly 5.
 
         Raises
         ------
         RuntimeError
             When the context length cannot be determined (e.g. all probes fail).
         """
-        probe_sizes = [4096, 2048, 1024, 512, 256]
-        for size in probe_sizes:
-            probe_text = "word " * size
+        lo, hi, best = 256, 8192, None
+        while hi - lo >= 256:
+            mid = (lo + hi) // 2
+            probe_text = "word " * mid
             try:
                 self._embed_text(text_input=probe_text)
-                return size
+                best = mid
+                lo = mid + 1
             except Exception:  # pylint: disable=broad-exception-caught
-                continue
+                hi = mid - 1
+        if best is not None:
+            return best
         raise RuntimeError(
             f"Failed to auto-detect 'context_length' for model '{self.model_id}'. "
             "Provide 'context_length' explicitly or ensure the embedding service is reachable."

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -47,6 +47,8 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
             raise TypeError(f"Incorrect type of 'params' parameter: {type(params)}.")
         if self._params.embedding_dimension is None:
             self._params.embedding_dimension = self._detect_embedding_dimension()
+        if self._params.context_length is None:
+            self._params.context_length = self._detect_context_length()
 
     def _detect_embedding_dimension(self) -> int:
         """Detect embedding dimension by making a minimal embedding call.
@@ -69,6 +71,31 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
                 "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
             ) from exc
         return len(embedding)
+
+    def _detect_context_length(self) -> int:
+        """Detect maximum context length by probing with increasing input sizes.
+
+        Sends probe texts of descending token counts and returns the largest
+        that the model accepts.  Each probe consists of repeated words so that
+        one word ≈ one token.
+
+        Raises
+        ------
+        RuntimeError
+            When the context length cannot be determined (e.g. all probes fail).
+        """
+        probe_sizes = [4096, 2048, 1024, 512, 256]
+        for size in probe_sizes:
+            probe_text = "word " * size
+            try:
+                self._embed_text(text_input=probe_text)
+                return size
+            except Exception:  # pylint: disable=broad-exception-caught
+                continue
+        raise RuntimeError(
+            f"Failed to auto-detect 'context_length' for model '{self.model_id}'. "
+            "Provide 'context_length' explicitly or ensure the embedding service is reachable."
+        )
 
     def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
         """Embeds documents.

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -27,6 +27,8 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
             self._params = params
         if "embedding_dimension" not in self._params:
             self._params["embedding_dimension"] = self._detect_embedding_dimension()
+        if "context_length" not in self._params:
+            self._params["context_length"] = self._detect_context_length()
 
     def _detect_embedding_dimension(self) -> int:
         """Detect embedding dimension by making a minimal embedding call.
@@ -49,6 +51,31 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
                 "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
             ) from exc
         return len(embedding)
+
+    def _detect_context_length(self) -> int:
+        """Detect maximum context length by probing with increasing input sizes.
+
+        Sends probe texts of descending token counts and returns the largest
+        that the model accepts.  Each probe consists of repeated words so that
+        one word ≈ one token.
+
+        Raises
+        ------
+        RuntimeError
+            When the context length cannot be determined (e.g. all probes fail).
+        """
+        probe_sizes = [4096, 2048, 1024, 512, 256]
+        for size in probe_sizes:
+            probe_text = "word " * size
+            try:
+                self.client.embeddings.create(model=self.model_id, input=probe_text)
+                return size
+            except Exception:  # pylint: disable=broad-exception-caught
+                continue
+        raise RuntimeError(
+            f"Failed to auto-detect 'context_length' for model '{self.model_id}'. "
+            "Provide 'context_length' explicitly or ensure the embedding service is reachable."
+        )
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embeds given list of strings.

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -53,25 +53,31 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
         return len(embedding)
 
     def _detect_context_length(self) -> int:
-        """Detect maximum context length by probing with increasing input sizes.
+        """Detect maximum context length via binary search over probe sizes.
 
-        Sends probe texts of descending token counts and returns the largest
-        that the model accepts.  Each probe consists of repeated words so that
-        one word ≈ one token.
+        Performs a binary search between 256 and 8192 tokens to find the
+        largest input the model accepts.  Each probe consists of repeated
+        words so that one word ≈ one token.  The search stops when the
+        remaining interval is smaller than 256 tokens, keeping the number
+        of API calls to roughly 5.
 
         Raises
         ------
         RuntimeError
             When the context length cannot be determined (e.g. all probes fail).
         """
-        probe_sizes = [4096, 2048, 1024, 512, 256]
-        for size in probe_sizes:
-            probe_text = "word " * size
+        lo, hi, best = 256, 8192, None
+        while hi - lo >= 256:
+            mid = (lo + hi) // 2
+            probe_text = "word " * mid
             try:
                 self.client.embeddings.create(model=self.model_id, input=probe_text)
-                return size
+                best = mid
+                lo = mid + 1
             except Exception:  # pylint: disable=broad-exception-caught
-                continue
+                hi = mid - 1
+        if best is not None:
+            return best
         raise RuntimeError(
             f"Failed to auto-detect 'context_length' for model '{self.model_id}'. "
             "Provide 'context_length' explicitly or ensure the embedding service is reachable."

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -88,7 +88,8 @@ def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsR
             client=client,
             params=LSEmbeddingParams(
                 embedding_dimension=m.custom_metadata.get("embedding_dimension")
-                or m.metadata.get("embedding_dimension")
+                or m.metadata.get("embedding_dimension"),
+                context_length=m.custom_metadata.get("context_length") or m.metadata.get("context_length"),
             ),
         )
         for m in embeddings

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -10,8 +10,8 @@ __all__ = [
 ]
 
 _default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (512, 1024)
-_default_chunk_overlaps = (128, 256)
+_default_chunk_sizes = (512, 1024, 2048)
+_default_chunk_overlaps = (128, 256, 512)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
 _default_numbers_of_chunks = (3, 5, 10)

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -57,6 +57,46 @@ def _rule_adjust_window_to_retrieval_method(combination: dict) -> bool:
     return True
 
 
+def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
+    """Check that estimated token count of a chunk fits the embedding model's context length.
+
+    The chunk_size and chunk_overlap are in characters.  We convert to an
+    estimated token count using a conservative ratio of 4 characters per token
+    (i.e. we *overestimate* the number of tokens so that borderline cases are
+    pruned rather than silently failing at runtime).
+
+    Parameters
+    ----------
+    combination : dict
+        Single node in the solutions space represented as a dict.
+
+    Returns
+    -------
+    bool
+        Whether the estimated token count fits within the embedding model's context length.
+    """
+    chunk_size = combination.get(AI4RAGParamNames.CHUNK_SIZE)
+    chunk_overlap = combination.get(AI4RAGParamNames.CHUNK_OVERLAP)
+    embedding_model = combination.get(AI4RAGParamNames.EMBEDDING_MODEL)
+
+    if chunk_size is None or chunk_overlap is None or embedding_model is None:
+        return True
+
+    context_length = getattr(getattr(embedding_model, "params", None), "context_length", None)
+    if context_length is None:
+        params = getattr(embedding_model, "params", None)
+        if isinstance(params, dict):
+            context_length = params.get("context_length")
+
+    if context_length is None:
+        return True
+
+    chars_per_token = 4
+    estimated_tokens = (chunk_size + 2 * chunk_overlap) / chars_per_token
+
+    return estimated_tokens <= context_length
+
+
 class SearchSpace:
     """
     Class that represents a search space used hyperparameter optimization.
@@ -185,6 +225,7 @@ class AI4RAGSearchSpace(SearchSpace):
     _rules = (
         _rule_chunk_size_bigger_than_chunk_overlap,
         _rule_adjust_window_to_retrieval_method,
+        _rule_chunk_size_within_embedding_context_length,
     )
 
     def __init__(self, params: list[Parameter] | None = None, rules: list[RuleFunction] | None = None):

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -37,7 +37,7 @@ def _rule_chunk_size_bigger_than_chunk_overlap(combination: dict) -> bool:
     if chunk_size is None or chunk_overlap is None:
         raise SearchSpaceValueError("Chunk size and chunk overlap are required.")
 
-    return chunk_size > chunk_overlap
+    return chunk_size > 2 * chunk_overlap
 
 
 def _rule_adjust_window_to_retrieval_method(combination: dict) -> bool:
@@ -60,10 +60,14 @@ def _rule_adjust_window_to_retrieval_method(combination: dict) -> bool:
 def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
     """Check that estimated token count of a chunk fits the embedding model's context length.
 
-    The chunk_size and chunk_overlap are in characters.  We convert to an
-    estimated token count using a conservative ratio of 4 characters per token
-    (i.e. we *overestimate* the number of tokens so that borderline cases are
-    pruned rather than silently failing at runtime).
+    The chunk_size is in characters.  We convert to an estimated token count
+    using a conservative ratio of 4 characters per token (i.e. we
+    *overestimate* the number of tokens so that borderline cases are pruned
+    rather than silently failing at runtime).
+
+    Note: ``chunk_overlap`` is not included in the estimation because
+    ``RecursiveCharacterTextSplitter`` already keeps chunks within the
+    ``chunk_size`` budget — overlap is not added on top.
 
     Parameters
     ----------
@@ -91,8 +95,8 @@ def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
     if context_length is None:
         return True
 
-    chars_per_token = 4
-    estimated_tokens = (chunk_size + 2 * chunk_overlap) / chars_per_token
+    chars_per_token = 4.5
+    estimated_tokens = chunk_size / chars_per_token
 
     return estimated_tokens <= context_length
 

--- a/tests/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/ai4rag/rag/embedding/test_llama_stack.py
@@ -30,43 +30,51 @@ class TestLSEmbeddingModel:
         return mock_client
 
     def test_init_with_explicit_dimension(self, mock_ls_client):
-        """Test initialization with explicit embedding_dimension does not trigger auto-detection."""
-        params = LSEmbeddingParams(embedding_dimension=768)
+        """Test initialization with explicit embedding_dimension and context_length does not trigger auto-detection."""
+        params = LSEmbeddingParams(embedding_dimension=768, context_length=512)
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
 
         assert model.params.embedding_dimension == 768
+        assert model.params.context_length == 512
         mock_ls_client.embeddings.create.assert_not_called()
 
     def test_init_with_dict_params_with_dimension(self, mock_ls_client):
-        """Test initialization with dict params containing embedding_dimension."""
+        """Test initialization with dict params containing embedding_dimension and context_length."""
         model = LSEmbeddingModel(
-            client=mock_ls_client, model_id="all-MiniLM-L6-v2", params={"embedding_dimension": 384}
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params={"embedding_dimension": 384, "context_length": 512},
         )
 
         assert model.params.embedding_dimension == 384
+        assert model.params.context_length == 512
         mock_ls_client.embeddings.create.assert_not_called()
 
     def test_init_without_params_auto_detects_dimension(self, mock_ls_client):
-        """Test initialization without params triggers auto-detection of embedding_dimension."""
+        """Test initialization without params triggers auto-detection of embedding_dimension and context_length."""
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2")
 
         assert model.params.embedding_dimension == 4
-        mock_ls_client.embeddings.create.assert_called_once()
+        assert model.params.context_length == 4096
+        # 1 call for dimension detection + 1 call for context_length detection (first probe succeeds)
+        assert mock_ls_client.embeddings.create.call_count == 2
 
     def test_init_with_none_params_auto_detects_dimension(self, mock_ls_client):
         """Test initialization with params=None triggers auto-detection."""
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=None)
 
         assert model.params.embedding_dimension == 4
-        mock_ls_client.embeddings.create.assert_called_once()
+        assert model.params.context_length == 4096
+        assert mock_ls_client.embeddings.create.call_count == 2
 
     def test_init_with_params_missing_dimension_auto_detects(self, mock_ls_client):
         """Test that auto-detection triggers when LSEmbeddingParams has no dimension."""
-        params = LSEmbeddingParams()  # embedding_dimension defaults to None
+        params = LSEmbeddingParams()  # embedding_dimension and context_length default to None
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
 
         assert model.params.embedding_dimension == 4
-        mock_ls_client.embeddings.create.assert_called_once()
+        assert model.params.context_length == 4096
+        assert mock_ls_client.embeddings.create.call_count == 2
 
     def test_init_with_invalid_params_type(self, mock_ls_client):
         """Test initialization with invalid params type raises TypeError."""
@@ -92,12 +100,64 @@ class TestLSEmbeddingModel:
 
         assert exc_info.value.__cause__ is original_error
 
+    def test_detect_context_length_succeeds_at_first_probe(self, mock_ls_client):
+        """Test that context_length detection returns 4096 when the first probe succeeds."""
+        params = LSEmbeddingParams(embedding_dimension=384)
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.context_length == 4096
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_detect_context_length_falls_back_to_smaller_probe(self, mocker):
+        """Test that context_length detection falls back to smaller probe sizes."""
+        mock_client = mocker.MagicMock()
+        response = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        def side_effect(**kwargs):
+            text = kwargs.get("input", "")
+            if isinstance(text, str) and len(text) > 2048 * 5:
+                raise ValueError("Input too long")
+            return response
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        params = LSEmbeddingParams(embedding_dimension=384)
+        model = LSEmbeddingModel(client=mock_client, model_id="test-model", params=params)
+
+        assert model.params.context_length == 2048
+
+    def test_detect_context_length_all_probes_fail(self, mocker):
+        """Test that RuntimeError is raised when all context_length probes fail."""
+        mock_client = mocker.MagicMock()
+        dim_response = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        call_count = [0]
+
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return dim_response  # dimension detection
+            raise ValueError("Input too long")
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect context length"):
+            LSEmbeddingModel(client=mock_client, model_id="test-model", params=None)
+
+    def test_detect_context_length_skipped_when_explicit(self, mock_ls_client):
+        """Test that context_length detection is skipped when explicitly provided."""
+        params = LSEmbeddingParams(embedding_dimension=384, context_length=1024)
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.context_length == 1024
+        mock_ls_client.embeddings.create.assert_not_called()
+
     def test_embed_documents(self, mock_ls_client, mocker):
         """Test embed_documents method."""
         model = LSEmbeddingModel(
             client=mock_ls_client,
             model_id="all-MiniLM-L6-v2",
-            params=LSEmbeddingParams(embedding_dimension=3),
+            params=LSEmbeddingParams(embedding_dimension=3, context_length=512),
         )
         mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(
             mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
@@ -114,7 +174,7 @@ class TestLSEmbeddingModel:
         model = LSEmbeddingModel(
             client=mock_ls_client,
             model_id="all-MiniLM-L6-v2",
-            params=LSEmbeddingParams(embedding_dimension=3),
+            params=LSEmbeddingParams(embedding_dimension=3, context_length=512),
         )
         mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
 
@@ -127,7 +187,7 @@ class TestLSEmbeddingModel:
         model = LSEmbeddingModel(
             client=mock_ls_client,
             model_id="all-MiniLM-L6-v2",
-            params=LSEmbeddingParams(embedding_dimension=384),
+            params=LSEmbeddingParams(embedding_dimension=384, context_length=512),
         )
 
         assert repr(model) == "all-MiniLM-L6-v2"

--- a/tests/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/ai4rag/rag/embedding/test_llama_stack.py
@@ -141,7 +141,7 @@ class TestLSEmbeddingModel:
 
         mock_client.embeddings.create.side_effect = side_effect
 
-        with pytest.raises(RuntimeError, match="Failed to auto-detect context length"):
+        with pytest.raises(RuntimeError, match="Failed to auto-detect 'context_length'"):
             LSEmbeddingModel(client=mock_client, model_id="test-model", params=None)
 
     def test_detect_context_length_skipped_when_explicit(self, mock_ls_client):

--- a/tests/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/ai4rag/rag/embedding/test_llama_stack.py
@@ -55,17 +55,15 @@ class TestLSEmbeddingModel:
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2")
 
         assert model.params.embedding_dimension == 4
-        assert model.params.context_length == 4096
-        # 1 call for dimension detection + 1 call for context_length detection (first probe succeeds)
-        assert mock_ls_client.embeddings.create.call_count == 2
+        # Binary search converges near upper bound when all probes succeed
+        assert model.params.context_length > 0
 
     def test_init_with_none_params_auto_detects_dimension(self, mock_ls_client):
         """Test initialization with params=None triggers auto-detection."""
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=None)
 
         assert model.params.embedding_dimension == 4
-        assert model.params.context_length == 4096
-        assert mock_ls_client.embeddings.create.call_count == 2
+        assert model.params.context_length > 0
 
     def test_init_with_params_missing_dimension_auto_detects(self, mock_ls_client):
         """Test that auto-detection triggers when LSEmbeddingParams has no dimension."""
@@ -73,8 +71,7 @@ class TestLSEmbeddingModel:
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
 
         assert model.params.embedding_dimension == 4
-        assert model.params.context_length == 4096
-        assert mock_ls_client.embeddings.create.call_count == 2
+        assert model.params.context_length > 0
 
     def test_init_with_invalid_params_type(self, mock_ls_client):
         """Test initialization with invalid params type raises TypeError."""
@@ -100,21 +97,23 @@ class TestLSEmbeddingModel:
 
         assert exc_info.value.__cause__ is original_error
 
-    def test_detect_context_length_succeeds_at_first_probe(self, mock_ls_client):
-        """Test that context_length detection returns 4096 when the first probe succeeds."""
+    def test_detect_context_length_all_probes_succeed(self, mock_ls_client):
+        """Test that context_length detection converges near upper bound when all probes succeed."""
         params = LSEmbeddingParams(embedding_dimension=384)
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
 
-        assert model.params.context_length == 4096
-        mock_ls_client.embeddings.create.assert_called_once()
+        # Binary search converges near 8192 when all probes succeed
+        assert model.params.context_length > 4096
 
-    def test_detect_context_length_falls_back_to_smaller_probe(self, mocker):
-        """Test that context_length detection falls back to smaller probe sizes."""
+    def test_detect_context_length_binary_search_finds_limit(self, mocker):
+        """Test that binary search finds the correct context_length limit."""
         mock_client = mocker.MagicMock()
         response = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
 
         def side_effect(**kwargs):
             text = kwargs.get("input", "")
+            # Each "word " is 5 chars, so N words = N*5 chars
+            # Accept up to 2048 words
             if isinstance(text, str) and len(text) > 2048 * 5:
                 raise ValueError("Input too long")
             return response
@@ -124,7 +123,8 @@ class TestLSEmbeddingModel:
         params = LSEmbeddingParams(embedding_dimension=384)
         model = LSEmbeddingModel(client=mock_client, model_id="test-model", params=params)
 
-        assert model.params.context_length == 2048
+        # Binary search should find a value close to 2048
+        assert 1792 <= model.params.context_length <= 2048
 
     def test_detect_context_length_all_probes_fail(self, mocker):
         """Test that RuntimeError is raised when all context_length probes fail."""

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -236,7 +236,7 @@ class TestOpenAIEmbeddingModel:
 
         mock_client.embeddings.create.side_effect = side_effect
 
-        with pytest.raises(RuntimeError, match="Failed to auto-detect context length"):
+        with pytest.raises(RuntimeError, match="Failed to auto-detect 'context_length'"):
             OpenAIEmbeddingModel(client=mock_client, model_id="test-model", params=None)
 
     def test_detect_context_length_skipped_when_explicit(self, mock_openai_client):

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -32,16 +32,16 @@ class TestOpenAIEmbeddingModel:
 
     @pytest.fixture
     def model_with_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel with parameters including embedding_dimension."""
+        """Create an OpenAIEmbeddingModel with parameters including embedding_dimension and context_length."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-ada-002",
-            params={"dimensions": 1536, "embedding_dimension": 1536},
+            params={"dimensions": 1536, "embedding_dimension": 1536, "context_length": 8191},
         )
 
     @pytest.fixture
     def model_without_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel without parameters (auto-detects embedding_dimension)."""
+        """Create an OpenAIEmbeddingModel without parameters (auto-detects embedding_dimension and context_length)."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-3-small",
@@ -53,17 +53,19 @@ class TestOpenAIEmbeddingModel:
         assert model_with_params.model_id == "text-embedding-ada-002"
         assert model_with_params.params["dimensions"] == 1536
         assert model_with_params.params["embedding_dimension"] == 1536
+        assert model_with_params.params["context_length"] == 8191
         assert model_with_params.client == mock_openai_client
         # No auto-detection call should have been made
         mock_openai_client.embeddings.create.assert_not_called()
 
     def test_init_without_params(self, model_without_params, mock_openai_client):
-        """Test initialization without parameters triggers auto-detection of embedding_dimension."""
+        """Test initialization without parameters triggers auto-detection of embedding_dimension and context_length."""
         assert model_without_params.model_id == "text-embedding-3-small"
         assert model_without_params.params["embedding_dimension"] == 5
+        assert model_without_params.params["context_length"] == 4096
         assert model_without_params.client == mock_openai_client
-        # Auto-detection call should have been made with "test"
-        mock_openai_client.embeddings.create.assert_called_once_with(model="text-embedding-3-small", input="test")
+        # 1 call for dimension + 1 call for context_length (first probe succeeds)
+        assert mock_openai_client.embeddings.create.call_count == 2
 
     def test_embed_documents(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents method."""
@@ -186,3 +188,64 @@ class TestOpenAIEmbeddingModel:
 
         with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
             OpenAIEmbeddingModel(client=mock_client, model_id="text-embedding-ada-002", params=None)
+
+    def test_detect_context_length_succeeds_at_first_probe(self, mock_openai_client, mocker):
+        """Test that context_length detection returns 4096 when the first probe succeeds."""
+        model = OpenAIEmbeddingModel(
+            client=mock_openai_client,
+            model_id="text-embedding-3-small",
+            params={"embedding_dimension": 1536},
+        )
+
+        assert model.params["context_length"] == 4096
+        mock_openai_client.embeddings.create.assert_called_once()
+
+    def test_detect_context_length_falls_back_to_smaller_probe(self, mocker):
+        """Test that context_length detection falls back to smaller probe sizes."""
+        mock_client = mocker.MagicMock()
+        response = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        def side_effect(**kwargs):
+            text = kwargs.get("input", "")
+            if isinstance(text, str) and len(text) > 2048 * 5:
+                raise ValueError("Input too long")
+            return response
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        model = OpenAIEmbeddingModel(
+            client=mock_client,
+            model_id="test-model",
+            params={"embedding_dimension": 384},
+        )
+
+        assert model.params["context_length"] == 2048
+
+    def test_detect_context_length_all_probes_fail(self, mocker):
+        """Test that RuntimeError is raised when all context_length probes fail."""
+        mock_client = mocker.MagicMock()
+        dim_response = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        call_count = [0]
+
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return dim_response  # dimension detection
+            raise ValueError("Input too long")
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect context length"):
+            OpenAIEmbeddingModel(client=mock_client, model_id="test-model", params=None)
+
+    def test_detect_context_length_skipped_when_explicit(self, mock_openai_client):
+        """Test that context_length detection is skipped when explicitly provided."""
+        model = OpenAIEmbeddingModel(
+            client=mock_openai_client,
+            model_id="text-embedding-3-small",
+            params={"embedding_dimension": 1536, "context_length": 8191},
+        )
+
+        assert model.params["context_length"] == 8191
+        mock_openai_client.embeddings.create.assert_not_called()

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -62,10 +62,9 @@ class TestOpenAIEmbeddingModel:
         """Test initialization without parameters triggers auto-detection of embedding_dimension and context_length."""
         assert model_without_params.model_id == "text-embedding-3-small"
         assert model_without_params.params["embedding_dimension"] == 5
-        assert model_without_params.params["context_length"] == 4096
+        # Binary search converges near upper bound when all probes succeed
+        assert model_without_params.params["context_length"] > 0
         assert model_without_params.client == mock_openai_client
-        # 1 call for dimension + 1 call for context_length (first probe succeeds)
-        assert mock_openai_client.embeddings.create.call_count == 2
 
     def test_embed_documents(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents method."""
@@ -189,24 +188,26 @@ class TestOpenAIEmbeddingModel:
         with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
             OpenAIEmbeddingModel(client=mock_client, model_id="text-embedding-ada-002", params=None)
 
-    def test_detect_context_length_succeeds_at_first_probe(self, mock_openai_client, mocker):
-        """Test that context_length detection returns 4096 when the first probe succeeds."""
+    def test_detect_context_length_all_probes_succeed(self, mock_openai_client):
+        """Test that context_length detection converges near upper bound when all probes succeed."""
         model = OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-3-small",
             params={"embedding_dimension": 1536},
         )
 
-        assert model.params["context_length"] == 4096
-        mock_openai_client.embeddings.create.assert_called_once()
+        # Binary search converges near 8192 when all probes succeed
+        assert model.params["context_length"] > 4096
 
-    def test_detect_context_length_falls_back_to_smaller_probe(self, mocker):
-        """Test that context_length detection falls back to smaller probe sizes."""
+    def test_detect_context_length_binary_search_finds_limit(self, mocker):
+        """Test that binary search finds the correct context_length limit."""
         mock_client = mocker.MagicMock()
         response = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3]])
 
         def side_effect(**kwargs):
             text = kwargs.get("input", "")
+            # Each "word " is 5 chars, so N words = N*5 chars
+            # Accept up to 2048 words
             if isinstance(text, str) and len(text) > 2048 * 5:
                 raise ValueError("Input too long")
             return response
@@ -219,7 +220,8 @@ class TestOpenAIEmbeddingModel:
             params={"embedding_dimension": 384},
         )
 
-        assert model.params["context_length"] == 2048
+        # Binary search should find a value close to 2048
+        assert 1792 <= model.params["context_length"] <= 2048
 
     def test_detect_context_length_all_probes_fail(self, mocker):
         """Test that RuntimeError is raised when all context_length probes fail."""

--- a/tests/ai4rag/search_space/prepare/test_llama_stack_utils.py
+++ b/tests/ai4rag/search_space/prepare/test_llama_stack_utils.py
@@ -57,22 +57,33 @@ class TestValidateEmbeddingModel:
         mock_client.embeddings.create.return_value = mock_response
 
         model = LSEmbeddingModel(
-            model_id="test-model", client=mock_client, params=LSEmbeddingParams(embedding_dimension=768)
+            model_id="test-model",
+            client=mock_client,
+            params=LSEmbeddingParams(embedding_dimension=768, context_length=512),
         )
 
         result = _validate_embedding_model(model)
 
         assert result is True
-        mock_client.embeddings.create.assert_called_once()
 
     def test_returns_false_when_model_fails(self):
         """Test that validation returns False when model raises exception."""
         mock_client = MagicMock()
-        mock_client.embeddings.create.side_effect = Exception("Model error")
+        mock_response = Mock()
+        mock_data = Mock()
+        mock_data.embedding = [0.1, 0.2, 0.3]
+        mock_response.data = [mock_data]
 
+        # First call succeeds (for embed_query in validation), but we need to
+        # create the model first with context_length set to avoid detection.
         model = LSEmbeddingModel(
-            model_id="test-model", client=mock_client, params=LSEmbeddingParams(embedding_dimension=768)
+            model_id="test-model",
+            client=mock_client,
+            params=LSEmbeddingParams(embedding_dimension=768, context_length=512),
         )
+
+        # Now set embed to fail for validation
+        mock_client.embeddings.create.side_effect = Exception("Model error")
 
         result = _validate_embedding_model(model)
 
@@ -94,7 +105,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 
@@ -125,7 +137,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_embedding]
 
@@ -172,11 +185,17 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding1 = Mock()
         mock_embedding1.id = "test-embedding-1"
-        mock_embedding1.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding1.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding1.metadata = {}
 
         mock_embedding2 = Mock()
         mock_embedding2.id = "test-embedding-2"
-        mock_embedding2.custom_metadata = {"model_type": "embedding", "embedding_dimension": 1024}
+        mock_embedding2.custom_metadata = {
+            "model_type": "embedding",
+            "embedding_dimension": 1024,
+            "context_length": 512,
+        }
+        mock_embedding2.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm1, mock_llm2, mock_embedding1, mock_embedding2]
 
@@ -214,7 +233,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 
@@ -241,7 +261,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 

--- a/tests/ai4rag/search_space/src/test_search_space.py
+++ b/tests/ai4rag/search_space/src/test_search_space.py
@@ -77,7 +77,7 @@ class _MockEmbeddingModelWithDictParams:
 @pytest.mark.parametrize(
     "combination, expected_value",
     (
-        # chunk_size=512, chunk_overlap=64 → estimated_tokens = (512 + 128) / 4 = 160, context=256 → True
+        # chunk_size=512 → estimated_tokens = 512 / 4 = 128, context=256 → True
         (
             {
                 "chunk_size": 512,
@@ -86,16 +86,16 @@ class _MockEmbeddingModelWithDictParams:
             },
             True,
         ),
-        # chunk_size=2048, chunk_overlap=512 → estimated_tokens = (2048 + 1024) / 4 = 768, context=512 → False
+        # chunk_size=2048 → estimated_tokens = 2048 / 4 = 512, context=256 → False
         (
             {
                 "chunk_size": 2048,
                 "chunk_overlap": 512,
-                "embedding_model": _MockEmbeddingModelWithParams(512),
+                "embedding_model": _MockEmbeddingModelWithParams(256),
             },
             False,
         ),
-        # Exact boundary: chunk_size=1024, chunk_overlap=0 → estimated_tokens = 256, context=256 → True
+        # Exact boundary: chunk_size=1024 → estimated_tokens = 256, context=256 → True
         (
             {
                 "chunk_size": 1024,
@@ -104,7 +104,7 @@ class _MockEmbeddingModelWithDictParams:
             },
             True,
         ),
-        # Dict-style params: chunk_size=512, chunk_overlap=0 → estimated_tokens = 128, context=256 → True
+        # Dict-style params: chunk_size=512 → estimated_tokens = 128, context=256 → True
         (
             {
                 "chunk_size": 512,
@@ -113,7 +113,7 @@ class _MockEmbeddingModelWithDictParams:
             },
             True,
         ),
-        # Dict-style params: over limit
+        # Dict-style params: chunk_size=2048 → estimated_tokens = 512, context=256 → False
         (
             {
                 "chunk_size": 2048,

--- a/tests/ai4rag/search_space/src/test_search_space.py
+++ b/tests/ai4rag/search_space/src/test_search_space.py
@@ -11,6 +11,7 @@ from ai4rag.search_space.src.search_space import (
     SearchSpaceValueError,
     _rule_adjust_window_to_retrieval_method,
     _rule_chunk_size_bigger_than_chunk_overlap,
+    _rule_chunk_size_within_embedding_context_length,
 )
 
 
@@ -57,6 +58,88 @@ def test_rule_adjust_window_to_retrieval_method(combination, expected_value):
 def test_rule_adjust_window_to_retrieval_method_raises():
     with pytest.raises(SearchSpaceValueError):
         _ = _rule_adjust_window_to_retrieval_method({"retrieval_method": "simple"})
+
+
+class _MockEmbeddingModelWithParams:
+    """Mock embedding model with params as a dataclass-like object."""
+
+    def __init__(self, context_length):
+        self.params = type("Params", (), {"context_length": context_length})()
+
+
+class _MockEmbeddingModelWithDictParams:
+    """Mock embedding model with params as a dict."""
+
+    def __init__(self, context_length):
+        self.params = {"context_length": context_length}
+
+
+@pytest.mark.parametrize(
+    "combination, expected_value",
+    (
+        # chunk_size=512, chunk_overlap=64 → estimated_tokens = (512 + 128) / 4 = 160, context=256 → True
+        (
+            {
+                "chunk_size": 512,
+                "chunk_overlap": 64,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            True,
+        ),
+        # chunk_size=2048, chunk_overlap=512 → estimated_tokens = (2048 + 1024) / 4 = 768, context=512 → False
+        (
+            {
+                "chunk_size": 2048,
+                "chunk_overlap": 512,
+                "embedding_model": _MockEmbeddingModelWithParams(512),
+            },
+            False,
+        ),
+        # Exact boundary: chunk_size=1024, chunk_overlap=0 → estimated_tokens = 256, context=256 → True
+        (
+            {
+                "chunk_size": 1024,
+                "chunk_overlap": 0,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            True,
+        ),
+        # Dict-style params: chunk_size=512, chunk_overlap=0 → estimated_tokens = 128, context=256 → True
+        (
+            {
+                "chunk_size": 512,
+                "chunk_overlap": 0,
+                "embedding_model": _MockEmbeddingModelWithDictParams(256),
+            },
+            True,
+        ),
+        # Dict-style params: over limit
+        (
+            {
+                "chunk_size": 2048,
+                "chunk_overlap": 512,
+                "embedding_model": _MockEmbeddingModelWithDictParams(256),
+            },
+            False,
+        ),
+    ),
+)
+def test_rule_chunk_size_within_embedding_context_length(combination, expected_value):
+    val = _rule_chunk_size_within_embedding_context_length(combination)
+    assert val == expected_value
+
+
+def test_rule_chunk_size_within_embedding_context_length_no_context_length():
+    """Rule returns True when context_length is not available on the embedding model."""
+    mock_model = type("Model", (), {"params": type("Params", (), {"context_length": None})()})()
+    combination = {"chunk_size": 2048, "chunk_overlap": 512, "embedding_model": mock_model}
+    assert _rule_chunk_size_within_embedding_context_length(combination) is True
+
+
+def test_rule_chunk_size_within_embedding_context_length_missing_fields():
+    """Rule returns True when chunk_size, chunk_overlap or embedding_model are missing."""
+    assert _rule_chunk_size_within_embedding_context_length({"chunk_size": 512}) is True
+    assert _rule_chunk_size_within_embedding_context_length({}) is True
 
 
 class TestSearchSpace:


### PR DESCRIPTION
  ---
  Title: Dynamic context window adjustment for embedding models

  ## Summary
  - Add automatic `context_length` detection for embedding models (Llama Stack and OpenAI) via binary search probing,
  mirroring the existing `embedding_dimension` auto-detection pattern
  - Introduce a new search space validation rule (`chunk_size_within_embedding_context_length`) that prunes parameter
  combinations where the estimated token count of a chunk exceeds the embedding model's context window
  - Tighten the `chunk_size > chunk_overlap` rule to require `chunk_size > 2 * chunk_overlap` and expand default chunk
  sizes/overlaps to include `2048`/`512`
  - Propagate `context_length` through model discovery from Llama Stack server metadata

  ## Changes

  ### Embedding Models
  - **`llama_stack.py`** / **`openai_model.py`**: Added `_detect_context_length()` method that uses binary search
  (256–8192 range, ~5 API calls) to find the maximum input size the model accepts. Auto-detection triggers during
  `__init__` when `context_length` is not explicitly provided.

  ### Search Space
  - **`search_space.py`**: Added `_rule_chunk_size_within_embedding_context_length` rule to `AI4RAGSearchSpace` —
  estimates token count from chunk_size using a 4.5 chars/token ratio and validates it fits within the embedding
  model's context length. Tightened overlap rule to `chunk_size > 2 * chunk_overlap`.
  - **`default_search_space.py`**: Extended default chunk sizes to `(512, 1024, 2048)` and overlaps to `(128, 256,
  512)`.
  - **`llama_stack_utils.py`**: Reads `context_length` from model metadata/custom_metadata when constructing
  `LSEmbeddingModel` instances.

  ### Tests
  - Added tests for context length detection (all-succeed, binary-search-finds-limit, all-fail, skipped-when-explicit)
  for both Llama Stack and OpenAI embedding models
  - Added parametrized tests for the new `_rule_chunk_size_within_embedding_context_length` rule (dataclass params,
  dict params, boundary cases, missing fields)
  - Updated existing tests to include `context_length` in params fixtures

  ## Test plan
  - [ ] Run `pytest tests/ai4rag/rag/embedding/` — context length detection tests
  - [ ] Run `pytest tests/ai4rag/search_space/` — new validation rule tests
  - [ ] Run full `pytest` suite to verify no regressions
  - [ ] Verify with a live Llama Stack server that context_length is correctly auto-detected