### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,31 @@
+name: Documentation Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  check:
+    name: Check Documentation Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git-revision-date-localized plugin
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Build documentation
+        run: mkdocs build --strict

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,25 +1,26 @@
 name: Deploy Documentation
 
 on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build docs from'
+        required: true
+        default: 'main'
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  build-and-deploy:
-    name: Documentation Build or Build and Deployment
+  deploy:
+    name: Build and Deploy Documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
           fetch-depth: 0  # Fetch all history for git-revision-date-localized plugin
           token: ${{ secrets.GITHUB_TOKEN }}  # Use GITHUB_TOKEN for authentication
 
@@ -34,17 +35,21 @@ jobs:
           pip install --upgrade pip
           pip install -e ".[docs]"
 
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(python -c "import ai4rag; print(ai4rag.__version__)")
+          # Strip 'v' prefix if present
+          VERSION=${VERSION#v}
+          echo "docs_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
       - name: Configure Git for mike
-        if: github.event_name != 'pull_request'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Build documentation (PR check)
-        if: github.event_name == 'pull_request'
-        run: mkdocs build --strict
-
-      - name: Deploy documentation (dev branch)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+      - name: Deploy documentation (manual trigger)
+        if: github.event_name == 'workflow_dispatch'
         run: |
-          mike deploy --push dev
+          mike deploy --push ${{ steps.version.outputs.docs_version }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -91,15 +91,10 @@ jobs:
           path: dist/*.tar.gz
           retention-days: 7
 
-  build-wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  build-wheel:
+    name: Build universal wheel
+    runs-on: ubuntu-latest
     needs: get-version
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.12', '3.13']
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -109,36 +104,32 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.13'
 
       - name: Verify version
         run: |
           echo "Building version: ${{ needs.get-version.outputs.version }}"
           grep __version__ ai4rag/__init__.py
-        shell: bash
 
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build wheel
+          pip install build
 
       - name: Build wheel
-        run: |
-          python -m build --wheel
-        env:
-          CIBW_BUILD: cp${{ matrix.python-version }}-*
+        run: python -m build --wheel
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: dist-wheel
           path: dist/*.whl
           retention-days: 7
 
   publish:
     name: Publish to ${{ inputs.target }}
     runs-on: ubuntu-latest
-    needs: [get-version, build-sdist, build-wheels]
+    needs: [get-version, build-sdist, build-wheel]
     environment:
       name: ${{ inputs.target }}
       url: ${{ inputs.target == 'pypi' && 'https://pypi.org/p/ai4rag' || 'https://test.pypi.org/p/ai4rag' }}

--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -124,7 +124,7 @@ class GAMOptimizer(BaseOptimizer):
         for _ in range(iterations_limit):
             self._run_iteration()
 
-        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] >= 0]
+        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] is not None]
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
 
@@ -157,7 +157,7 @@ class GAMOptimizer(BaseOptimizer):
         while successful_evaluations < self.settings.n_random_nodes:
             params = next(gen)
             score = self._objective_function(params=params)
-            if score > 0:
+            if score is not None:
                 successful_evaluations += 1
             self._evaluated_combinations.append(params)
             params_with_score = params | {"score": score}
@@ -174,6 +174,7 @@ class GAMOptimizer(BaseOptimizer):
         """
         self._prepare_encoder()
         df = pd.DataFrame(data=self.evaluations)  # --> These are already known observations with scores.
+        df = df[df["score"].notna()].copy()
         data = df.drop(columns=["score"])
         target = df["score"]
 
@@ -252,7 +253,7 @@ class GAMOptimizer(BaseOptimizer):
 
         return remaining
 
-    def _objective_function(self, params: dict) -> float:
+    def _objective_function(self, params: dict) -> float | None:
         """
         Wrapper around the objective function provided to the optimizer.
 
@@ -263,9 +264,9 @@ class GAMOptimizer(BaseOptimizer):
 
         Returns
         -------
-        float
+        float | None
             Optimization score achieved for single node evaluation.
-            Returns -1 if the iteration failed (used as a penalty sentinel).
+            If None - iteration has ended up with a failed status.
         """
 
         try:
@@ -273,6 +274,7 @@ class GAMOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            loss = -1
+            # None is here to avoid penalization of iterations failing due to unknown reasons
+            loss = None
 
         return loss

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -124,7 +124,7 @@ class GAMOptimizer(BaseOptimizer):
         for _ in range(iterations_limit):
             self._run_iteration()
 
-        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] is not None]
+        successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] >= 0]
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
 
@@ -157,7 +157,7 @@ class GAMOptimizer(BaseOptimizer):
         while successful_evaluations < self.settings.n_random_nodes:
             params = next(gen)
             score = self._objective_function(params=params)
-            if score is not None:
+            if score > 0:
                 successful_evaluations += 1
             self._evaluated_combinations.append(params)
             params_with_score = params | {"score": score}
@@ -169,12 +169,11 @@ class GAMOptimizer(BaseOptimizer):
     def _run_iteration(self) -> None:
         """
         Run single optimization iteration that consists of training GAM model
-        to predict score for remaining nodes in the solutions space and chose
-        best n ones to further evaluation.
+        to predict score for remaining nodes in the solutions space and choose
+        the best n ones for further evaluation.
         """
         self._prepare_encoder()
         df = pd.DataFrame(data=self.evaluations)  # --> These are already known observations with scores.
-        df = df[df["score"].notna()].copy()
         data = df.drop(columns=["score"])
         target = df["score"]
 
@@ -253,7 +252,7 @@ class GAMOptimizer(BaseOptimizer):
 
         return remaining
 
-    def _objective_function(self, params: dict) -> float | None:
+    def _objective_function(self, params: dict) -> float:
         """
         Wrapper around the objective function provided to the optimizer.
 
@@ -264,9 +263,9 @@ class GAMOptimizer(BaseOptimizer):
 
         Returns
         -------
-        float | None
+        float
             Optimization score achieved for single node evaluation.
-            If None - iteration has ended up with a failed status.
+            Returns -1 if the iteration failed (used as a penalty sentinel).
         """
 
         try:
@@ -274,7 +273,6 @@ class GAMOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            # None is here to avoid penalization of iterations failing due to unknown reasons
-            loss = None
+            loss = -1
 
         return loss

--- a/ai4rag/core/hpo/random_opt.py
+++ b/ai4rag/core/hpo/random_opt.py
@@ -49,7 +49,7 @@ class RandomOptimizer(BaseOptimizer):
             score = self._objective_function(combinations[idx])
             self._evaluated_combinations.append(combinations[idx] | {"score": score})
 
-        successful_evaluations = [ev for ev in self._evaluated_combinations if ev["score"] >= 0]
+        successful_evaluations = [ev for ev in self._evaluated_combinations if ev["score"] is not None]
 
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
@@ -58,7 +58,7 @@ class RandomOptimizer(BaseOptimizer):
 
         return best_config_with_score
 
-    def _objective_function(self, params: dict) -> float:
+    def _objective_function(self, params: dict) -> float | None:
         """
         Wrapper around the objective function provided to the optimizer.
 
@@ -69,9 +69,9 @@ class RandomOptimizer(BaseOptimizer):
 
         Returns
         -------
-        float
+        float | None
             Optimization score achieved for single node evaluation.
-            Returns -1 if the iteration failed (used as a penalty sentinel).
+            If None - iteration has ended up with a failed status.
         """
 
         try:
@@ -79,6 +79,7 @@ class RandomOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            loss = -1
+            # None is here to avoid penalization of iterations failing due to unknown reasons
+            loss = None
 
         return loss

--- a/ai4rag/core/hpo/random_opt.py
+++ b/ai4rag/core/hpo/random_opt.py
@@ -49,7 +49,7 @@ class RandomOptimizer(BaseOptimizer):
             score = self._objective_function(combinations[idx])
             self._evaluated_combinations.append(combinations[idx] | {"score": score})
 
-        successful_evaluations = [ev for ev in self._evaluated_combinations if ev["score"] is not None]
+        successful_evaluations = [ev for ev in self._evaluated_combinations if ev["score"] >= 0]
 
         if not successful_evaluations:
             raise OptimizationError("Number of evaluations has reached limit. All iterations have failed.")
@@ -58,7 +58,7 @@ class RandomOptimizer(BaseOptimizer):
 
         return best_config_with_score
 
-    def _objective_function(self, params: dict) -> float | None:
+    def _objective_function(self, params: dict) -> float:
         """
         Wrapper around the objective function provided to the optimizer.
 
@@ -69,9 +69,9 @@ class RandomOptimizer(BaseOptimizer):
 
         Returns
         -------
-        float | None
+        float
             Optimization score achieved for single node evaluation.
-            If None - iteration has ended up with a failed status.
+            Returns -1 if the iteration failed (used as a penalty sentinel).
         """
 
         try:
@@ -79,7 +79,6 @@ class RandomOptimizer(BaseOptimizer):
             loss = self.objective_function(params)
 
         except FailedIterationError:
-            # None is here to avoid penalization of iterations failing due to unknown reasons
-            loss = None
+            loss = -1
 
         return loss

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -17,7 +17,7 @@ __all__ = ["LSEmbeddingModel", "LSEmbeddingParams"]
 class LSEmbeddingParams:
     """LLamaStack parameters to be used to create embeddings."""
 
-    embedding_dimension: int
+    embedding_dimension: Optional[int] = None
     context_length: Optional[int] = None
     timeout: Optional[float | Timeout] = None
     model_type: Optional[str] = None
@@ -28,7 +28,7 @@ class LSEmbeddingParams:
 class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
     """Creates embeddings for LLamaStack client."""
 
-    def __init__(self, client: LlamaStackClient, model_id: str, params: dict | LSEmbeddingParams):
+    def __init__(self, client: LlamaStackClient, model_id: str, params: dict | LSEmbeddingParams | None = None):
         super().__init__(client=client, model_id=model_id, params=params)
 
     @property
@@ -36,13 +36,39 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
         return self._params
 
     @params.setter
-    def params(self, params: dict | LSEmbeddingParams) -> None:
-        if isinstance(params, LSEmbeddingParams):
+    def params(self, params: dict | LSEmbeddingParams | None) -> None:
+        if params is None:
+            self._params = LSEmbeddingParams()
+        elif isinstance(params, LSEmbeddingParams):
             self._params = params
         elif isinstance(params, dict):
             self._params = LSEmbeddingParams(**params)
         else:
             raise TypeError(f"Incorrect type of 'params' parameter: {type(params)}.")
+        if self._params.embedding_dimension is None:
+            self._params.embedding_dimension = self._detect_embedding_dimension()
+
+    def _detect_embedding_dimension(self) -> int:
+        """Detect embedding dimension by making a minimal embedding call.
+
+        Note: This method is called during initialization when ``embedding_dimension``
+        is not explicitly provided.  It issues a real API request to the Llama Stack
+        server, so the server must be reachable at construction time.
+
+        Raises
+        ------
+        RuntimeError
+            When the embedding dimension cannot be determined (e.g. the server
+            is unreachable or the model is not available).
+        """
+        try:
+            embedding = self._embed_text(text_input="test")[0]
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to auto-detect embedding dimension for model '{self.model_id}'. "
+                "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
+            ) from exc
+        return len(embedding)
 
     def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
         """Embeds documents.

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -2,33 +2,47 @@
 # Copyright IBM Corp. 2025-2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from typing import Optional, TypedDict
+from dataclasses import dataclass
+from typing import Optional
 
 from httpx import Timeout
-from llama_stack_client import Client
+from llama_stack_client import LlamaStackClient
 
 from .base_model import BaseEmbeddingModel
 
 __all__ = ["LSEmbeddingModel", "LSEmbeddingParams"]
 
 
-class LSEmbeddingParams(TypedDict, total=False):
+@dataclass
+class LSEmbeddingParams:
     """LLamaStack parameters to be used to create embeddings."""
 
     embedding_dimension: int
-    context_length: int
-    timeout: Optional[float | Timeout]
-    model_type: Optional[str]
-    provider_id: Optional[str]
-    provider_resource_id: Optional[str]
+    context_length: Optional[int] = None
+    timeout: Optional[float | Timeout] = None
+    model_type: Optional[str] = None
+    provider_id: Optional[str] = None
+    provider_resource_id: Optional[str] = None
 
 
-class LSEmbeddingModel(BaseEmbeddingModel[Client, LSEmbeddingParams]):
+class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
     """Creates embeddings for LLamaStack client."""
 
-    def __init__(self, client: Client, model_id: str, params: LSEmbeddingParams):
-        params = params or {}
+    def __init__(self, client: LlamaStackClient, model_id: str, params: dict | LSEmbeddingParams):
         super().__init__(client=client, model_id=model_id, params=params)
+
+    @property
+    def params(self) -> LSEmbeddingParams:
+        return self._params
+
+    @params.setter
+    def params(self, params: dict | LSEmbeddingParams) -> None:
+        if isinstance(params, LSEmbeddingParams):
+            self._params = params
+        elif isinstance(params, dict):
+            self._params = LSEmbeddingParams(**params)
+        else:
+            raise TypeError(f"Incorrect type of 'params' parameter: {type(params)}.")
 
     def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
         """Embeds documents.

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -47,6 +47,8 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
             raise TypeError(f"Incorrect type of 'params' parameter: {type(params)}.")
         if self._params.embedding_dimension is None:
             self._params.embedding_dimension = self._detect_embedding_dimension()
+        if self._params.context_length is None:
+            self._params.context_length = self._detect_context_length()
 
     def _detect_embedding_dimension(self) -> int:
         """Detect embedding dimension by making a minimal embedding call.
@@ -69,6 +71,37 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
                 "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
             ) from exc
         return len(embedding)
+
+    def _detect_context_length(self) -> int:
+        """Detect maximum context length via binary search over probe sizes.
+
+        Performs a binary search between 256 and 8192 tokens to find the
+        largest input the model accepts.  Each probe consists of repeated
+        words so that one word ≈ one token.  The search stops when the
+        remaining interval is smaller than 256 tokens, keeping the number
+        of API calls to roughly 5.
+
+        Raises
+        ------
+        RuntimeError
+            When the context length cannot be determined (e.g. all probes fail).
+        """
+        lo, hi, best = 256, 8192, None
+        while hi - lo >= 256:
+            mid = (lo + hi) // 2
+            probe_text = "word " * mid
+            try:
+                self._embed_text(text_input=probe_text)
+                best = mid
+                lo = mid + 1
+            except Exception:  # pylint: disable=broad-exception-caught
+                hi = mid - 1
+        if best is not None:
+            return best
+        raise RuntimeError(
+            f"Failed to auto-detect 'context_length' for model '{self.model_id}'. "
+            "Provide 'context_length' explicitly or ensure the embedding service is reachable."
+        )
 
     def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
         """Embeds documents.

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -75,7 +75,7 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
     def _detect_context_length(self) -> int:
         """Detect maximum context length via binary search over probe sizes.
 
-        Performs a binary search between 256 and 8192 tokens to find the
+        Performs a binary search between 64 and 8192 tokens to find the
         largest input the model accepts.  Each probe consists of repeated
         words so that one word ≈ one token.  The search stops when the
         remaining interval is smaller than 256 tokens, keeping the number
@@ -86,7 +86,7 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
         RuntimeError
             When the context length cannot be determined (e.g. all probes fail).
         """
-        lo, hi, best = 256, 8192, None
+        lo, hi, best = 64, 8192, None
         while hi - lo >= 256:
             mid = (lo + hi) // 2
             probe_text = "word " * mid

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -15,6 +15,41 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
     def __init__(self, client: OpenAI, model_id: str, params: dict[str, Any] | None = None):
         super().__init__(client=client, model_id=model_id, params=params)
 
+    @property
+    def params(self) -> dict[str, Any]:
+        return self._params
+
+    @params.setter
+    def params(self, params: dict[str, Any] | None) -> None:
+        if params is None:
+            self._params = {}
+        else:
+            self._params = params
+        if "embedding_dimension" not in self._params:
+            self._params["embedding_dimension"] = self._detect_embedding_dimension()
+
+    def _detect_embedding_dimension(self) -> int:
+        """Detect embedding dimension by making a minimal embedding call.
+
+        Note: This method is called during initialization when ``embedding_dimension``
+        is not present in the params dict.  It issues a real API request to the
+        OpenAI API compliant endpoint, so the service must be reachable at construction time.
+
+        Raises
+        ------
+        RuntimeError
+            When the embedding dimension cannot be determined (e.g. the service
+            is unreachable or the model is not available).
+        """
+        try:
+            embedding = self.client.embeddings.create(model=self.model_id, input="test").data[0].embedding
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to auto-detect embedding dimension for model '{self.model_id}'. "
+                "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
+            ) from exc
+        return len(embedding)
+
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embeds given list of strings.
 

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -55,7 +55,7 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
     def _detect_context_length(self) -> int:
         """Detect maximum context length via binary search over probe sizes.
 
-        Performs a binary search between 256 and 8192 tokens to find the
+        Performs a binary search between 64 and 8192 tokens to find the
         largest input the model accepts.  Each probe consists of repeated
         words so that one word ≈ one token.  The search stops when the
         remaining interval is smaller than 256 tokens, keeping the number
@@ -66,7 +66,7 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
         RuntimeError
             When the context length cannot be determined (e.g. all probes fail).
         """
-        lo, hi, best = 256, 8192, None
+        lo, hi, best = 64, 8192, None
         while hi - lo >= 256:
             mid = (lo + hi) // 2
             probe_text = "word " * mid

--- a/ai4rag/rag/embedding/openai_model.py
+++ b/ai4rag/rag/embedding/openai_model.py
@@ -27,6 +27,8 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
             self._params = params
         if "embedding_dimension" not in self._params:
             self._params["embedding_dimension"] = self._detect_embedding_dimension()
+        if "context_length" not in self._params:
+            self._params["context_length"] = self._detect_context_length()
 
     def _detect_embedding_dimension(self) -> int:
         """Detect embedding dimension by making a minimal embedding call.
@@ -49,6 +51,37 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
                 "Provide 'embedding_dimension' explicitly or ensure the embedding service is reachable."
             ) from exc
         return len(embedding)
+
+    def _detect_context_length(self) -> int:
+        """Detect maximum context length via binary search over probe sizes.
+
+        Performs a binary search between 256 and 8192 tokens to find the
+        largest input the model accepts.  Each probe consists of repeated
+        words so that one word ≈ one token.  The search stops when the
+        remaining interval is smaller than 256 tokens, keeping the number
+        of API calls to roughly 5.
+
+        Raises
+        ------
+        RuntimeError
+            When the context length cannot be determined (e.g. all probes fail).
+        """
+        lo, hi, best = 256, 8192, None
+        while hi - lo >= 256:
+            mid = (lo + hi) // 2
+            probe_text = "word " * mid
+            try:
+                self.client.embeddings.create(model=self.model_id, input=probe_text)
+                best = mid
+                lo = mid + 1
+            except Exception:  # pylint: disable=broad-exception-caught
+                hi = mid - 1
+        if best is not None:
+            return best
+        raise RuntimeError(
+            f"Failed to auto-detect 'context_length' for model '{self.model_id}'. "
+            "Provide 'context_length' explicitly or ensure the embedding service is reachable."
+        )
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embeds given list of strings.

--- a/ai4rag/rag/foundation_models/base_model.py
+++ b/ai4rag/rag/foundation_models/base_model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, Literal, TypedDict, TypeVar
 
 from ai4rag.rag.foundation_models.utils import RAGPromptTemplateString
 from ai4rag.search_space.src.model_props import (
@@ -16,6 +16,11 @@ FoundationModelClientT = TypeVar("FoundationModelClientT")
 FoundationModelParamsT = TypeVar("FoundationModelParamsT")
 
 
+class MessageTyped(TypedDict):
+    role: str
+    content: str
+
+
 class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT], ABC):
 
     user_message_text: RAGPromptTemplateString = RAGPromptTemplateString(template_name="user_message_text")
@@ -25,14 +30,14 @@ class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT
         self,
         client: FoundationModelClientT,
         model_id: str,
-        model_params: FoundationModelParamsT,
+        params: FoundationModelParamsT,
         system_message_text: str | None = None,
         user_message_text: str | None = None,
         context_template_text: str | None = None,
     ):
         self.client = client
         self.model_id = model_id
-        self.model_params = model_params
+        self.params = params
         self.system_message_text = system_message_text or get_system_message_text(model_name=model_id)
         self.user_message_text = (
             user_message_text if user_message_text is not None else get_user_message_text(model_name=model_id)
@@ -59,5 +64,5 @@ class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT
         return hash(self.model_id)
 
     @abstractmethod
-    def chat(self, system_message: str, user_message: str) -> str:
+    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
         """Docstring here"""

--- a/ai4rag/rag/foundation_models/llama_stack.py
+++ b/ai4rag/rag/foundation_models/llama_stack.py
@@ -8,7 +8,7 @@ from annotated_types import Ge, Gt, Le
 from llama_stack_client import LlamaStackClient
 from pydantic import BaseModel
 
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
 from ai4rag.utils.constants import ChatGenerationConstants
 
 
@@ -24,7 +24,7 @@ class LSFoundationModel(BaseFoundationModel[LlamaStackClient, dict[str, Any] | M
         self,
         client: LlamaStackClient,
         model_id: str,
-        model_params: dict[str, Any] | ModelParameters | None = None,
+        params: dict[str, Any] | ModelParameters | None = None,
         system_message_text: str | None = None,
         user_message_text: str | None = None,
         context_template_text: str | None = None,
@@ -32,23 +32,20 @@ class LSFoundationModel(BaseFoundationModel[LlamaStackClient, dict[str, Any] | M
         super().__init__(
             client=client,
             model_id=model_id,
-            model_params=model_params,
+            params=params,
             system_message_text=system_message_text,
             user_message_text=user_message_text,
             context_template_text=context_template_text,
         )
 
-    def chat(self, system_message: str, user_message: str) -> str:
+    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
         """
         Chat completion for communication with selected foundation model.
 
         Parameters
         ----------
-        system_message : str
-            System messages in the str format.
-
-        user_message : str
-            User message in the str format.
+        messages : list[MessageTyped]
+            Messages to be included in the chat completion.
 
         Returns
         -------
@@ -57,11 +54,8 @@ class LSFoundationModel(BaseFoundationModel[LlamaStackClient, dict[str, Any] | M
         """
         response_chat = self.client.chat.completions.create(
             model=self.model_id,
-            messages=[
-                {"role": "system", "content": system_message},
-                {"role": "user", "content": user_message},
-            ],
+            messages=messages,
         )
-        answer = response_chat.choices[0].message.content
+        response_choices = response_chat.choices
 
-        return answer
+        return response_choices

--- a/ai4rag/rag/foundation_models/openai_model.py
+++ b/ai4rag/rag/foundation_models/openai_model.py
@@ -6,17 +6,17 @@ from typing import Any
 
 from openai import OpenAI
 
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
 
 
-class OpenAIFoundationModel(BaseFoundationModel):
+class OpenAIFoundationModel(BaseFoundationModel[OpenAI, dict[str, Any] | None]):
     """Wrapper for OpenAI client handled foundation models."""
 
     def __init__(
         self,
         client: OpenAI,
         model_id: str,
-        model_params: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
         system_message_text: str | None = None,
         user_message_text: str | None = None,
         context_template_text: str | None = None,
@@ -24,36 +24,30 @@ class OpenAIFoundationModel(BaseFoundationModel):
         super().__init__(
             client=client,
             model_id=model_id,
-            model_params=model_params,
+            params=params,
             system_message_text=system_message_text,
             user_message_text=user_message_text,
             context_template_text=context_template_text,
         )
 
-    def chat(self, system_message: str, user_message: str) -> str:
+    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
         """
         Chat completion for communication with selected foundation model.
 
         Parameters
         ----------
-        system_message : str
-            System messages in the str format.
-
-        user_message : str
-            User message in the str format.
+        messages : list[MessageTyped]
+            Messages to be included in the chat completion.
 
         Returns
         -------
-        str
-            Chat response from the model.
+        list[MessageTyped]
+            Chat response choices from the model.
         """
         response_chat = self.client.chat.completions.create(
             model=self.model_id,
-            messages=[
-                {"role": "system", "content": system_message},
-                {"role": "user", "content": user_message},
-            ],
+            messages=messages,
         )
-        answer = response_chat.choices[0].message.content
+        response_choices = response_chat.choices
 
-        return answer
+        return response_choices

--- a/ai4rag/rag/template/llama_stack_rag_template.py
+++ b/ai4rag/rag/template/llama_stack_rag_template.py
@@ -111,13 +111,15 @@ class LlamaStackRAG(BaseRAGTemplate):
             question=question,
         )
 
-        answer = self.foundation_model.chat(
-            system_message=self.foundation_model.system_message_text,
-            user_message=user_message,
-        )
+        messages = [
+            {"role": "system", "content": self.foundation_model.system_message_text},
+            {"role": "user", "content": user_message},
+        ]
+
+        chat_response = self.foundation_model.chat(messages=messages)
 
         return {
-            "answer": answer,
+            "answer": chat_response[0].message.content,
             "reference_documents": reference_documents,
             "question": question,
         }

--- a/ai4rag/rag/vector_store/llama_stack.py
+++ b/ai4rag/rag/vector_store/llama_stack.py
@@ -62,12 +62,17 @@ class LSVectorStore(BaseVectorStore):
             _vs = client.vector_stores.retrieve(reuse_collection_name)
             return _vs
 
+        # Handle both dict and LSEmbeddingParams for backward compatibility
+        if isinstance(embedding_model.params, dict):
+            embedding_dimension = embedding_model.params["embedding_dimension"]
+        else:
+            embedding_dimension = embedding_model.params.embedding_dimension
+
         _vs = client.vector_stores.create(
             extra_body={
                 "provider_id": provider_id,
-                # "provider_vector_store_id": collection_name,  # --> not working in 0.4.x
                 "embedding_model": embedding_model.model_id,
-                "embedding_dimension": embedding_model.params["embedding_dimension"],
+                "embedding_dimension": embedding_dimension,
             }
         )
 
@@ -129,13 +134,19 @@ class LSVectorStore(BaseVectorStore):
             Documents to add to the collection.
         """
 
+        # Handle both dict and LSEmbeddingParams for backward compatibility
+        if isinstance(self.embedding_model.params, dict):
+            embedding_dimension = self.embedding_model.params["embedding_dimension"]
+        else:
+            embedding_dimension = self.embedding_model.params.embedding_dimension
+
         chunks = [
             {
                 "content": doc.page_content,
                 "chunk_metadata": doc.metadata,
                 "chunk_id": doc.metadata["document_id"],
                 "embedding_model": self.embedding_model.model_id,
-                "embedding_dimension": self.embedding_model.params["embedding_dimension"],
+                "embedding_dimension": embedding_dimension,
             }
             for doc in documents
         ]

--- a/ai4rag/search_space/prepare/input_payload_types.py
+++ b/ai4rag/search_space/prepare/input_payload_types.py
@@ -4,27 +4,13 @@
 # -----------------------------------------------------------------------------
 from typing import Annotated, Optional
 
-from annotated_types import Ge, Gt, Le, MinLen
+from annotated_types import MinLen
 from pydantic import (
     BaseModel,
     ConfigDict,
-    Field,
-)
-
-from ai4rag.utils.constants import (
-    ChatGenerationConstants,
 )
 
 config = ConfigDict(extra="forbid")
-
-
-class AI4RAGFoundationModelParams(BaseModel):
-    """Attributes to be included in the generation.foundation_models payload."""
-
-    model_config = config
-
-    max_completion_tokens: Annotated[int, Gt(0)] = ChatGenerationConstants.MAX_COMPLETION_TOKENS
-    temperature: Annotated[float, Ge(0), Le(1)] = ChatGenerationConstants.TEMPERATURE
 
 
 class AI4RAGFoundationModel(BaseModel):
@@ -33,7 +19,14 @@ class AI4RAGFoundationModel(BaseModel):
     model_config = config
 
     model_id: Annotated[str, MinLen(1)]
-    parameters: Optional[AI4RAGFoundationModelParams] = Field(default_factory=AI4RAGFoundationModelParams)
+
+
+class AI4RAGEmbeddingModel(BaseModel):
+    """Attributes to be included in the generation.embedding_models payload."""
+
+    model_config = config
+
+    model_id: Annotated[str, MinLen(1)]
 
 
 class AI4RAGConstraints(BaseModel):
@@ -42,4 +35,4 @@ class AI4RAGConstraints(BaseModel):
     model_config = config
 
     embedding_models: Optional[Annotated[list[AI4RAGFoundationModel], MinLen(1)]] = None
-    foundation_models: Optional[Annotated[list[AI4RAGFoundationModel], MinLen(1)]] = None
+    foundation_models: Optional[Annotated[list[AI4RAGEmbeddingModel], MinLen(1)]] = None

--- a/ai4rag/search_space/prepare/input_payload_types.py
+++ b/ai4rag/search_space/prepare/input_payload_types.py
@@ -34,5 +34,5 @@ class AI4RAGConstraints(BaseModel):
 
     model_config = config
 
-    embedding_models: Optional[Annotated[list[AI4RAGFoundationModel], MinLen(1)]] = None
-    foundation_models: Optional[Annotated[list[AI4RAGEmbeddingModel], MinLen(1)]] = None
+    embedding_models: Optional[Annotated[list[AI4RAGEmbeddingModel], MinLen(1)]] = None
+    foundation_models: Optional[Annotated[list[AI4RAGFoundationModel], MinLen(1)]] = None

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -65,7 +65,7 @@ def _validate_embedding_model(model: LSEmbeddingModel) -> bool:
         return True
     except Exception:  # pylint: disable=broad-exception-caught
         logger.warning(
-            "Embedding model '%s' does not respond and will be excluded fro msearch space.",
+            "Embedding model '%s' does not respond and will be excluded from search space.",
             model.model_id,
             exc_info=True,
         )

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+from typing import TypedDict
+
+from llama_stack_client import LlamaStackClient
+
+from ai4rag import logger
+from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel, LSEmbeddingParams
+from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+from ai4rag.search_space.src.exceptions import SearchSpaceValueError
+
+
+class _DefaultModelsResponseType(TypedDict):
+    foundation_models: list[LSFoundationModel]
+    embedding_models: list[LSEmbeddingModel]
+
+
+def _validate_foundation_model(model: LSFoundationModel) -> bool:
+    """
+    Validate that a foundation model responds correctly with minimal tokens.
+
+    Parameters
+    ----------
+    model : LSFoundationModel
+        Foundation model to validate.
+
+    Returns
+    -------
+    bool
+        True if model responds successfully, False otherwise.
+    """
+    try:
+        # Test with minimal message and 1 token response
+        test_messages = [{"role": "user", "content": "Hi"}]
+        model.chat(messages=test_messages)
+        return True
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "Foundation model '%s' does not respond and will be excluded from search space.",
+            model.model_id,
+            exc_info=True,
+        )
+        return False
+
+
+def _validate_embedding_model(model: LSEmbeddingModel) -> bool:
+    """
+    Validate that an embedding model responds correctly with minimal input.
+
+    Parameters
+    ----------
+    model : LSEmbeddingModel
+        Embedding model to validate.
+
+    Returns
+    -------
+    bool
+        True if model responds successfully, False otherwise.
+    """
+    try:
+        # Test with minimal text
+        model.embed_query("test")
+        return True
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.warning(
+            "Embedding model '%s' does not respond and will be excluded fro msearch space.",
+            model.model_id,
+            exc_info=True,
+        )
+        return False
+
+
+def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsResponseType:
+    """Get list of default foundation models based on the available ones in llama stack."""
+
+    logger.info("Selecting default foundation models...")
+    available_models = client.models.list()
+    llms = [model for model in available_models if model.custom_metadata.get("model_type") == "llm"]
+    embeddings = [model for model in available_models if model.custom_metadata.get("model_type") == "embedding"]
+
+    # Create model instances
+    foundation_models_unvalidated = [LSFoundationModel(model_id=m.id, client=client) for m in llms]
+    embedding_models_unvalidated = [
+        LSEmbeddingModel(
+            model_id=m.id,
+            client=client,
+            params=LSEmbeddingParams(
+                embedding_dimension=m.custom_metadata.get("embedding_dimension")
+                or m.metadata.get("embedding_dimension")
+            ),
+        )
+        for m in embeddings
+    ]
+
+    # Validate each model
+    logger.info("Validating foundation models...")
+    foundation_models = [m for m in foundation_models_unvalidated if _validate_foundation_model(m)]
+
+    logger.info("Validating embedding models...")
+    embedding_models = [m for m in embedding_models_unvalidated if _validate_embedding_model(m)]
+
+    if not foundation_models:
+        raise SearchSpaceValueError("There are no available models of type 'llm'.")
+    if not embedding_models:
+        raise SearchSpaceValueError("There are no available models of type 'embedding'.")
+
+    logger.info("Selected default foundation models: %s.", foundation_models)
+    logger.info("Selected default embedding models: %s.", embedding_models)
+
+    return {"foundation_models": foundation_models, "embedding_models": embedding_models}
+
+
+def _are_provided_models_available(
+    provided_models: list, available_models: list[LSFoundationModel | LSEmbeddingModel]
+) -> bool:
+    """Check whether models provided by the user are available for the experiment."""
+
+    available_ids = [m.model_id for m in available_models]
+
+    for model in provided_models:
+        m_id = model.model_id
+        if m_id not in available_ids:
+            raise SearchSpaceValueError(f"Provided model with model_id: '{m_id}' is not available for the experiment.")
+    return True

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -88,7 +88,8 @@ def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsR
             client=client,
             params=LSEmbeddingParams(
                 embedding_dimension=m.custom_metadata.get("embedding_dimension")
-                or m.metadata.get("embedding_dimension")
+                or m.metadata.get("embedding_dimension"),
+                context_length=m.custom_metadata.get("context_length") or m.metadata.get("context_length"),
             ),
         )
         for m in embeddings

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -90,9 +90,7 @@ def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: Llama
         for em in validated_payload.embedding_models:
             matched_model = next(filter(lambda x, _id=em.model_id: x.model_id == _id, default_embedding_models), None)
             if matched_model is None:
-                raise SearchSpaceValueError(
-                    f"Embedding model '{em.model_id}' not found among available models."
-                )
+                raise SearchSpaceValueError(f"Embedding model '{em.model_id}' not found among available models.")
             embedding_models_values.append(
                 LSEmbeddingModel(model_id=em.model_id, client=client, params=matched_model.params)
             )

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -2,7 +2,7 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from typing import Any, TypedDict
+from typing import Any
 
 from llama_stack_client import LlamaStackClient
 from pydantic import TypeAdapter, ValidationError
@@ -11,57 +11,16 @@ from ai4rag import logger
 from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel
 from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
 from ai4rag.search_space.prepare.input_payload_types import AI4RAGConstraints
+from ai4rag.search_space.prepare.llama_stack_utils import (
+    _are_provided_models_available,
+    _get_default_llama_stack_models,
+)
 from ai4rag.search_space.prepare.validation_error_decoder import validation_error_decoder
 from ai4rag.search_space.src.exceptions import SearchSpaceValueError
 from ai4rag.search_space.src.parameter import Parameter
 from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
 
 __all__ = ["prepare_search_space_with_llama_stack"]
-
-
-class _DefaultModelsResponseType(TypedDict):
-    foundation_models: list[LSFoundationModel]
-    embedding_models: list[LSEmbeddingModel]
-
-
-def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsResponseType:
-    """Get list of default foundation models based on the available ones in llama stack."""
-
-    logger.info("Selecting default foundation models...")
-    available_models = client.models.list()
-    llms = [model for model in available_models if model.custom_metadata.get("model_type") == "llm"]
-    embeddings = [model for model in available_models if model.custom_metadata.get("model_type") == "embedding"]
-    foundation_models = [LSFoundationModel(model_id=m.id, client=client) for m in llms]
-    embedding_models = [
-        LSEmbeddingModel(
-            model_id=m.id, client=client, params={"embedding_dimension": m.custom_metadata["embedding_dimension"]}
-        )
-        for m in embeddings
-    ]
-
-    if not foundation_models:
-        raise SearchSpaceValueError("There are no available models of type 'llm'.")
-    if not embedding_models:
-        raise SearchSpaceValueError("There are no available models of type 'embedding'.")
-
-    logger.info("Selected default foundation models: %s.", foundation_models)
-    logger.info("Selected default embedding models: %s.", embedding_models)
-
-    return {"foundation_models": foundation_models, "embedding_models": embedding_models}
-
-
-def _are_provided_models_available(
-    provided_models: list, available_models: list[LSFoundationModel | LSEmbeddingModel]
-) -> bool:
-    """Check whether models provided by the user are available for the experiment."""
-
-    available_ids = [m.model_id for m in available_models]
-
-    for model in provided_models:
-        m_id = model.model_id
-        if m_id not in available_ids:
-            raise SearchSpaceValueError(f"Provided model with model_id: {m_id} is not available for the experiment.")
-    return True
 
 
 def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: LlamaStackClient) -> AI4RAGSearchSpace:
@@ -101,7 +60,7 @@ def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: Llama
         default_foundation_models = models["foundation_models"]
         default_embedding_models = models["embedding_models"]
     else:
-        raise SearchSpaceValueError(f"Unrecognized client type: {client.__class__.__name__}")
+        raise SearchSpaceValueError(f"Unrecognized client type: '{client.__class__.__name__}'")
 
     if validated_payload.foundation_models:
         _are_provided_models_available(validated_payload.foundation_models, default_foundation_models)
@@ -112,12 +71,10 @@ def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: Llama
     if validated_payload.foundation_models is not None:
         fms_param = Parameter(
             name="foundation_model",
-            param_type="C",
             values=[
                 LSFoundationModel(
                     model_id=fm.model_id,
                     client=client,
-                    model_params=fm.parameters.model_dump() if fm.parameters else {},
                 )
                 for fm in validated_payload.foundation_models
             ],
@@ -125,17 +82,17 @@ def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: Llama
     else:
         fms_param = Parameter(
             name="foundation_model",
-            param_type="C",
             values=default_foundation_models,
         )
 
     if validated_payload.embedding_models is not None:
         ems_param = Parameter(
             name="embedding_model",
-            param_type="C",
             values=[
                 LSEmbeddingModel(
-                    model_id=em.model_id, client=client, params=em.parameters.model_dump() if em.parameters else {}
+                    model_id=em.model_id,
+                    client=client,
+                    params=next(filter(lambda x: x.model_id == em.model_id, default_embedding_models), None).params,
                 )
                 for em in validated_payload.embedding_models
             ],
@@ -143,7 +100,6 @@ def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: Llama
     else:
         ems_param = Parameter(
             name="embedding_model",
-            param_type="C",
             values=default_embedding_models,
         )
 

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -86,16 +86,19 @@ def prepare_search_space_with_llama_stack(payload: dict[str, Any], client: Llama
         )
 
     if validated_payload.embedding_models is not None:
+        embedding_models_values = []
+        for em in validated_payload.embedding_models:
+            matched_model = next(filter(lambda x, _id=em.model_id: x.model_id == _id, default_embedding_models), None)
+            if matched_model is None:
+                raise SearchSpaceValueError(
+                    f"Embedding model '{em.model_id}' not found among available models."
+                )
+            embedding_models_values.append(
+                LSEmbeddingModel(model_id=em.model_id, client=client, params=matched_model.params)
+            )
         ems_param = Parameter(
             name="embedding_model",
-            values=[
-                LSEmbeddingModel(
-                    model_id=em.model_id,
-                    client=client,
-                    params=next(filter(lambda x: x.model_id == em.model_id, default_embedding_models), None).params,
-                )
-                for em in validated_payload.embedding_models
-            ],
+            values=embedding_models_values,
         )
     else:
         ems_param = Parameter(

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -10,8 +10,8 @@ __all__ = [
 ]
 
 _default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (512, 1024)
-_default_chunk_overlaps = (128, 256)
+_default_chunk_sizes = (512, 1024, 2048)
+_default_chunk_overlaps = (128, 256, 512)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
 _default_numbers_of_chunks = (3, 5, 10)

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -10,8 +10,8 @@ __all__ = [
 ]
 
 _default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (512, 1024, 2048)
-_default_chunk_overlaps = (256, 512)
+_default_chunk_sizes = (512, 1024)
+_default_chunk_overlaps = (128, 256)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
 _default_numbers_of_chunks = (3, 5, 10)

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 _default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (1024, 2048)
+_default_chunk_sizes = (512, 1024, 2048)
 _default_chunk_overlaps = (256, 512)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
@@ -28,32 +28,12 @@ def get_default_ai4rag_search_space_parameters() -> list[Parameter]:
     """
 
     default_search_space_parameters = [
-        Parameter(
-            name=AI4RAGParamNames.CHUNKING_METHOD,
-            param_type="C",
-            values=_default_chunking_methods,
-        ),
-        Parameter(
-            name=AI4RAGParamNames.CHUNK_SIZE,
-            param_type="C",
-            values=_default_chunk_sizes,
-        ),
-        Parameter(
-            name=AI4RAGParamNames.CHUNK_OVERLAP,
-            param_type="C",
-            values=_default_chunk_overlaps,
-        ),
-        Parameter(
-            name=AI4RAGParamNames.RETRIEVAL_METHOD,
-            param_type="C",
-            values=_default_retrieval_methods,
-        ),
-        Parameter(name=AI4RAGParamNames.WINDOW_SIZE, param_type="C", values=_default_window_sizes),
-        Parameter(
-            name=AI4RAGParamNames.NUMBER_OF_CHUNKS,
-            param_type="C",
-            values=_default_numbers_of_chunks,
-        ),
+        Parameter(name=AI4RAGParamNames.CHUNKING_METHOD, values=_default_chunking_methods),
+        Parameter(name=AI4RAGParamNames.CHUNK_SIZE, values=_default_chunk_sizes),
+        Parameter(name=AI4RAGParamNames.CHUNK_OVERLAP, values=_default_chunk_overlaps),
+        Parameter(name=AI4RAGParamNames.RETRIEVAL_METHOD, values=_default_retrieval_methods),
+        Parameter(name=AI4RAGParamNames.WINDOW_SIZE, values=_default_window_sizes),
+        Parameter(name=AI4RAGParamNames.NUMBER_OF_CHUNKS, values=_default_numbers_of_chunks),
     ]
 
     return default_search_space_parameters

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -61,7 +61,7 @@ def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
     """Check that estimated token count of a chunk fits the embedding model's context length.
 
     The chunk_size is in characters.  We convert to an estimated token count
-    using a conservative ratio of 4 characters per token (i.e. we
+    using a conservative ratio of 4.5 characters per token (i.e. we
     *overestimate* the number of tokens so that borderline cases are pruned
     rather than silently failing at runtime).
 

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -37,7 +37,7 @@ def _rule_chunk_size_bigger_than_chunk_overlap(combination: dict) -> bool:
     if chunk_size is None or chunk_overlap is None:
         raise SearchSpaceValueError("Chunk size and chunk overlap are required.")
 
-    return chunk_size > chunk_overlap
+    return chunk_size > 2 * chunk_overlap
 
 
 def _rule_adjust_window_to_retrieval_method(combination: dict) -> bool:
@@ -55,6 +55,50 @@ def _rule_adjust_window_to_retrieval_method(combination: dict) -> bool:
         return False
 
     return True
+
+
+def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
+    """Check that estimated token count of a chunk fits the embedding model's context length.
+
+    The chunk_size is in characters.  We convert to an estimated token count
+    using a conservative ratio of 4 characters per token (i.e. we
+    *overestimate* the number of tokens so that borderline cases are pruned
+    rather than silently failing at runtime).
+
+    Note: ``chunk_overlap`` is not included in the estimation because
+    ``RecursiveCharacterTextSplitter`` already keeps chunks within the
+    ``chunk_size`` budget — overlap is not added on top.
+
+    Parameters
+    ----------
+    combination : dict
+        Single node in the solutions space represented as a dict.
+
+    Returns
+    -------
+    bool
+        Whether the estimated token count fits within the embedding model's context length.
+    """
+    chunk_size = combination.get(AI4RAGParamNames.CHUNK_SIZE)
+    chunk_overlap = combination.get(AI4RAGParamNames.CHUNK_OVERLAP)
+    embedding_model = combination.get(AI4RAGParamNames.EMBEDDING_MODEL)
+
+    if chunk_size is None or chunk_overlap is None or embedding_model is None:
+        return True
+
+    context_length = getattr(getattr(embedding_model, "params", None), "context_length", None)
+    if context_length is None:
+        params = getattr(embedding_model, "params", None)
+        if isinstance(params, dict):
+            context_length = params.get("context_length")
+
+    if context_length is None:
+        return True
+
+    chars_per_token = 4.5
+    estimated_tokens = chunk_size / chars_per_token
+
+    return estimated_tokens <= context_length
 
 
 class SearchSpace:
@@ -185,6 +229,7 @@ class AI4RAGSearchSpace(SearchSpace):
     _rules = (
         _rule_chunk_size_bigger_than_chunk_overlap,
         _rule_adjust_window_to_retrieval_method,
+        _rule_chunk_size_within_embedding_context_length,
     )
 
     def __init__(self, params: list[Parameter] | None = None, rules: list[RuleFunction] | None = None):

--- a/dev_utils/mocks.py
+++ b/dev_utils/mocks.py
@@ -6,27 +6,44 @@ from random import random, seed
 from typing import Any
 
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
 
 seed(42)
 
 
-class MockedFoundationModel(BaseFoundationModel):
+class MockedFoundationModel(BaseFoundationModel[None, dict[str, Any] | None]):
     def __init__(
         self,
         model_id: str,
-        model_params: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
         client: None = None,
+        system_message_text: str | None = None,
+        user_message_text: str | None = None,
+        context_template_text: str | None = None,
     ):
-        super().__init__(client, model_id, model_params)
+        super().__init__(
+            client=client,
+            model_id=model_id,
+            params=params,
+            system_message_text=system_message_text,
+            user_message_text=user_message_text,
+            context_template_text=context_template_text,
+        )
 
-    def chat(self, system_message: str, user_message: str) -> str:
-        return "I cannot answer this question, because I am just a mocked model."
+    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
+        # Create a mock response that mimics the structure of real model responses
+        class MockMessage:
+            content = "I cannot answer this question, because I am just a mocked model."
+
+        class MockChoice:
+            message = MockMessage()
+
+        return [MockChoice()]
 
 
-class MockedEmbeddingModel(BaseEmbeddingModel):
+class MockedEmbeddingModel(BaseEmbeddingModel[None, dict[str, Any]]):
     def __init__(self, model_id: str, params: dict[str, Any], client: None = None):
-        super().__init__(client, model_id, params)
+        super().__init__(client=client, model_id=model_id, params=params)
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         n = []

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Foundation model `chat()` API now accepts structured message list instead of separate system/user message strings
-- HPO optimizers use `-1` penalty for failed iterations instead of `None` for better numerical handling
 - Default search space expanded with additional `chunk_size` (512) and `chunk_overlap` (128) values
 - Chunk size validation rule now requires `chunk_size > 2 * chunk_overlap`
 - `LSEmbeddingParams` refactored from `TypedDict` to `@dataclass`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0](https://github.com/IBM/ai4rag/releases/tag/v0.3.0)
+
+### Added
+- Auto-detection of embedding model `embedding_dimension` and `context_length` when not explicitly provided
+- Model availability validation against the Llama Stack server during search space preparation
+- Search space validation rule ensuring `chunk_size` respects embedding model context length
+- New `prepare_search_space_with_llama_stack` utility for streamlined search space setup
+
+### Changed
+- Foundation model `chat()` API now accepts structured message list instead of separate system/user message strings
+- HPO optimizers use `-1` penalty for failed iterations instead of `None` for better numerical handling
+- Default search space expanded with additional `chunk_size` (512) and `chunk_overlap` (128) values
+- Chunk size validation rule now requires `chunk_size > 2 * chunk_overlap`
+- `LSEmbeddingParams` refactored from `TypedDict` to `@dataclass`
+
+### Fixed
+- Embedding model backwards compatibility in vector store for both legacy dict and new dataclass params
+
 ## [0.2.1](https://github.com/IBM/ai4rag/releases/tag/v0.2.1)
 
 ### Changed

--- a/samples/run_ai4rag.ipynb
+++ b/samples/run_ai4rag.ipynb
@@ -46,7 +46,7 @@
     "!pip install boto3 | tail -n 1\n",
     "!pip install -U --no-cache-dir git+https://github.com/LukaszCmielowski/pipelines-components.git@rhoai_autorag | tail -n 1\n",
     "!pip install docling | tail -n 1\n",
-    "!pip install \"ai4rag==0.2.2\" | tail -n 1"
+    "!pip install \"ai4rag==0.3.0\" | tail -n 1"
    ],
    "id": "f18bd4df3d9f4af8"
   },

--- a/samples/run_ai4rag.ipynb
+++ b/samples/run_ai4rag.ipynb
@@ -42,11 +42,35 @@
    "cell_type": "code",
    "source": [
     "!pip install boto3 | tail -n 1\n",
-    "!pip install -U --no-cache-dir git+https://github.com/LukaszCmielowski/pipelines-components.git | tail -n 1\n",
+    "!pip install -U --no-cache-dir git+https://github.com/LukaszCmielowski/pipelines-components.git@rhoai_autorag | tail -n 1\n",
     "!pip install docling | tail -n 1\n",
     "!pip install \"ai4rag==0.2.1\" | tail -n 1"
    ],
    "id": "226c8d4936a1f060",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "import sqlite3\n",
+    "import sys\n",
+    "\n",
+    "REQUIRED_SQLITE_VERSION = (3, 35, 0)\n",
+    "\n",
+    "if sqlite3.sqlite_version_info < REQUIRED_SQLITE_VERSION:\n",
+    "    print(f\"⚠️ SQLite version {sqlite3.sqlite_version} is too low. Applying fix...\")\n",
+    "    !pip install pysqlite3-binary -q\n",
+    "    __import__('pysqlite3')\n",
+    "    sys.modules['sqlite3'] = sys.modules.pop('pysqlite3')\n",
+    "\n",
+    "    import sqlite3\n",
+    "    print(f\"✅ Fixed! New SQLite version: {sqlite3.sqlite_version}\")\n",
+    "else:\n",
+    "    print(f\"✨ SQLite version {sqlite3.sqlite_version} is sufficient. No fix needed.\")"
+   ],
+   "id": "a5872f103e2ee6b0",
    "outputs": [],
    "execution_count": null
   },
@@ -101,8 +125,6 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "AWS_ACCESS_KEY_ID = \"\"\n",
     "AWS_SECRET_ACCESS_KEY = \"\"\n",
@@ -119,7 +141,9 @@
     "if missing:\n",
     "    raise ValueError(f\"Missing required environment variables: {missing}\")"
    ],
-   "id": "76c8482150beaf1"
+   "id": "76c8482150beaf1",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -134,16 +158,16 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
-    "BUCKET_NAME = \"\"\n",
+    "AWS_S3_BUCKET = \"\"\n",
     "\n",
-    "BUCKET_NAME = BUCKET_NAME or os.environ.get(\"BUCKET_NAME\")\n",
-    "if not BUCKET_NAME:\n",
-    "    raise Exception(\"BUCKET_NAME must be provided\")"
+    "AWS_S3_BUCKET = AWS_S3_BUCKET or os.environ.get(\"AWS_S3_BUCKET\")\n",
+    "if not AWS_S3_BUCKET:\n",
+    "    raise Exception(\"AWS_S3_BUCKET must be provided\")"
    ],
-   "id": "777db008f3158bd4"
+   "id": "777db008f3158bd4",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -203,7 +227,7 @@
     "        content = response.read()\n",
     "        content_disposition = response.headers.get(\"Content-Disposition\")\n",
     "        filename = re.findall('filename=\"(.+)\"', content_disposition)[0]\n",
-    "        s3_client.put_object(Bucket=BUCKET_NAME, Key=f\"documents/{filename}\", Body=content)"
+    "        s3_client.put_object(Bucket=AWS_S3_BUCKET, Key=f\"autorag_sample/documents/{filename}\", Body=content)"
    ],
    "id": "3ab70736f269beb5",
    "outputs": [],
@@ -212,7 +236,20 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "### Upload benchmark dataset\nBenchmark data is required for proper evaluation of each created RAG pattern.\nEvery benchmark record needs to have the following fields:\n- `\"question\"`: question that will be sent to the LLM and for which the retrieval will be made\n- `\"correct_answers\"`: array (list in Python) of correct answers for the given question\n- `\"correct_answer_document_ids\"`: filenames of the documents based on which the correct answers were created.\n\n⚠️ **Warning**: Nested folders are currently not supported for the grounding documents in the selected S3 location.\nPlease use a single folder to store your documents.\n\n⚠️ **Warning**: `document_id` corresponds to the document's filename.\nThat might change in the future.",
+   "source": [
+    "### Upload benchmark dataset\n",
+    "Benchmark data is required for proper evaluation of each created RAG pattern.\n",
+    "Every benchmark record needs to have the following fields:\n",
+    "- `\"question\"`: question that will be sent to the LLM and for which the retrieval will be made\n",
+    "- `\"correct_answers\"`: array (list in Python) of correct answers for the given question\n",
+    "- `\"correct_answer_document_ids\"`: filenames of the documents based on which the correct answers were created.\n",
+    "\n",
+    "️🔖 **Note**: Nested folders are currently not supported for the grounding documents in the selected S3 location.\n",
+    "Please use a single folder to store your documents.\n",
+    "\n",
+    "🔖 **Note**: `document_id` corresponds to the document's filename.\n",
+    "That might change in the future."
+   ],
    "id": "dd275ccefa9be89a"
   },
   {
@@ -221,12 +258,12 @@
    "source": [
     "benchmark = [\n",
     "    {\n",
-    "        \"question\": \"What was IBM's revenue in the first quarter of 2024?\",\n",
+    "        \"question\": \"What are IBM's revenue expectations for year 2025?\",\n",
     "        \"correct_answers\": [\n",
-    "            \"Revenue of $14.5 billion, up 1 percent, up 3 percent at constant currency.\"\n",
+    "            \"The company expects full-year constant currency revenue growth of at least 5 percent. At current foreign exchange rates, currency is expected to be about a two-point headwind to growth for the year.\"\n",
     "        ],\n",
     "        \"correct_answer_document_ids\": [\n",
-    "            \"ibm-1q25-earnings-press-release.pdf\"\n",
+    "            \"ibm-4q24-earnings-press-release.pdf\"\n",
     "        ]\n",
     "    },\n",
     "    {\n",
@@ -267,7 +304,7 @@
     "    },\n",
     "]\n",
     "\n",
-    "res = s3_client.put_object(Bucket=BUCKET_NAME, Key=\"benchmark.json\", Body=json.dumps(benchmark))"
+    "res = s3_client.put_object(Bucket=AWS_S3_BUCKET, Key=\"autorag_sample/benchmark.json\", Body=json.dumps(benchmark))"
    ],
    "id": "aa1e2adc1e159d45",
    "outputs": [],
@@ -276,7 +313,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "Look up bucket contents",
+   "source": "Bucket content preview.",
    "id": "7b30681d0e68584a"
   },
   {
@@ -284,8 +321,8 @@
    "cell_type": "code",
    "source": [
     "res = s3_client.list_objects_v2(\n",
-    "    Bucket=BUCKET_NAME,\n",
-    "    Prefix=\"\",\n",
+    "    Bucket=AWS_S3_BUCKET,\n",
+    "    Prefix=\"autorag_sample\",\n",
     ").get(\"Contents\", [])\n",
     "\n",
     "print(\"Bucket contents:\")\n",
@@ -313,10 +350,10 @@
     "step_output_dir = Path(\"./step_outputs\")\n",
     "step_output_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "test_data_bucket_name = BUCKET_NAME\n",
-    "test_data_key = \"benchmark.json\"\n",
-    "input_data_bucket_name = BUCKET_NAME\n",
-    "input_data_key = \"\"\n",
+    "test_data_bucket_name = AWS_S3_BUCKET\n",
+    "test_data_key = \"autorag_sample/benchmark.json\"\n",
+    "input_data_bucket_name = AWS_S3_BUCKET\n",
+    "input_data_key = \"autorag_sample/documents\"\n",
     "sampling_config = {}"
    ],
    "id": "362ce34b55fd0e94",
@@ -445,7 +482,12 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "## Run ai4rag experiment",
+   "source": [
+    "## Run ai4rag experiment\n",
+    "\n",
+    "️🔖 **Note**: This sample notebooks requires Llama Stack server to be available for AutoRAG experiment.\n",
+    "Detailed instruction on how to setup Llama Stack server for AutoRAG can be found under this link: https://github.com/LukaszCmielowski/prototypes/blob/main/llamastack/SETUP.md"
+   ],
    "id": "bf51694eb76232a4"
   },
   {
@@ -493,55 +535,28 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "### Configure the search space\n\n📌 **Action**: You need to select foundation models and embedding models. You can use the models listed above. A foundation model requires only `model_id` and `client`. An embedding model requires you to provide `params` as a `dict` with at least 1 parameter: `embedding_dimension`. This information can be extracted from the embedding model metadata.",
+   "source": [
+    "### Create the search space\n",
+    "You can create a search space with automatic models discovery.\n",
+    "To edit used models you can provide payload containing `foundation_models` and `embedding_models`, e.g.: `payload={\"foundation_models\": [{\"model_id\": \"<ID-OF-THE-MODEL>\"}]}`.\n",
+    "\n",
+    "💡 **Tip**: You can make more configurations on the search space by creating it directly via `ai4rag.search_space.src.search_space.AI4RAGSearchSpace`."
+   ],
    "id": "369aa6e451762b75"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel\n",
-    "from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel\n",
-    "from ai4rag.search_space.src.parameter import Parameter\n",
+    "from ai4rag.search_space.prepare.prepare_search_space import prepare_search_space_with_llama_stack\n",
     "\n",
-    "foundation_models = [LSFoundationModel(model_id=\"vllm-inference-llama-3-1/redhataillama-31-8b-instruct\", client=client)]\n",
-    "\n",
-    "embedding_models = [\n",
-    "    LSEmbeddingModel(\n",
-    "        model_id=\"vllm-embedding/granite-278m-multilingual-1\",\n",
-    "        client=client,\n",
-    "        params={\"embedding_dimension\": 768},\n",
-    "    ),\n",
-    "]"
-   ],
-   "id": "24ef8d1101ee33b1",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "Now you can create a search space that will be used during the experiment.",
-   "id": "b9f9981b4add247f"
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
-   "source": [
-    "from ai4rag.search_space.src.search_space import AI4RAGSearchSpace\n",
-    "\n",
-    "search_space = AI4RAGSearchSpace(\n",
-    "    params=[\n",
-    "        Parameter(name=\"foundation_model\", param_type=\"C\", values=foundation_models),\n",
-    "        Parameter(name=\"embedding_model\", param_type=\"C\", values=embedding_models),\n",
-    "    ]\n",
-    ")\n",
+    "search_space = prepare_search_space_with_llama_stack(payload={}, client=client)\n",
     "\n",
     "print(f\"Maximum possible combinations: {search_space.max_combinations}\")"
    ],
-   "id": "19ebd850b420ad6e"
+   "id": "19ebd850b420ad6e",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -559,14 +574,14 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "from ai4rag.core.hpo.gam_opt import GAMOptSettings\n",
     "\n",
     "optimizer_settings = GAMOptSettings(max_evals=10, n_random_nodes=4)"
    ],
-   "id": "4e6edd96b6642d7f"
+   "id": "4e6edd96b6642d7f",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -652,14 +667,14 @@
     "    \n",
     "    Parameters\n",
     "    ----------\n",
-    "    rag_pattern : LlamaStackRAG\n",
+    "    rag_pattern : BaseRAGTemplate\n",
     "        RAG pattern that is able to retrieve proper context\n",
     "        and respond to the question.\n",
     "\n",
     "    Returns\n",
     "    -------\n",
     "    dict\n",
-    "    Response containing answer, reference_documents, and question\n",
+    "        Response containing answer, reference_documents, and question\n",
     "    \"\"\"\n",
     "    question = input(\"Question: \")\n",
     "    print(f\"\\n{'=' * 80}\")\n",

--- a/samples/run_ai4rag.ipynb
+++ b/samples/run_ai4rag.ipynb
@@ -40,19 +40,21 @@
   {
    "metadata": {},
    "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "!pip install boto3 | tail -n 1\n",
     "!pip install -U --no-cache-dir git+https://github.com/LukaszCmielowski/pipelines-components.git@rhoai_autorag | tail -n 1\n",
     "!pip install docling | tail -n 1\n",
-    "!pip install \"ai4rag==0.2.1\" | tail -n 1"
+    "!pip install \"ai4rag==0.2.2\" | tail -n 1"
    ],
-   "id": "226c8d4936a1f060",
-   "outputs": [],
-   "execution_count": null
+   "id": "f18bd4df3d9f4af8"
   },
   {
    "metadata": {},
    "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "import sqlite3\n",
     "import sys\n",
@@ -70,9 +72,7 @@
     "else:\n",
     "    print(f\"✨ SQLite version {sqlite3.sqlite_version} is sufficient. No fix needed.\")"
    ],
-   "id": "a5872f103e2ee6b0",
-   "outputs": [],
-   "execution_count": null
+   "id": "a8e9a9ba9b39c37"
   },
   {
    "metadata": {},

--- a/tests/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/ai4rag/core/hpo/test_gam_opt.py
@@ -205,7 +205,7 @@ class TestGAMOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns None."""
+        """Test that _objective_function catches FailedIterationError and returns -1."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = GAMOptimizer(
@@ -217,7 +217,7 @@ class TestGAMOptimizer:
         params = {"param1": "test", "param2": 10}
         result = optimizer._objective_function(params)
 
-        assert result is None
+        assert result == -1
         objective_func.assert_called_once_with(params)
 
     def test_get_iterations_limit(self, mock_search_space, optimizer_settings):
@@ -280,8 +280,8 @@ class TestGAMOptimizer:
             assert "score" in evaluation
 
     def test_evaluate_initial_random_nodes_with_failures(self, mock_search_space, optimizer_settings, mocker):
-        """Test evaluate_initial_random_nodes with some failed iterations."""
-        # First fails, second succeeds, third succeeds
+        """Test evaluate_initial_random_nodes skips failed iterations (score=-1) when counting successes."""
+        # First fails (returns -1), second succeeds, third fails (returns -1), fourth succeeds, fifth succeeds
         objective_func = MagicMock(
             side_effect=[
                 FailedIterationError("Failed"),
@@ -301,11 +301,13 @@ class TestGAMOptimizer:
 
         optimizer.evaluate_initial_random_nodes()
 
-        # Should continue until n_random_nodes=3 successful evaluations
-        # or until max_iterations is reached
-        successful_evals = [e for e in optimizer.evaluations if e["score"] is not None]
+        # Failures (score=-1) are NOT counted as successful, so we need 3 successes.
+        # Sequence: fail(-1), 0.7, fail(-1), 0.5, 0.3 → 5 total evaluations, 3 successful
+        assert len(optimizer.evaluations) == 5
+        successful_evals = [e for e in optimizer.evaluations if e["score"] > 0]
         assert len(successful_evals) == 3
-        assert len(optimizer.evaluations) >= 3
+        failed_evals = [e for e in optimizer.evaluations if e["score"] == -1]
+        assert len(failed_evals) == 2
 
     def test_evaluate_initial_random_nodes_stops_at_max_iterations(self, mock_search_space, mocker):
         """Test that evaluate_initial_random_nodes stops at max_iterations."""
@@ -470,18 +472,22 @@ class TestGAMOptimizer:
         settings = GAMOptSettings(max_evals=5, n_random_nodes=2, evals_per_trial=1)
 
         # Mock LinearGAM
+        # After initial random evals (0.3 success, fail -1, need 1 more success),
+        # we get 3 evals during random phase. Then 3 remaining for GAM iterations.
         mock_gam = MagicMock()
-        mock_gam.predict.return_value = np.array([0.6, 0.7, 0.5])
+        mock_gam.predict.side_effect = [
+            np.array([0.6, 0.7, 0.5]),  # First iteration: 3 remaining
+            np.array([0.65, 0.55]),  # Second iteration: 2 remaining
+        ]
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
         objective_func = MagicMock(
             side_effect=[
-                0.3,
-                FailedIterationError("Failed"),
-                0.5,
-                0.8,
-                FailedIterationError("Failed"),
-                0.6,
+                0.3,  # Initial random 1 (success)
+                FailedIterationError("Failed"),  # Initial random 2 (returns -1, not counted)
+                0.5,  # Initial random 3 (success, reaches n_random_nodes=2)
+                0.8,  # GAM iteration 1
+                0.6,  # GAM iteration 2
             ]
         )
         mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
@@ -498,7 +504,7 @@ class TestGAMOptimizer:
 
         result = optimizer.search()
 
-        # Should return the best successful evaluation
+        # Should return the best successful evaluation (score >= 0)
         assert result["score"] == 0.8
 
     def test_run_iteration_evaluates_best_predictions(self, mock_search_space, mocker):
@@ -530,21 +536,23 @@ class TestGAMOptimizer:
         # Should have evaluated evals_per_trial=2 more combinations
         assert len(optimizer.evaluations) == 4
 
-    def test_run_iteration_filters_out_nan_scores_for_training(self, mock_search_space, mocker):
-        """Test that _run_iteration filters out NaN scores when training GAM."""
+    def test_run_iteration_includes_failed_evaluations_in_training(self, mock_search_space, mocker):
+        """Test that _run_iteration includes failed evaluations (score=-1) when training GAM."""
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3, evals_per_trial=1)
 
         mock_gam = MagicMock()
-        mock_gam.predict.return_value = np.array([0.6, 0.7, 0.5])
+        mock_gam.predict.return_value = np.array([0.6, 0.7])
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
-        # Mix of successful and failed evaluations
+        # Need 3 successful evals (score > 0). Failure doesn't count.
+        # Sequence: 0.3 (ok), fail(-1), 0.5 (ok), 0.8 (ok) → 4 total, 3 successful
         objective_func = MagicMock(
             side_effect=[
                 0.3,
-                FailedIterationError("Failed"),
+                FailedIterationError("Failed"),  # This will return score=-1
                 0.5,
                 0.8,
+                0.6,  # extra for _run_iteration
             ]
         )
         mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
@@ -559,22 +567,18 @@ class TestGAMOptimizer:
             settings=settings,
         )
 
-        # Manually set evaluations with some None scores
-        optimizer.evaluations = [
-            {"param1": "a", "param2": 1, "score": 0.3},
-            {"param1": "b", "param2": 2, "score": None},
-            {"param1": "c", "param2": 3, "score": 0.5},
-        ]
-        optimizer._evaluated_combinations = [
-            {"param1": "a", "param2": 1},
-            {"param1": "b", "param2": 2},
-            {"param1": "c", "param2": 3},
-        ]
+        optimizer.evaluate_initial_random_nodes()
+
+        # Should have 4 evaluations: [0.3, -1, 0.5, 0.8] (3 successful + 1 failure)
+        assert len(optimizer.evaluations) == 4
+        assert optimizer.evaluations[0]["score"] == 0.3
+        assert optimizer.evaluations[1]["score"] == -1  # Failed iteration
+        assert optimizer.evaluations[2]["score"] == 0.5
+        assert optimizer.evaluations[3]["score"] == 0.8
 
         optimizer._run_iteration()
 
-        # GAM should be trained only on non-None scores
-        # The fit call should receive only 2 samples (those with non-None scores)
+        # GAM should be trained on all scores, including the -1 from failed iteration
         call_args = mock_gam.fit.call_args
-        assert call_args[0][0].shape[0] == 2  # X_train should have 2 samples
-        assert call_args[0][1].shape[0] == 2  # y_train should have 2 samples
+        assert call_args[0][0].shape[0] == 4  # X_train should have 4 samples
+        assert call_args[0][1].shape[0] == 4  # y_train should have 4 samples

--- a/tests/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/ai4rag/core/hpo/test_gam_opt.py
@@ -205,7 +205,7 @@ class TestGAMOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns -1."""
+        """Test that _objective_function catches FailedIterationError and returns None."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = GAMOptimizer(
@@ -217,7 +217,7 @@ class TestGAMOptimizer:
         params = {"param1": "test", "param2": 10}
         result = optimizer._objective_function(params)
 
-        assert result == -1
+        assert result is None
         objective_func.assert_called_once_with(params)
 
     def test_get_iterations_limit(self, mock_search_space, optimizer_settings):
@@ -280,8 +280,8 @@ class TestGAMOptimizer:
             assert "score" in evaluation
 
     def test_evaluate_initial_random_nodes_with_failures(self, mock_search_space, optimizer_settings, mocker):
-        """Test evaluate_initial_random_nodes skips failed iterations (score=-1) when counting successes."""
-        # First fails (returns -1), second succeeds, third fails (returns -1), fourth succeeds, fifth succeeds
+        """Test evaluate_initial_random_nodes skips failed iterations (score=None) when counting successes."""
+        # First fails (returns None), second succeeds, third fails (returns None), fourth succeeds, fifth succeeds
         objective_func = MagicMock(
             side_effect=[
                 FailedIterationError("Failed"),
@@ -301,12 +301,12 @@ class TestGAMOptimizer:
 
         optimizer.evaluate_initial_random_nodes()
 
-        # Failures (score=-1) are NOT counted as successful, so we need 3 successes.
-        # Sequence: fail(-1), 0.7, fail(-1), 0.5, 0.3 → 5 total evaluations, 3 successful
+        # Failures (score=None) are NOT counted as successful, so we need 3 successes.
+        # Sequence: fail(None), 0.7, fail(None), 0.5, 0.3 → 5 total evaluations, 3 successful
         assert len(optimizer.evaluations) == 5
-        successful_evals = [e for e in optimizer.evaluations if e["score"] > 0]
+        successful_evals = [e for e in optimizer.evaluations if e["score"] is not None]
         assert len(successful_evals) == 3
-        failed_evals = [e for e in optimizer.evaluations if e["score"] == -1]
+        failed_evals = [e for e in optimizer.evaluations if e["score"] is None]
         assert len(failed_evals) == 2
 
     def test_evaluate_initial_random_nodes_stops_at_max_iterations(self, mock_search_space, mocker):
@@ -472,8 +472,9 @@ class TestGAMOptimizer:
         settings = GAMOptSettings(max_evals=5, n_random_nodes=2, evals_per_trial=1)
 
         # Mock LinearGAM
-        # After initial random evals (0.3 success, fail -1, need 1 more success),
+        # After initial random evals (0.3 success, fail None, need 1 more success),
         # we get 3 evals during random phase. Then 3 remaining for GAM iterations.
+        # Note: None scores are filtered out before GAM training, so GAM sees only 2 samples.
         mock_gam = MagicMock()
         mock_gam.predict.side_effect = [
             np.array([0.6, 0.7, 0.5]),  # First iteration: 3 remaining
@@ -484,7 +485,7 @@ class TestGAMOptimizer:
         objective_func = MagicMock(
             side_effect=[
                 0.3,  # Initial random 1 (success)
-                FailedIterationError("Failed"),  # Initial random 2 (returns -1, not counted)
+                FailedIterationError("Failed"),  # Initial random 2 (returns None, not counted)
                 0.5,  # Initial random 3 (success, reaches n_random_nodes=2)
                 0.8,  # GAM iteration 1
                 0.6,  # GAM iteration 2
@@ -504,7 +505,7 @@ class TestGAMOptimizer:
 
         result = optimizer.search()
 
-        # Should return the best successful evaluation (score >= 0)
+        # Should return the best successful evaluation (score is not None)
         assert result["score"] == 0.8
 
     def test_run_iteration_evaluates_best_predictions(self, mock_search_space, mocker):
@@ -536,20 +537,20 @@ class TestGAMOptimizer:
         # Should have evaluated evals_per_trial=2 more combinations
         assert len(optimizer.evaluations) == 4
 
-    def test_run_iteration_includes_failed_evaluations_in_training(self, mock_search_space, mocker):
-        """Test that _run_iteration includes failed evaluations (score=-1) when training GAM."""
+    def test_run_iteration_filters_out_none_scores_for_training(self, mock_search_space, mocker):
+        """Test that _run_iteration filters out None scores when training GAM."""
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3, evals_per_trial=1)
 
         mock_gam = MagicMock()
         mock_gam.predict.return_value = np.array([0.6, 0.7])
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
-        # Need 3 successful evals (score > 0). Failure doesn't count.
-        # Sequence: 0.3 (ok), fail(-1), 0.5 (ok), 0.8 (ok) → 4 total, 3 successful
+        # Need 3 successful evals (score is not None). Failure doesn't count.
+        # Sequence: 0.3 (ok), fail(None), 0.5 (ok), 0.8 (ok) → 4 total, 3 successful
         objective_func = MagicMock(
             side_effect=[
                 0.3,
-                FailedIterationError("Failed"),  # This will return score=-1
+                FailedIterationError("Failed"),  # This will return score=None
                 0.5,
                 0.8,
                 0.6,  # extra for _run_iteration
@@ -569,16 +570,17 @@ class TestGAMOptimizer:
 
         optimizer.evaluate_initial_random_nodes()
 
-        # Should have 4 evaluations: [0.3, -1, 0.5, 0.8] (3 successful + 1 failure)
+        # Should have 4 evaluations: [0.3, None, 0.5, 0.8] (3 successful + 1 failure)
         assert len(optimizer.evaluations) == 4
         assert optimizer.evaluations[0]["score"] == 0.3
-        assert optimizer.evaluations[1]["score"] == -1  # Failed iteration
+        assert optimizer.evaluations[1]["score"] is None  # Failed iteration
         assert optimizer.evaluations[2]["score"] == 0.5
         assert optimizer.evaluations[3]["score"] == 0.8
 
         optimizer._run_iteration()
 
-        # GAM should be trained on all scores, including the -1 from failed iteration
+        # GAM should be trained only on non-None scores
+        # The fit call should receive only 3 samples (those with non-None scores)
         call_args = mock_gam.fit.call_args
-        assert call_args[0][0].shape[0] == 4  # X_train should have 4 samples
-        assert call_args[0][1].shape[0] == 4  # y_train should have 4 samples
+        assert call_args[0][0].shape[0] == 3  # X_train should have 3 samples
+        assert call_args[0][1].shape[0] == 3  # y_train should have 3 samples

--- a/tests/ai4rag/core/hpo/test_random_opt.py
+++ b/tests/ai4rag/core/hpo/test_random_opt.py
@@ -159,7 +159,7 @@ class TestRandomOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns None."""
+        """Test that _objective_function catches FailedIterationError and returns -1."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = RandomOptimizer(
@@ -171,7 +171,7 @@ class TestRandomOptimizer:
         params = {"param1": 10, "param2": "test"}
         result = optimizer._objective_function(params)
 
-        assert result is None
+        assert result == -1
         objective_func.assert_called_once_with(params)
 
     def test_search_shuffles_combinations(self, mock_search_space, optimizer_settings, mocker):
@@ -250,8 +250,8 @@ class TestRandomOptimizer:
             assert "param2" in evaluation
             assert "score" in evaluation
 
-    def test_search_filters_out_none_scores(self, mock_search_space, mocker):
-        """Test that search correctly filters out evaluations with None scores."""
+    def test_search_filters_out_failed_scores(self, mock_search_space, mocker):
+        """Test that search correctly filters out evaluations with negative scores (failures)."""
         settings = RandomOptSettings(max_evals=4)
         # Mix of successful and failed evaluations
         objective_func = MagicMock(

--- a/tests/ai4rag/core/hpo/test_random_opt.py
+++ b/tests/ai4rag/core/hpo/test_random_opt.py
@@ -159,7 +159,7 @@ class TestRandomOptimizer:
         objective_func.assert_called_once_with(params)
 
     def test_objective_function_wrapper_catches_failed_iteration_error(self, mock_search_space, optimizer_settings):
-        """Test that _objective_function catches FailedIterationError and returns -1."""
+        """Test that _objective_function catches FailedIterationError and returns None."""
         objective_func = MagicMock(side_effect=FailedIterationError("Iteration failed"))
 
         optimizer = RandomOptimizer(
@@ -171,7 +171,7 @@ class TestRandomOptimizer:
         params = {"param1": 10, "param2": "test"}
         result = optimizer._objective_function(params)
 
-        assert result == -1
+        assert result is None
         objective_func.assert_called_once_with(params)
 
     def test_search_shuffles_combinations(self, mock_search_space, optimizer_settings, mocker):
@@ -250,8 +250,8 @@ class TestRandomOptimizer:
             assert "param2" in evaluation
             assert "score" in evaluation
 
-    def test_search_filters_out_failed_scores(self, mock_search_space, mocker):
-        """Test that search correctly filters out evaluations with negative scores (failures)."""
+    def test_search_filters_out_none_scores(self, mock_search_space, mocker):
+        """Test that search correctly filters out evaluations with None scores."""
         settings = RandomOptSettings(max_evals=4)
         # Mix of successful and failed evaluations
         objective_func = MagicMock(

--- a/tests/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/ai4rag/rag/embedding/test_llama_stack.py
@@ -30,43 +30,48 @@ class TestLSEmbeddingModel:
         return mock_client
 
     def test_init_with_explicit_dimension(self, mock_ls_client):
-        """Test initialization with explicit embedding_dimension does not trigger auto-detection."""
-        params = LSEmbeddingParams(embedding_dimension=768)
+        """Test initialization with explicit embedding_dimension and context_length does not trigger auto-detection."""
+        params = LSEmbeddingParams(embedding_dimension=768, context_length=512)
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
 
         assert model.params.embedding_dimension == 768
+        assert model.params.context_length == 512
         mock_ls_client.embeddings.create.assert_not_called()
 
     def test_init_with_dict_params_with_dimension(self, mock_ls_client):
-        """Test initialization with dict params containing embedding_dimension."""
+        """Test initialization with dict params containing embedding_dimension and context_length."""
         model = LSEmbeddingModel(
-            client=mock_ls_client, model_id="all-MiniLM-L6-v2", params={"embedding_dimension": 384}
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params={"embedding_dimension": 384, "context_length": 512},
         )
 
         assert model.params.embedding_dimension == 384
+        assert model.params.context_length == 512
         mock_ls_client.embeddings.create.assert_not_called()
 
     def test_init_without_params_auto_detects_dimension(self, mock_ls_client):
-        """Test initialization without params triggers auto-detection of embedding_dimension."""
+        """Test initialization without params triggers auto-detection of embedding_dimension and context_length."""
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2")
 
         assert model.params.embedding_dimension == 4
-        mock_ls_client.embeddings.create.assert_called_once()
+        # Binary search converges near upper bound when all probes succeed
+        assert model.params.context_length > 0
 
     def test_init_with_none_params_auto_detects_dimension(self, mock_ls_client):
         """Test initialization with params=None triggers auto-detection."""
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=None)
 
         assert model.params.embedding_dimension == 4
-        mock_ls_client.embeddings.create.assert_called_once()
+        assert model.params.context_length > 0
 
     def test_init_with_params_missing_dimension_auto_detects(self, mock_ls_client):
         """Test that auto-detection triggers when LSEmbeddingParams has no dimension."""
-        params = LSEmbeddingParams()  # embedding_dimension defaults to None
+        params = LSEmbeddingParams()  # embedding_dimension and context_length default to None
         model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
 
         assert model.params.embedding_dimension == 4
-        mock_ls_client.embeddings.create.assert_called_once()
+        assert model.params.context_length > 0
 
     def test_init_with_invalid_params_type(self, mock_ls_client):
         """Test initialization with invalid params type raises TypeError."""
@@ -92,12 +97,67 @@ class TestLSEmbeddingModel:
 
         assert exc_info.value.__cause__ is original_error
 
+    def test_detect_context_length_all_probes_succeed(self, mock_ls_client):
+        """Test that context_length detection converges near upper bound when all probes succeed."""
+        params = LSEmbeddingParams(embedding_dimension=384)
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        # Binary search converges near 8192 when all probes succeed
+        assert model.params.context_length > 4096
+
+    def test_detect_context_length_binary_search_finds_limit(self, mocker):
+        """Test that binary search finds the correct context_length limit."""
+        mock_client = mocker.MagicMock()
+        response = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        def side_effect(**kwargs):
+            text = kwargs.get("input", "")
+            # Each "word " is 5 chars, so N words = N*5 chars
+            # Accept up to 2048 words
+            if isinstance(text, str) and len(text) > 2048 * 5:
+                raise ValueError("Input too long")
+            return response
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        params = LSEmbeddingParams(embedding_dimension=384)
+        model = LSEmbeddingModel(client=mock_client, model_id="test-model", params=params)
+
+        # Binary search should find a value close to 2048
+        assert 1792 <= model.params.context_length <= 2048
+
+    def test_detect_context_length_all_probes_fail(self, mocker):
+        """Test that RuntimeError is raised when all context_length probes fail."""
+        mock_client = mocker.MagicMock()
+        dim_response = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        call_count = [0]
+
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return dim_response  # dimension detection
+            raise ValueError("Input too long")
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect 'context_length'"):
+            LSEmbeddingModel(client=mock_client, model_id="test-model", params=None)
+
+    def test_detect_context_length_skipped_when_explicit(self, mock_ls_client):
+        """Test that context_length detection is skipped when explicitly provided."""
+        params = LSEmbeddingParams(embedding_dimension=384, context_length=1024)
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.context_length == 1024
+        mock_ls_client.embeddings.create.assert_not_called()
+
     def test_embed_documents(self, mock_ls_client, mocker):
         """Test embed_documents method."""
         model = LSEmbeddingModel(
             client=mock_ls_client,
             model_id="all-MiniLM-L6-v2",
-            params=LSEmbeddingParams(embedding_dimension=3),
+            params=LSEmbeddingParams(embedding_dimension=3, context_length=512),
         )
         mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(
             mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
@@ -114,7 +174,7 @@ class TestLSEmbeddingModel:
         model = LSEmbeddingModel(
             client=mock_ls_client,
             model_id="all-MiniLM-L6-v2",
-            params=LSEmbeddingParams(embedding_dimension=3),
+            params=LSEmbeddingParams(embedding_dimension=3, context_length=512),
         )
         mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
 
@@ -127,7 +187,7 @@ class TestLSEmbeddingModel:
         model = LSEmbeddingModel(
             client=mock_ls_client,
             model_id="all-MiniLM-L6-v2",
-            params=LSEmbeddingParams(embedding_dimension=384),
+            params=LSEmbeddingParams(embedding_dimension=384, context_length=512),
         )
 
         assert repr(model) == "all-MiniLM-L6-v2"

--- a/tests/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/ai4rag/rag/embedding/test_llama_stack.py
@@ -1,0 +1,134 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+
+import pytest
+
+from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel, LSEmbeddingParams
+
+
+def _make_mock_ls_embedding_response(mocker, embeddings):
+    """Helper to create a mock Llama Stack embedding response."""
+    mock_response = mocker.MagicMock()
+    mock_response.data = []
+    for emb in embeddings:
+        mock_data = mocker.MagicMock()
+        mock_data.embedding = emb
+        mock_response.data.append(mock_data)
+    return mock_response
+
+
+class TestLSEmbeddingModel:
+    """Test suite for LSEmbeddingModel class."""
+
+    @pytest.fixture
+    def mock_ls_client(self, mocker):
+        """Create a mock Llama Stack client with default embedding response for auto-detection."""
+        mock_client = mocker.MagicMock()
+        mock_client.embeddings.create.return_value = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3, 0.4]])
+        return mock_client
+
+    def test_init_with_explicit_dimension(self, mock_ls_client):
+        """Test initialization with explicit embedding_dimension does not trigger auto-detection."""
+        params = LSEmbeddingParams(embedding_dimension=768)
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.embedding_dimension == 768
+        mock_ls_client.embeddings.create.assert_not_called()
+
+    def test_init_with_dict_params_with_dimension(self, mock_ls_client):
+        """Test initialization with dict params containing embedding_dimension."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client, model_id="all-MiniLM-L6-v2", params={"embedding_dimension": 384}
+        )
+
+        assert model.params.embedding_dimension == 384
+        mock_ls_client.embeddings.create.assert_not_called()
+
+    def test_init_without_params_auto_detects_dimension(self, mock_ls_client):
+        """Test initialization without params triggers auto-detection of embedding_dimension."""
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2")
+
+        assert model.params.embedding_dimension == 4
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_init_with_none_params_auto_detects_dimension(self, mock_ls_client):
+        """Test initialization with params=None triggers auto-detection."""
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=None)
+
+        assert model.params.embedding_dimension == 4
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_init_with_params_missing_dimension_auto_detects(self, mock_ls_client):
+        """Test that auto-detection triggers when LSEmbeddingParams has no dimension."""
+        params = LSEmbeddingParams()  # embedding_dimension defaults to None
+        model = LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params=params)
+
+        assert model.params.embedding_dimension == 4
+        mock_ls_client.embeddings.create.assert_called_once()
+
+    def test_init_with_invalid_params_type(self, mock_ls_client):
+        """Test initialization with invalid params type raises TypeError."""
+        with pytest.raises(TypeError, match="Incorrect type of 'params' parameter"):
+            LSEmbeddingModel(client=mock_ls_client, model_id="all-MiniLM-L6-v2", params="invalid")
+
+    def test_detect_embedding_dimension_api_failure(self, mocker):
+        """Test that _detect_embedding_dimension raises RuntimeError on API failure."""
+        mock_client = mocker.MagicMock()
+        mock_client.embeddings.create.side_effect = ConnectionError("Service unavailable")
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
+            LSEmbeddingModel(client=mock_client, model_id="all-MiniLM-L6-v2", params=None)
+
+    def test_detect_embedding_dimension_preserves_original_exception(self, mocker):
+        """Test that the original exception is chained in the RuntimeError."""
+        mock_client = mocker.MagicMock()
+        original_error = ConnectionError("Connection refused")
+        mock_client.embeddings.create.side_effect = original_error
+
+        with pytest.raises(RuntimeError) as exc_info:
+            LSEmbeddingModel(client=mock_client, model_id="test-model", params=None)
+
+        assert exc_info.value.__cause__ is original_error
+
+    def test_embed_documents(self, mock_ls_client, mocker):
+        """Test embed_documents method."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=3),
+        )
+        mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(
+            mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        )
+
+        embeddings = model.embed_documents(["text1", "text2"])
+
+        assert len(embeddings) == 2
+        assert embeddings[0] == [0.1, 0.2, 0.3]
+        assert embeddings[1] == [0.4, 0.5, 0.6]
+
+    def test_embed_query(self, mock_ls_client, mocker):
+        """Test embed_query method."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=3),
+        )
+        mock_ls_client.embeddings.create.return_value = _make_mock_ls_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        embedding = model.embed_query("test query")
+
+        assert embedding == [0.1, 0.2, 0.3]
+
+    def test_model_repr(self, mock_ls_client):
+        """Test string representation."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=384),
+        )
+
+        assert repr(model) == "all-MiniLM-L6-v2"
+        assert str(model) == "all-MiniLM-L6-v2"

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -32,16 +32,16 @@ class TestOpenAIEmbeddingModel:
 
     @pytest.fixture
     def model_with_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel with parameters including embedding_dimension."""
+        """Create an OpenAIEmbeddingModel with parameters including embedding_dimension and context_length."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-ada-002",
-            params={"dimensions": 1536, "embedding_dimension": 1536},
+            params={"dimensions": 1536, "embedding_dimension": 1536, "context_length": 8191},
         )
 
     @pytest.fixture
     def model_without_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel without parameters (auto-detects embedding_dimension)."""
+        """Create an OpenAIEmbeddingModel without parameters (auto-detects embedding_dimension and context_length)."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-3-small",
@@ -53,17 +53,18 @@ class TestOpenAIEmbeddingModel:
         assert model_with_params.model_id == "text-embedding-ada-002"
         assert model_with_params.params["dimensions"] == 1536
         assert model_with_params.params["embedding_dimension"] == 1536
+        assert model_with_params.params["context_length"] == 8191
         assert model_with_params.client == mock_openai_client
         # No auto-detection call should have been made
         mock_openai_client.embeddings.create.assert_not_called()
 
     def test_init_without_params(self, model_without_params, mock_openai_client):
-        """Test initialization without parameters triggers auto-detection of embedding_dimension."""
+        """Test initialization without parameters triggers auto-detection of embedding_dimension and context_length."""
         assert model_without_params.model_id == "text-embedding-3-small"
         assert model_without_params.params["embedding_dimension"] == 5
+        # Binary search converges near upper bound when all probes succeed
+        assert model_without_params.params["context_length"] > 0
         assert model_without_params.client == mock_openai_client
-        # Auto-detection call should have been made with "test"
-        mock_openai_client.embeddings.create.assert_called_once_with(model="text-embedding-3-small", input="test")
 
     def test_embed_documents(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents method."""
@@ -186,3 +187,67 @@ class TestOpenAIEmbeddingModel:
 
         with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
             OpenAIEmbeddingModel(client=mock_client, model_id="text-embedding-ada-002", params=None)
+
+    def test_detect_context_length_all_probes_succeed(self, mock_openai_client):
+        """Test that context_length detection converges near upper bound when all probes succeed."""
+        model = OpenAIEmbeddingModel(
+            client=mock_openai_client,
+            model_id="text-embedding-3-small",
+            params={"embedding_dimension": 1536},
+        )
+
+        # Binary search converges near 8192 when all probes succeed
+        assert model.params["context_length"] > 4096
+
+    def test_detect_context_length_binary_search_finds_limit(self, mocker):
+        """Test that binary search finds the correct context_length limit."""
+        mock_client = mocker.MagicMock()
+        response = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        def side_effect(**kwargs):
+            text = kwargs.get("input", "")
+            # Each "word " is 5 chars, so N words = N*5 chars
+            # Accept up to 2048 words
+            if isinstance(text, str) and len(text) > 2048 * 5:
+                raise ValueError("Input too long")
+            return response
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        model = OpenAIEmbeddingModel(
+            client=mock_client,
+            model_id="test-model",
+            params={"embedding_dimension": 384},
+        )
+
+        # Binary search should find a value close to 2048
+        assert 1792 <= model.params["context_length"] <= 2048
+
+    def test_detect_context_length_all_probes_fail(self, mocker):
+        """Test that RuntimeError is raised when all context_length probes fail."""
+        mock_client = mocker.MagicMock()
+        dim_response = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        call_count = [0]
+
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return dim_response  # dimension detection
+            raise ValueError("Input too long")
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect 'context_length'"):
+            OpenAIEmbeddingModel(client=mock_client, model_id="test-model", params=None)
+
+    def test_detect_context_length_skipped_when_explicit(self, mock_openai_client):
+        """Test that context_length detection is skipped when explicitly provided."""
+        model = OpenAIEmbeddingModel(
+            client=mock_openai_client,
+            model_id="text-embedding-3-small",
+            params={"embedding_dimension": 1536, "context_length": 8191},
+        )
+
+        assert model.params["context_length"] == 8191
+        mock_openai_client.embeddings.create.assert_not_called()

--- a/tests/ai4rag/rag/embedding/test_openai_model.py
+++ b/tests/ai4rag/rag/embedding/test_openai_model.py
@@ -8,34 +8,40 @@ import pytest
 from ai4rag.rag.embedding.openai_model import OpenAIEmbeddingModel
 
 
+def _make_mock_embedding_response(mocker, embeddings):
+    """Helper to create a mock OpenAI embedding response."""
+    mock_response = mocker.MagicMock()
+    mock_response.data = []
+    for emb in embeddings:
+        mock_data = mocker.MagicMock()
+        mock_data.embedding = emb
+        mock_response.data.append(mock_data)
+    return mock_response
+
+
 class TestOpenAIEmbeddingModel:
     """Test suite for OpenAIEmbeddingModel class."""
 
     @pytest.fixture
     def mock_openai_client(self, mocker):
-        """Create a mock OpenAI client."""
+        """Create a mock OpenAI client with default embedding response for auto-detection."""
         mock_client = mocker.MagicMock()
+        # Default response for embedding_dimension auto-detection
+        mock_client.embeddings.create.return_value = _make_mock_embedding_response(mocker, [[0.1, 0.2, 0.3, 0.4, 0.5]])
         return mock_client
 
     @pytest.fixture
-    def mock_embedding_response(self, mocker):
-        """Create a mock embedding response."""
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
-        return mock_data
-
-    @pytest.fixture
     def model_with_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel with parameters."""
+        """Create an OpenAIEmbeddingModel with parameters including embedding_dimension."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-ada-002",
-            params={"dimensions": 1536},
+            params={"dimensions": 1536, "embedding_dimension": 1536},
         )
 
     @pytest.fixture
     def model_without_params(self, mock_openai_client):
-        """Create an OpenAIEmbeddingModel without parameters."""
+        """Create an OpenAIEmbeddingModel without parameters (auto-detects embedding_dimension)."""
         return OpenAIEmbeddingModel(
             client=mock_openai_client,
             model_id="text-embedding-3-small",
@@ -43,40 +49,36 @@ class TestOpenAIEmbeddingModel:
         )
 
     def test_init_with_params(self, model_with_params, mock_openai_client):
-        """Test initialization with parameters."""
+        """Test initialization with parameters does not trigger auto-detection."""
         assert model_with_params.model_id == "text-embedding-ada-002"
-        assert model_with_params.params == {"dimensions": 1536}
+        assert model_with_params.params["dimensions"] == 1536
+        assert model_with_params.params["embedding_dimension"] == 1536
         assert model_with_params.client == mock_openai_client
+        # No auto-detection call should have been made
+        mock_openai_client.embeddings.create.assert_not_called()
 
     def test_init_without_params(self, model_without_params, mock_openai_client):
-        """Test initialization without parameters."""
+        """Test initialization without parameters triggers auto-detection of embedding_dimension."""
         assert model_without_params.model_id == "text-embedding-3-small"
-        assert model_without_params.params is None
+        assert model_without_params.params["embedding_dimension"] == 5
         assert model_without_params.client == mock_openai_client
+        # Auto-detection call should have been made with "test"
+        mock_openai_client.embeddings.create.assert_called_once_with(model="text-embedding-3-small", input="test")
 
     def test_embed_documents(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents method."""
-        # Setup mock response
-        mock_response = mocker.MagicMock()
-        mock_data_1 = mocker.MagicMock()
-        mock_data_1.embedding = [0.1, 0.2, 0.3]
-        mock_data_2 = mocker.MagicMock()
-        mock_data_2.embedding = [0.4, 0.5, 0.6]
-        mock_data_3 = mocker.MagicMock()
-        mock_data_3.embedding = [0.7, 0.8, 0.9]
-        mock_response.data = [mock_data_1, mock_data_2, mock_data_3]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+        )
 
         texts = ["first document", "second document", "third document"]
         embeddings = model_with_params.embed_documents(texts)
 
-        # Verify client was called correctly
         mock_openai_client.embeddings.create.assert_called_once_with(
             model="text-embedding-ada-002",
             input=texts,
         )
 
-        # Verify returned embeddings
         assert len(embeddings) == 3
         assert embeddings[0] == [0.1, 0.2, 0.3]
         assert embeddings[1] == [0.4, 0.5, 0.6]
@@ -84,9 +86,7 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_documents_empty_list(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents with empty list."""
-        mock_response = mocker.MagicMock()
-        mock_response.data = []
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(mocker, [])
 
         embeddings = model_with_params.embed_documents([])
 
@@ -98,11 +98,9 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_documents_single_text(self, model_with_params, mock_openai_client, mocker):
         """Test embed_documents with single text."""
-        mock_response = mocker.MagicMock()
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = [0.1, 0.2, 0.3, 0.4]
-        mock_response.data = [mock_data]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[0.1, 0.2, 0.3, 0.4]]
+        )
 
         embeddings = model_with_params.embed_documents(["single document"])
 
@@ -111,31 +109,23 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_query(self, model_with_params, mock_openai_client, mocker):
         """Test embed_query method."""
-        mock_response = mocker.MagicMock()
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
-        mock_response.data = [mock_data]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[0.1, 0.2, 0.3, 0.4, 0.5]]
+        )
 
         query = "What is machine learning?"
         embedding = model_with_params.embed_query(query)
 
-        # Verify client was called correctly
         mock_openai_client.embeddings.create.assert_called_once_with(
             model="text-embedding-ada-002",
             input=query,
         )
 
-        # Verify returned embedding
         assert embedding == [0.1, 0.2, 0.3, 0.4, 0.5]
 
     def test_embed_query_empty_string(self, model_with_params, mock_openai_client, mocker):
         """Test embed_query with empty string."""
-        mock_response = mocker.MagicMock()
-        mock_data = mocker.MagicMock()
-        mock_data.embedding = []
-        mock_response.data = [mock_data]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(mocker, [[]])
 
         embedding = model_with_params.embed_query("")
 
@@ -143,10 +133,7 @@ class TestOpenAIEmbeddingModel:
 
     def test_model_inherits_from_base(self, model_with_params):
         """Test that OpenAIEmbeddingModel inherits BaseEmbeddingModel methods."""
-        # Test __repr__
         assert repr(model_with_params) == "text-embedding-ada-002"
-
-        # Test __str__
         assert str(model_with_params) == "text-embedding-ada-002"
 
     @pytest.mark.parametrize(
@@ -168,13 +155,9 @@ class TestOpenAIEmbeddingModel:
 
     def test_embed_documents_preserves_order(self, model_without_params, mock_openai_client, mocker):
         """Test that embed_documents preserves the order of input texts."""
-        mock_response = mocker.MagicMock()
-        mock_data_1 = mocker.MagicMock()
-        mock_data_1.embedding = [1.0, 1.0, 1.0]
-        mock_data_2 = mocker.MagicMock()
-        mock_data_2.embedding = [2.0, 2.0, 2.0]
-        mock_response.data = [mock_data_1, mock_data_2]
-        mock_openai_client.embeddings.create.return_value = mock_response
+        mock_openai_client.embeddings.create.return_value = _make_mock_embedding_response(
+            mocker, [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]
+        )
 
         texts = ["first", "second"]
         embeddings = model_without_params.embed_documents(texts)
@@ -184,17 +167,10 @@ class TestOpenAIEmbeddingModel:
 
     def test_multiple_calls_to_embed_query(self, model_with_params, mock_openai_client, mocker):
         """Test multiple sequential calls to embed_query."""
-        mock_response_1 = mocker.MagicMock()
-        mock_data_1 = mocker.MagicMock()
-        mock_data_1.embedding = [0.1, 0.2]
-        mock_response_1.data = [mock_data_1]
-
-        mock_response_2 = mocker.MagicMock()
-        mock_data_2 = mocker.MagicMock()
-        mock_data_2.embedding = [0.3, 0.4]
-        mock_response_2.data = [mock_data_2]
-
-        mock_openai_client.embeddings.create.side_effect = [mock_response_1, mock_response_2]
+        mock_openai_client.embeddings.create.side_effect = [
+            _make_mock_embedding_response(mocker, [[0.1, 0.2]]),
+            _make_mock_embedding_response(mocker, [[0.3, 0.4]]),
+        ]
 
         embedding_1 = model_with_params.embed_query("query 1")
         embedding_2 = model_with_params.embed_query("query 2")
@@ -202,3 +178,11 @@ class TestOpenAIEmbeddingModel:
         assert embedding_1 == [0.1, 0.2]
         assert embedding_2 == [0.3, 0.4]
         assert mock_openai_client.embeddings.create.call_count == 2
+
+    def test_detect_embedding_dimension_api_failure(self, mocker):
+        """Test that _detect_embedding_dimension raises RuntimeError on API failure."""
+        mock_client = mocker.MagicMock()
+        mock_client.embeddings.create.side_effect = ConnectionError("Service unavailable")
+
+        with pytest.raises(RuntimeError, match="Failed to auto-detect embedding dimension"):
+            OpenAIEmbeddingModel(client=mock_client, model_id="text-embedding-ada-002", params=None)

--- a/tests/ai4rag/rag/foundation_models/test_base_model.py
+++ b/tests/ai4rag/rag/foundation_models/test_base_model.py
@@ -7,15 +7,27 @@ from typing import Any
 
 import pytest
 
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
 
 
 class ConcreteFoundationModel(BaseFoundationModel[Any, dict]):
     """Concrete implementation of BaseFoundationModel for testing purposes."""
 
-    def chat(self, system_message: str, user_message: str) -> str:
+    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
         """Simple chat implementation for testing."""
-        return f"System: {system_message}, User: {user_message}"
+
+        # Create a mock response that mimics the structure of real model responses
+        class MockMessage:
+            def __init__(self, content: str):
+                self.content = content
+
+        class MockChoice:
+            def __init__(self, content: str):
+                self.message = MockMessage(content)
+
+        # Simulate processing the messages
+        response_content = f"Response to {len(messages)} messages"
+        return [MockChoice(response_content)]
 
 
 class TestFoundationModel:
@@ -34,14 +46,14 @@ class TestFoundationModel:
     @pytest.fixture
     def foundation_model(self, mock_client, model_params):
         """Create a concrete foundation model instance for testing."""
-        return ConcreteFoundationModel(client=mock_client, model_id="test-model-id", model_params=model_params)
+        return ConcreteFoundationModel(client=mock_client, model_id="test-model-id", params=model_params)
 
     def test_init(self, mock_client, model_params):
         """Test BaseFoundationModel initialization."""
-        model = ConcreteFoundationModel(client=mock_client, model_id="test-model-123", model_params=model_params)
+        model = ConcreteFoundationModel(client=mock_client, model_id="test-model-123", params=model_params)
         assert model.client == mock_client
         assert model.model_id == "test-model-123"
-        assert model.model_params == model_params
+        assert model.params == model_params
 
     def test_repr(self, foundation_model):
         """Test __repr__ returns model_id."""
@@ -54,14 +66,14 @@ class TestFoundationModel:
 
     def test_eq_same_model_id(self, mock_client, model_params):
         """Test equality when model_ids are the same."""
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="same-id", model_params=model_params)
-        model2 = ConcreteFoundationModel(client=mock_client, model_id="same-id", model_params={"different": "params"})
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="same-id", params=model_params)
+        model2 = ConcreteFoundationModel(client=mock_client, model_id="same-id", params={"different": "params"})
         assert model1 == model2
 
     def test_eq_different_model_id(self, mock_client, model_params):
         """Test inequality when model_ids are different."""
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", model_params=model_params)
-        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", model_params=model_params)
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", params=model_params)
+        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", params=model_params)
         assert model1 != model2
 
     def test_eq_with_non_foundation_model(self, foundation_model):
@@ -85,31 +97,31 @@ class TestFoundationModel:
 
     def test_hash_consistency(self, mock_client, model_params):
         """Test that models with same model_id have same hash."""
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="same-id", model_params=model_params)
-        model2 = ConcreteFoundationModel(client=mock_client, model_id="same-id", model_params={"different": "params"})
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="same-id", params=model_params)
+        model2 = ConcreteFoundationModel(client=mock_client, model_id="same-id", params={"different": "params"})
         assert hash(model1) == hash(model2)
 
     def test_hash_different_for_different_ids(self, mock_client, model_params):
         """Test that models with different model_ids have different hashes."""
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", model_params=model_params)
-        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", model_params=model_params)
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", params=model_params)
+        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", params=model_params)
         assert hash(model1) != hash(model2)
 
     def test_models_can_be_used_in_set(self, mock_client, model_params):
         """Test that BaseFoundationModel instances can be added to a set."""
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", model_params=model_params)
-        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", model_params=model_params)
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", params=model_params)
+        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", params=model_params)
         model3 = ConcreteFoundationModel(
-            client=mock_client, model_id="model-1", model_params={"different": "params"}  # Same as model1
+            client=mock_client, model_id="model-1", params={"different": "params"}  # Same as model1
         )
         model_set = {model1, model2, model3}
         assert len(model_set) == 2  # model1 and model3 are considered equal
 
     def test_models_can_be_used_as_dict_keys(self, mock_client, model_params):
         """Test that BaseFoundationModel instances can be used as dictionary keys."""
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", model_params=model_params)
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", params=model_params)
         model2 = ConcreteFoundationModel(
-            client=mock_client, model_id="model-1", model_params={"different": "params"}  # Same as model1
+            client=mock_client, model_id="model-1", params={"different": "params"}  # Same as model1
         )
         model_dict = {model1: "value1"}
         model_dict[model2] = "value2"
@@ -118,13 +130,18 @@ class TestFoundationModel:
 
     def test_chat_implementation(self, foundation_model):
         """Test that concrete implementation's chat method works."""
-        result = foundation_model.chat("system prompt", "user query")
-        assert result == "System: system prompt, User: user query"
+        messages = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "user query"},
+        ]
+        result = foundation_model.chat(messages)
+        assert len(result) == 1
+        assert result[0].message.content == "Response to 2 messages"
 
     def test_chat_is_abstract(self):
         """Test that BaseFoundationModel.chat is abstract and cannot be instantiated without implementation."""
         with pytest.raises(TypeError) as exc_info:
-            BaseFoundationModel(client=None, model_id="test", model_params={})
+            BaseFoundationModel(client=None, model_id="test", params={})
         assert "Can't instantiate abstract class" in str(exc_info.value)
 
     @pytest.mark.parametrize(
@@ -139,7 +156,7 @@ class TestFoundationModel:
     )
     def test_repr_various_model_ids(self, mock_client, model_params, model_id, expected_repr):
         """Test __repr__ with various model_id formats."""
-        model = ConcreteFoundationModel(client=mock_client, model_id=model_id, model_params=model_params)
+        model = ConcreteFoundationModel(client=mock_client, model_id=model_id, params=model_params)
         assert repr(model) == expected_repr
 
     def test_different_client_types(self, model_params):
@@ -149,23 +166,23 @@ class TestFoundationModel:
             pass
 
         client = CustomClient()
-        model = ConcreteFoundationModel(client=client, model_id="test-model", model_params=model_params)
+        model = ConcreteFoundationModel(client=client, model_id="test-model", params=model_params)
         assert isinstance(model.client, CustomClient)
 
     def test_different_param_types(self, mock_client):
         """Test that BaseFoundationModel works with different parameter types."""
         # Test with dict
-        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", model_params={"key": "value"})
-        assert model1.model_params == {"key": "value"}
+        model1 = ConcreteFoundationModel(client=mock_client, model_id="model-1", params={"key": "value"})
+        assert model1.params == {"key": "value"}
 
         # Test with None
-        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", model_params=None)
-        assert model2.model_params is None
+        model2 = ConcreteFoundationModel(client=mock_client, model_id="model-2", params=None)
+        assert model2.params is None
 
         # Test with custom object
         class CustomParams:
             pass
 
         params = CustomParams()
-        model3 = ConcreteFoundationModel(client=mock_client, model_id="model-3", model_params=params)
-        assert model3.model_params is params
+        model3 = ConcreteFoundationModel(client=mock_client, model_id="model-3", params=params)
+        assert model3.params is params

--- a/tests/ai4rag/rag/foundation_models/test_llama_stack.py
+++ b/tests/ai4rag/rag/foundation_models/test_llama_stack.py
@@ -132,7 +132,7 @@ class TestLlamaStackFoundationModel:
         """Create a LSFoundationModel with dict parameters."""
         return LSFoundationModel(
             model_id="test-model-id",
-            model_params={"max_completion_tokens": 1024, "temperature": 0.3},
+            params={"max_completion_tokens": 1024, "temperature": 0.3},
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -147,7 +147,7 @@ class TestLlamaStackFoundationModel:
         params = ModelParameters(max_completion_tokens=512, temperature=0.7)
         return LSFoundationModel(
             model_id="test-model-id",
-            model_params=params,
+            params=params,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -161,7 +161,7 @@ class TestLlamaStackFoundationModel:
         """Create a LSFoundationModel with None parameters."""
         return LSFoundationModel(
             model_id="test-model-id",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -171,7 +171,7 @@ class TestLlamaStackFoundationModel:
     def test_init_with_dict_params(self, model_with_dict_params, mock_llama_client):
         """Test initialization with dict parameters."""
         assert model_with_dict_params.model_id == "test-model-id"
-        assert model_with_dict_params.model_params == {"max_completion_tokens": 1024, "temperature": 0.3}
+        assert model_with_dict_params.params == {"max_completion_tokens": 1024, "temperature": 0.3}
         assert model_with_dict_params.client == mock_llama_client
         assert "question" in model_with_dict_params.user_message_text
         assert "document" in model_with_dict_params.context_template_text
@@ -179,15 +179,15 @@ class TestLlamaStackFoundationModel:
     def test_init_with_model_parameters(self, model_with_model_params, mock_llama_client):
         """Test initialization with ModelParameters object."""
         assert model_with_model_params.model_id == "test-model-id"
-        assert isinstance(model_with_model_params.model_params, ModelParameters)
-        assert model_with_model_params.model_params.max_completion_tokens == 512
-        assert model_with_model_params.model_params.temperature == 0.7
+        assert isinstance(model_with_model_params.params, ModelParameters)
+        assert model_with_model_params.params.max_completion_tokens == 512
+        assert model_with_model_params.params.temperature == 0.7
         assert model_with_model_params.client == mock_llama_client
 
     def test_init_with_none_params(self, model_with_none_params, mock_llama_client):
         """Test initialization with None parameters."""
         assert model_with_none_params.model_id == "test-model-id"
-        assert model_with_none_params.model_params is None
+        assert model_with_none_params.params is None
         assert model_with_none_params.client == mock_llama_client
 
     def test_user_message_text_custom(self, mock_llama_client, valid_context_template, valid_system_message):
@@ -195,7 +195,7 @@ class TestLlamaStackFoundationModel:
         custom_template = "Custom question: {question} and refs: {reference_documents}"
         model = LSFoundationModel(
             model_id="test-model",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=custom_template,
             context_template_text=valid_context_template,
@@ -213,7 +213,7 @@ class TestLlamaStackFoundationModel:
         )
         model = LSFoundationModel(
             model_id="llama-3-70b",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=None,
             context_template_text=valid_context_template,
@@ -227,7 +227,7 @@ class TestLlamaStackFoundationModel:
         custom_template = "Custom: {document}"
         model = LSFoundationModel(
             model_id="test-model",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=custom_template,
@@ -245,7 +245,7 @@ class TestLlamaStackFoundationModel:
         )
         model = LSFoundationModel(
             model_id="granite-13b",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=None,
@@ -261,7 +261,7 @@ class TestLlamaStackFoundationModel:
         system_msg = "Custom system message"
         model = LSFoundationModel(
             model_id="test-model",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -271,10 +271,12 @@ class TestLlamaStackFoundationModel:
 
     def test_chat_method(self, model_with_dict_params, mock_llama_client):
         """Test that chat method calls client correctly and returns response."""
-        system_msg = "You are helpful"
-        user_msg = "What is AI?"
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "What is AI?"},
+        ]
 
-        response = model_with_dict_params.chat(system_msg, user_msg)
+        response = model_with_dict_params.chat(messages)
 
         # Verify the client was called
         mock_llama_client.chat.completions.create.assert_called_once()
@@ -284,36 +286,42 @@ class TestLlamaStackFoundationModel:
         assert call_args.kwargs["model"] == "test-model-id"
 
         # Verify messages were passed correctly
-        messages = call_args.kwargs["messages"]
-        assert len(messages) == 2
-        assert messages[0]["role"] == "system"
-        assert messages[0]["content"] == system_msg
-        assert messages[1]["role"] == "user"
-        assert messages[1]["content"] == user_msg
+        passed_messages = call_args.kwargs["messages"]
+        assert len(passed_messages) == 2
+        assert passed_messages[0]["role"] == "system"
+        assert passed_messages[0]["content"] == "You are helpful"
+        assert passed_messages[1]["role"] == "user"
+        assert passed_messages[1]["content"] == "What is AI?"
 
-        # Verify response
-        assert response == "Test response from model"
+        # Verify response - should return choices list
+        assert len(response) == 1
+        assert response[0].message.content == "Test response from model"
 
     def test_chat_method_extracts_content(self, model_with_dict_params, mock_llama_client):
-        """Test that chat method correctly extracts content from response."""
-        response = model_with_dict_params.chat("system", "user")
-        assert response == "Test response from model"
+        """Test that chat method correctly returns choices from response."""
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user"},
+        ]
+        response = model_with_dict_params.chat(messages)
+        assert len(response) == 1
+        assert response[0].message.content == "Test response from model"
 
     def test_chat_with_different_messages(self, model_with_dict_params, mock_llama_client):
         """Test chat with different message combinations."""
         test_cases = [
-            ("System prompt 1", "User query 1"),
-            ("", "User query 2"),
-            ("System prompt 3", ""),
-            ("Multi\nline\nsystem", "Multi\nline\nuser"),
+            [{"role": "system", "content": "System prompt 1"}, {"role": "user", "content": "User query 1"}],
+            [{"role": "system", "content": ""}, {"role": "user", "content": "User query 2"}],
+            [{"role": "system", "content": "System prompt 3"}, {"role": "user", "content": ""}],
+            [{"role": "system", "content": "Multi\nline\nsystem"}, {"role": "user", "content": "Multi\nline\nuser"}],
         ]
 
-        for sys_msg, usr_msg in test_cases:
-            model_with_dict_params.chat(sys_msg, usr_msg)
+        for test_messages in test_cases:
+            model_with_dict_params.chat(test_messages)
             call_args = mock_llama_client.chat.completions.create.call_args
-            messages = call_args.kwargs["messages"]
-            assert messages[0]["content"] == sys_msg
-            assert messages[1]["content"] == usr_msg
+            passed_messages = call_args.kwargs["messages"]
+            assert passed_messages[0]["content"] == test_messages[0]["content"]
+            assert passed_messages[1]["content"] == test_messages[1]["content"]
 
     def test_invalid_user_message_template_missing_placeholder(
         self, mock_llama_client, valid_context_template, valid_system_message
@@ -323,7 +331,7 @@ class TestLlamaStackFoundationModel:
         with pytest.raises(ConstraintsValidationError) as exc_info:
             LSFoundationModel(
                 model_id="test-model",
-                model_params=None,
+                params=None,
                 client=mock_llama_client,
                 user_message_text=invalid_template,
                 context_template_text=valid_context_template,
@@ -339,7 +347,7 @@ class TestLlamaStackFoundationModel:
         with pytest.raises(ConstraintsValidationError) as exc_info:
             LSFoundationModel(
                 model_id="test-model",
-                model_params=None,
+                params=None,
                 client=mock_llama_client,
                 user_message_text=invalid_template,
                 context_template_text=valid_context_template,
@@ -355,7 +363,7 @@ class TestLlamaStackFoundationModel:
         with pytest.raises(ConstraintsValidationError) as exc_info:
             LSFoundationModel(
                 model_id="test-model",
-                model_params=None,
+                params=None,
                 client=mock_llama_client,
                 user_message_text=valid_user_message_template,
                 context_template_text=invalid_template,
@@ -371,7 +379,7 @@ class TestLlamaStackFoundationModel:
         with pytest.raises(ConstraintsValidationError) as exc_info:
             LSFoundationModel(
                 model_id="test-model",
-                model_params=None,
+                params=None,
                 client=mock_llama_client,
                 user_message_text=valid_user_message_template,
                 context_template_text=invalid_template,
@@ -396,7 +404,7 @@ class TestLlamaStackFoundationModel:
         """Test that models with same model_id are equal."""
         model1 = LSFoundationModel(
             model_id="same-id",
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -404,7 +412,7 @@ class TestLlamaStackFoundationModel:
         )
         model2 = LSFoundationModel(
             model_id="same-id",
-            model_params={"different": "params"},
+            params={"different": "params"},
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -427,7 +435,7 @@ class TestLlamaStackFoundationModel:
         """Test initialization with various model IDs."""
         model = LSFoundationModel(
             model_id=model_id,
-            model_params=None,
+            params=None,
             client=mock_llama_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,

--- a/tests/ai4rag/rag/foundation_models/test_openai_model.py
+++ b/tests/ai4rag/rag/foundation_models/test_openai_model.py
@@ -43,7 +43,7 @@ class TestOpenAIFoundationModel:
         """Create an OpenAIFoundationModel with dict parameters."""
         return OpenAIFoundationModel(
             model_id="gpt-4",
-            model_params={"temperature": 0.3, "max_tokens": 1024},
+            params={"temperature": 0.3, "max_tokens": 1024},
             client=mock_openai_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -57,7 +57,7 @@ class TestOpenAIFoundationModel:
         """Create an OpenAIFoundationModel with None parameters."""
         return OpenAIFoundationModel(
             model_id="gpt-3.5-turbo",
-            model_params=None,
+            params=None,
             client=mock_openai_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -67,7 +67,7 @@ class TestOpenAIFoundationModel:
     def test_init_with_dict_params(self, model_with_dict_params, mock_openai_client):
         """Test initialization with dict parameters."""
         assert model_with_dict_params.model_id == "gpt-4"
-        assert model_with_dict_params.model_params == {"temperature": 0.3, "max_tokens": 1024}
+        assert model_with_dict_params.params == {"temperature": 0.3, "max_tokens": 1024}
         assert model_with_dict_params.client == mock_openai_client
         assert "question" in model_with_dict_params.user_message_text
         assert "document" in model_with_dict_params.context_template_text
@@ -75,7 +75,7 @@ class TestOpenAIFoundationModel:
     def test_init_with_none_params(self, model_with_none_params, mock_openai_client):
         """Test initialization with None parameters."""
         assert model_with_none_params.model_id == "gpt-3.5-turbo"
-        assert model_with_none_params.model_params is None
+        assert model_with_none_params.params is None
         assert model_with_none_params.client == mock_openai_client
 
     def test_system_message_text_assignment(
@@ -85,7 +85,7 @@ class TestOpenAIFoundationModel:
         system_msg = "Custom system message for OpenAI"
         model = OpenAIFoundationModel(
             model_id="gpt-4",
-            model_params=None,
+            params=None,
             client=mock_openai_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -95,10 +95,12 @@ class TestOpenAIFoundationModel:
 
     def test_chat_method(self, model_with_dict_params, mock_openai_client):
         """Test that chat method calls client correctly and returns response."""
-        system_msg = "You are helpful"
-        user_msg = "What is AI?"
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "What is AI?"},
+        ]
 
-        response = model_with_dict_params.chat(system_msg, user_msg)
+        response = model_with_dict_params.chat(messages)
 
         # Verify the client was called
         mock_openai_client.chat.completions.create.assert_called_once()
@@ -108,36 +110,42 @@ class TestOpenAIFoundationModel:
         assert call_args.kwargs["model"] == "gpt-4"
 
         # Verify messages were passed correctly
-        messages = call_args.kwargs["messages"]
-        assert len(messages) == 2
-        assert messages[0]["role"] == "system"
-        assert messages[0]["content"] == system_msg
-        assert messages[1]["role"] == "user"
-        assert messages[1]["content"] == user_msg
+        passed_messages = call_args.kwargs["messages"]
+        assert len(passed_messages) == 2
+        assert passed_messages[0]["role"] == "system"
+        assert passed_messages[0]["content"] == "You are helpful"
+        assert passed_messages[1]["role"] == "user"
+        assert passed_messages[1]["content"] == "What is AI?"
 
-        # Verify response
-        assert response == "Test response from OpenAI model"
+        # Verify response - should return choices list
+        assert len(response) == 1
+        assert response[0].message.content == "Test response from OpenAI model"
 
     def test_chat_method_extracts_content(self, model_with_dict_params, mock_openai_client):
-        """Test that chat method correctly extracts content from response."""
-        response = model_with_dict_params.chat("system", "user")
-        assert response == "Test response from OpenAI model"
+        """Test that chat method correctly returns choices from response."""
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user"},
+        ]
+        response = model_with_dict_params.chat(messages)
+        assert len(response) == 1
+        assert response[0].message.content == "Test response from OpenAI model"
 
     def test_chat_with_different_messages(self, model_with_dict_params, mock_openai_client):
         """Test chat with different message combinations."""
         test_cases = [
-            ("System prompt 1", "User query 1"),
-            ("", "User query 2"),
-            ("System prompt 3", ""),
-            ("Multi\nline\nsystem", "Multi\nline\nuser"),
+            [{"role": "system", "content": "System prompt 1"}, {"role": "user", "content": "User query 1"}],
+            [{"role": "system", "content": ""}, {"role": "user", "content": "User query 2"}],
+            [{"role": "system", "content": "System prompt 3"}, {"role": "user", "content": ""}],
+            [{"role": "system", "content": "Multi\nline\nsystem"}, {"role": "user", "content": "Multi\nline\nuser"}],
         ]
 
-        for sys_msg, usr_msg in test_cases:
-            model_with_dict_params.chat(sys_msg, usr_msg)
+        for test_messages in test_cases:
+            model_with_dict_params.chat(test_messages)
             call_args = mock_openai_client.chat.completions.create.call_args
-            messages = call_args.kwargs["messages"]
-            assert messages[0]["content"] == sys_msg
-            assert messages[1]["content"] == usr_msg
+            passed_messages = call_args.kwargs["messages"]
+            assert passed_messages[0]["content"] == test_messages[0]["content"]
+            assert passed_messages[1]["content"] == test_messages[1]["content"]
 
     def test_model_inherits_from_foundation_model(self, model_with_dict_params):
         """Test that OpenAIFoundationModel inherits BaseFoundationModel methods."""
@@ -153,7 +161,7 @@ class TestOpenAIFoundationModel:
         """Test that models with same model_id are considered equal based on model_id."""
         model1 = OpenAIFoundationModel(
             model_id="gpt-4",
-            model_params=None,
+            params=None,
             client=mock_openai_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -161,7 +169,7 @@ class TestOpenAIFoundationModel:
         )
         model2 = OpenAIFoundationModel(
             model_id="gpt-4",
-            model_params={"different": "params"},
+            params={"different": "params"},
             client=mock_openai_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -184,7 +192,7 @@ class TestOpenAIFoundationModel:
         """Test initialization with various OpenAI model IDs."""
         model = OpenAIFoundationModel(
             model_id=model_id,
-            model_params=None,
+            params=None,
             client=mock_openai_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -195,5 +203,10 @@ class TestOpenAIFoundationModel:
     def test_chat_with_empty_response(self, model_with_dict_params, mock_openai_client):
         """Test chat method with empty response content."""
         mock_openai_client.chat.completions.create.return_value.choices[0].message.content = ""
-        response = model_with_dict_params.chat("system", "user")
-        assert response == ""
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user"},
+        ]
+        response = model_with_dict_params.chat(messages)
+        assert len(response) == 1
+        assert response[0].message.content == ""

--- a/tests/ai4rag/rag/template/test_llama_stack_rag_template.py
+++ b/tests/ai4rag/rag/template/test_llama_stack_rag_template.py
@@ -338,7 +338,13 @@ class TestLlamaStackRAGGenerate:
         mock.system_message_text = "You are a helpful assistant."
         mock.user_message_text = "Question: {question}\nReferences: {reference_documents}"
         mock.context_template_text = "Document: {document}"
-        mock.chat.return_value = "This is the generated answer."
+
+        # Mock the chat response to match new API (returns list of choices)
+        mock_message = mocker.MagicMock()
+        mock_message.content = "This is the generated answer."
+        mock_choice = mocker.MagicMock()
+        mock_choice.message = mock_message
+        mock.chat.return_value = [mock_choice]
         return mock
 
     @pytest.fixture
@@ -420,8 +426,14 @@ class TestLlamaStackRAGGenerate:
         mock_foundation_model.chat.assert_called_once()
         call_args = mock_foundation_model.chat.call_args
 
+        # Verify messages list was passed correctly
+        messages = call_args.kwargs["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a helpful assistant."
+        assert messages[1]["role"] == "user"
         # Verify user message contains formatted context
-        user_message = call_args.kwargs["user_message"]
+        user_message = messages[1]["content"]
         assert "Document: Relevant document 1" in user_message
         assert "Document: Relevant document 2" in user_message
         assert "What is AI?" in user_message
@@ -442,8 +454,13 @@ class TestLlamaStackRAGGenerate:
         mock_foundation_model.chat.assert_called_once()
         call_args = mock_foundation_model.chat.call_args
 
-        assert call_args.kwargs["system_message"] == "You are a helpful assistant."
-        assert "What is AI?" in call_args.kwargs["user_message"]
+        # Verify messages list was passed correctly
+        messages = call_args.kwargs["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a helpful assistant."
+        assert messages[1]["role"] == "user"
+        assert "What is AI?" in messages[1]["content"]
 
     def test_generate_returns_correct_answer(
         self,
@@ -513,7 +530,9 @@ class TestLlamaStackRAGGenerate:
 
         # Verify chat was called with empty context
         call_args = mock_foundation_model.chat.call_args
-        user_message = call_args.kwargs["user_message"]
+        messages = call_args.kwargs["messages"]
+        assert len(messages) == 2
+        user_message = messages[1]["content"]
         assert "What is AI?" in user_message
 
     def test_generate_with_single_retrieved_document(
@@ -557,7 +576,8 @@ class TestLlamaStackRAGGenerate:
 
         # Should use empty string when page_content is missing
         call_args = mock_foundation_model.chat.call_args
-        user_message = call_args.kwargs["user_message"]
+        messages = call_args.kwargs["messages"]
+        user_message = messages[1]["content"]
         assert "Document: " in user_message
         assert result["answer"] == "This is the generated answer."
 
@@ -620,7 +640,13 @@ class TestLlamaStackRAGGenerateStream:
         mock.system_message_text = "You are a helpful assistant."
         mock.user_message_text = "Question: {question}\nReferences: {reference_documents}"
         mock.context_template_text = "Document: {document}"
-        mock.chat.return_value = "This is the generated answer."
+
+        # Mock the chat response to match new API (returns list of choices)
+        mock_message = mocker.MagicMock()
+        mock_message.content = "This is the generated answer."
+        mock_choice = mocker.MagicMock()
+        mock_choice.message = mock_message
+        mock.chat.return_value = [mock_choice]
         return mock
 
     @pytest.fixture
@@ -709,7 +735,9 @@ class TestLlamaStackRAGGenerateStream:
         mock_retriever,
     ):
         """Test that generate_stream yields the complete answer in single chunk."""
-        mock_foundation_model.chat.return_value = "This is a longer answer with multiple sentences."
+        # Update the mock to return a longer answer
+        mock_message = mock_foundation_model.chat.return_value[0].message
+        mock_message.content = "This is a longer answer with multiple sentences."
 
         rag = LlamaStackRAG(
             foundation_model=mock_foundation_model,
@@ -751,7 +779,13 @@ class TestLlamaStackRAGIntegration:
         foundation_model.system_message_text = "You are a helpful assistant."
         foundation_model.user_message_text = "Question: {question}\nReferences: {reference_documents}"
         foundation_model.context_template_text = "Document: {document}"
-        foundation_model.chat.return_value = "The answer is 42."
+
+        # Mock the chat response to match new API (returns list of choices)
+        mock_message = mocker.MagicMock()
+        mock_message.content = "The answer is 42."
+        mock_choice = mocker.MagicMock()
+        mock_choice.message = mock_message
+        foundation_model.chat.return_value = [mock_choice]
 
         # Retriever
         retriever = mocker.MagicMock()
@@ -859,7 +893,13 @@ class TestLlamaStackRAGEdgeCases:
         mock.system_message_text = "System message"
         mock.user_message_text = "{question} {reference_documents}"
         mock.context_template_text = "{document}"
-        mock.chat.return_value = "Answer"
+
+        # Mock the chat response to match new API (returns list of choices)
+        mock_message = mocker.MagicMock()
+        mock_message.content = "Answer"
+        mock_choice = mocker.MagicMock()
+        mock_choice.message = mock_message
+        mock.chat.return_value = [mock_choice]
         return mock
 
     @pytest.fixture

--- a/tests/ai4rag/search_space/prepare/__init__.py
+++ b/tests/ai4rag/search_space/prepare/__init__.py
@@ -1,6 +1,4 @@
 # -----------------------------------------------------------------------------
-# Copyright IBM Corp. 2025-2026
+# Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-
-from ai4rag.search_space.prepare.prepare_search_space import prepare_search_space_with_llama_stack

--- a/tests/ai4rag/search_space/prepare/test_llama_stack_utils.py
+++ b/tests/ai4rag/search_space/prepare/test_llama_stack_utils.py
@@ -1,0 +1,300 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel, LSEmbeddingParams
+from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+from ai4rag.search_space.prepare.llama_stack_utils import (
+    SearchSpaceValueError,
+    _are_provided_models_available,
+    _get_default_llama_stack_models,
+    _validate_embedding_model,
+    _validate_foundation_model,
+)
+
+
+class TestValidateFoundationModel:
+    """Test _validate_foundation_model function."""
+
+    def test_returns_true_when_model_responds(self):
+        """Test that validation returns True when model responds successfully."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = Mock(choices=[])
+
+        model = LSFoundationModel(model_id="test-model", client=mock_client)
+
+        result = _validate_foundation_model(model)
+
+        assert result is True
+        mock_client.chat.completions.create.assert_called_once()
+
+    def test_returns_false_when_model_fails(self):
+        """Test that validation returns False when model raises exception."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("Model error")
+
+        model = LSFoundationModel(model_id="test-model", client=mock_client)
+
+        result = _validate_foundation_model(model)
+
+        assert result is False
+
+
+class TestValidateEmbeddingModel:
+    """Test _validate_embedding_model function."""
+
+    def test_returns_true_when_model_responds(self):
+        """Test that validation returns True when model responds successfully."""
+        mock_client = MagicMock()
+        mock_data = Mock()
+        mock_data.embedding = [0.1, 0.2, 0.3]
+        mock_response = Mock()
+        mock_response.data = [mock_data]
+        mock_client.embeddings.create.return_value = mock_response
+
+        model = LSEmbeddingModel(
+            model_id="test-model", client=mock_client, params=LSEmbeddingParams(embedding_dimension=768)
+        )
+
+        result = _validate_embedding_model(model)
+
+        assert result is True
+        mock_client.embeddings.create.assert_called_once()
+
+    def test_returns_false_when_model_fails(self):
+        """Test that validation returns False when model raises exception."""
+        mock_client = MagicMock()
+        mock_client.embeddings.create.side_effect = Exception("Model error")
+
+        model = LSEmbeddingModel(
+            model_id="test-model", client=mock_client, params=LSEmbeddingParams(embedding_dimension=768)
+        )
+
+        result = _validate_embedding_model(model)
+
+        assert result is False
+
+
+class TestGetDefaultLlamaStackModels:
+    """Test _get_default_llama_stack_models function."""
+
+    def test_returns_foundation_and_embedding_models(self, mocker):
+        """Test that function returns both foundation and embedding models."""
+        # Mock client
+        mock_client = MagicMock()
+
+        # Mock model list response
+        mock_llm = Mock()
+        mock_llm.id = "test-llm"
+        mock_llm.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding = Mock()
+        mock_embedding.id = "test-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+
+        # Mock validation functions to always return True
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        # Call function
+        result = _get_default_llama_stack_models(mock_client)
+
+        # Assertions
+        assert "foundation_models" in result
+        assert "embedding_models" in result
+        assert len(result["foundation_models"]) == 1
+        assert len(result["embedding_models"]) == 1
+        assert result["foundation_models"][0].model_id == "test-llm"
+        assert result["embedding_models"][0].model_id == "test-embedding"
+
+    def test_raises_error_when_no_llm_models(self, mocker):
+        """Test that function raises error when no LLM models available."""
+        mock_client = MagicMock()
+
+        mock_embedding = Mock()
+        mock_embedding.id = "test-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_embedding]
+
+        # Mock validation to return True for embedding models
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'"):
+            _get_default_llama_stack_models(mock_client)
+
+    def test_raises_error_when_no_embedding_models(self, mocker):
+        """Test that function raises error when no embedding models available."""
+        mock_client = MagicMock()
+
+        mock_llm = Mock()
+        mock_llm.id = "test-llm"
+        mock_llm.custom_metadata = {"model_type": "llm"}
+
+        mock_client.models.list.return_value = [mock_llm]
+
+        # Mock validation to return True for foundation models
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'"):
+            _get_default_llama_stack_models(mock_client)
+
+    def test_excludes_models_that_fail_validation(self, mocker):
+        """Test that models failing validation are excluded from results."""
+        mock_client = MagicMock()
+
+        # Create multiple models of each type
+        mock_llm1 = Mock()
+        mock_llm1.id = "test-llm-1"
+        mock_llm1.custom_metadata = {"model_type": "llm"}
+
+        mock_llm2 = Mock()
+        mock_llm2.id = "test-llm-2"
+        mock_llm2.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding1 = Mock()
+        mock_embedding1.id = "test-embedding-1"
+        mock_embedding1.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_embedding2 = Mock()
+        mock_embedding2.id = "test-embedding-2"
+        mock_embedding2.custom_metadata = {"model_type": "embedding", "embedding_dimension": 1024}
+
+        mock_client.models.list.return_value = [mock_llm1, mock_llm2, mock_embedding1, mock_embedding2]
+
+        # Mock validation to fail for first model of each type
+        def mock_validate_foundation(model):
+            return model.model_id != "test-llm-1"
+
+        def mock_validate_embedding(model):
+            return model.model_id != "test-embedding-1"
+
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            side_effect=mock_validate_foundation,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            side_effect=mock_validate_embedding,
+        )
+
+        result = _get_default_llama_stack_models(mock_client)
+
+        # Only validated models should be included
+        assert len(result["foundation_models"]) == 1
+        assert result["foundation_models"][0].model_id == "test-llm-2"
+        assert len(result["embedding_models"]) == 1
+        assert result["embedding_models"][0].model_id == "test-embedding-2"
+
+    def test_raises_error_when_all_foundation_models_fail_validation(self, mocker):
+        """Test that error is raised when all foundation models fail validation."""
+        mock_client = MagicMock()
+
+        mock_llm = Mock()
+        mock_llm.id = "test-llm"
+        mock_llm.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding = Mock()
+        mock_embedding.id = "test-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+
+        # Mock validation to fail for foundation model
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=False,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'"):
+            _get_default_llama_stack_models(mock_client)
+
+    def test_raises_error_when_all_embedding_models_fail_validation(self, mocker):
+        """Test that error is raised when all embedding models fail validation."""
+        mock_client = MagicMock()
+
+        mock_llm = Mock()
+        mock_llm.id = "test-llm"
+        mock_llm.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding = Mock()
+        mock_embedding.id = "test-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+
+        # Mock validation to fail for embedding model
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=False,
+        )
+
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'"):
+            _get_default_llama_stack_models(mock_client)
+
+
+class TestAreProvidedModelsAvailable:
+    """Test _are_provided_models_available function."""
+
+    def test_returns_true_when_all_models_available(self):
+        """Test that function returns True when all provided models are available."""
+        from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
+
+        mock_client = MagicMock()
+        available_models = [
+            LSFoundationModel(model_id="model-1", client=mock_client),
+            LSFoundationModel(model_id="model-2", client=mock_client),
+        ]
+
+        provided_models = [
+            AI4RAGFoundationModel(model_id="model-1"),
+            AI4RAGFoundationModel(model_id="model-2"),
+        ]
+
+        # Should return True without raising
+        result = _are_provided_models_available(provided_models, available_models)
+        assert result is True
+
+    def test_raises_error_when_model_not_available(self):
+        """Test that function raises error when provided model is not available."""
+        from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
+
+        mock_client = MagicMock()
+        available_models = [
+            LSFoundationModel(model_id="model-1", client=mock_client),
+        ]
+
+        provided_models = [
+            AI4RAGFoundationModel(model_id="model-2"),  # Not available
+        ]
+
+        with pytest.raises(SearchSpaceValueError, match="model-2.*not available"):
+            _are_provided_models_available(provided_models, available_models)

--- a/tests/ai4rag/search_space/prepare/test_llama_stack_utils.py
+++ b/tests/ai4rag/search_space/prepare/test_llama_stack_utils.py
@@ -57,22 +57,33 @@ class TestValidateEmbeddingModel:
         mock_client.embeddings.create.return_value = mock_response
 
         model = LSEmbeddingModel(
-            model_id="test-model", client=mock_client, params=LSEmbeddingParams(embedding_dimension=768)
+            model_id="test-model",
+            client=mock_client,
+            params=LSEmbeddingParams(embedding_dimension=768, context_length=512),
         )
 
         result = _validate_embedding_model(model)
 
         assert result is True
-        mock_client.embeddings.create.assert_called_once()
 
     def test_returns_false_when_model_fails(self):
         """Test that validation returns False when model raises exception."""
         mock_client = MagicMock()
-        mock_client.embeddings.create.side_effect = Exception("Model error")
+        mock_response = Mock()
+        mock_data = Mock()
+        mock_data.embedding = [0.1, 0.2, 0.3]
+        mock_response.data = [mock_data]
 
+        # First call succeeds (for embed_query in validation), but we need to
+        # create the model first with context_length set to avoid detection.
         model = LSEmbeddingModel(
-            model_id="test-model", client=mock_client, params=LSEmbeddingParams(embedding_dimension=768)
+            model_id="test-model",
+            client=mock_client,
+            params=LSEmbeddingParams(embedding_dimension=768, context_length=512),
         )
+
+        # Now set embed to fail for validation
+        mock_client.embeddings.create.side_effect = Exception("Model error")
 
         result = _validate_embedding_model(model)
 
@@ -94,7 +105,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 
@@ -125,7 +137,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_embedding]
 
@@ -172,11 +185,17 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding1 = Mock()
         mock_embedding1.id = "test-embedding-1"
-        mock_embedding1.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding1.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding1.metadata = {}
 
         mock_embedding2 = Mock()
         mock_embedding2.id = "test-embedding-2"
-        mock_embedding2.custom_metadata = {"model_type": "embedding", "embedding_dimension": 1024}
+        mock_embedding2.custom_metadata = {
+            "model_type": "embedding",
+            "embedding_dimension": 1024,
+            "context_length": 512,
+        }
+        mock_embedding2.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm1, mock_llm2, mock_embedding1, mock_embedding2]
 
@@ -214,7 +233,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 
@@ -241,7 +261,8 @@ class TestGetDefaultLlamaStackModels:
 
         mock_embedding = Mock()
         mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_embedding.metadata = {}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 

--- a/tests/ai4rag/search_space/prepare/test_prepare_search_space.py
+++ b/tests/ai4rag/search_space/prepare/test_prepare_search_space.py
@@ -9,116 +9,14 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from llama_stack_client import LlamaStackClient
 
-from ai4rag.search_space.prepare_search_space import (
-    _are_provided_models_available,
-    _get_default_llama_stack_models,
-    prepare_search_space_with_llama_stack,
-)
+from ai4rag.search_space.prepare import prepare_search_space_with_llama_stack
 from ai4rag.search_space.src.exceptions import SearchSpaceValueError
-
-
-class TestGetDefaultLlamaStackModels:
-    """Test _get_default_llama_stack_models function."""
-
-    def test_returns_foundation_and_embedding_models(self):
-        """Test that function returns both foundation and embedding models."""
-        # Mock client
-        mock_client = MagicMock()
-
-        # Mock model list response
-        mock_llm = Mock()
-        mock_llm.id = "test-llm"
-        mock_llm.custom_metadata = {"model_type": "llm"}
-
-        mock_embedding = Mock()
-        mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
-
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
-
-        # Call function
-        result = _get_default_llama_stack_models(mock_client)
-
-        # Assertions
-        assert "foundation_models" in result
-        assert "embedding_models" in result
-        assert len(result["foundation_models"]) == 1
-        assert len(result["embedding_models"]) == 1
-        assert result["foundation_models"][0].model_id == "test-llm"
-        assert result["embedding_models"][0].model_id == "test-embedding"
-
-    def test_raises_error_when_no_llm_models(self):
-        """Test that function raises error when no LLM models available."""
-        mock_client = MagicMock()
-
-        mock_embedding = Mock()
-        mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
-
-        mock_client.models.list.return_value = [mock_embedding]
-
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'"):
-            _get_default_llama_stack_models(mock_client)
-
-    def test_raises_error_when_no_embedding_models(self):
-        """Test that function raises error when no embedding models available."""
-        mock_client = MagicMock()
-
-        mock_llm = Mock()
-        mock_llm.id = "test-llm"
-        mock_llm.custom_metadata = {"model_type": "llm"}
-
-        mock_client.models.list.return_value = [mock_llm]
-
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'"):
-            _get_default_llama_stack_models(mock_client)
-
-
-class TestAreProvidedModelsAvailable:
-    """Test _are_provided_models_available function."""
-
-    def test_returns_true_when_all_models_available(self):
-        """Test that function returns True when all provided models are available."""
-        from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
-        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
-
-        mock_client = MagicMock()
-        available_models = [
-            LSFoundationModel(model_id="model-1", client=mock_client),
-            LSFoundationModel(model_id="model-2", client=mock_client),
-        ]
-
-        provided_models = [
-            AI4RAGFoundationModel(model_id="model-1"),
-            AI4RAGFoundationModel(model_id="model-2"),
-        ]
-
-        # Should return True without raising
-        result = _are_provided_models_available(provided_models, available_models)
-        assert result is True
-
-    def test_raises_error_when_model_not_available(self):
-        """Test that function raises error when provided model is not available."""
-        from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
-        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
-
-        mock_client = MagicMock()
-        available_models = [
-            LSFoundationModel(model_id="model-1", client=mock_client),
-        ]
-
-        provided_models = [
-            AI4RAGFoundationModel(model_id="model-2"),  # Not available
-        ]
-
-        with pytest.raises(SearchSpaceValueError, match="model-2.*not available"):
-            _are_provided_models_available(provided_models, available_models)
 
 
 class TestPrepareSearchSpaceWithLlamaStack:
     """Test prepare_search_space_with_llama_stack function."""
 
-    def test_basic_payload_with_defaults(self):
+    def test_basic_payload_with_defaults(self, mocker):
         """Test preparation with empty payload using defaults."""
         mock_client = MagicMock(spec=LlamaStackClient)
 
@@ -133,6 +31,16 @@ class TestPrepareSearchSpaceWithLlamaStack:
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 
+        # Mock validation functions to always return True
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
         # Empty payload should use defaults
         payload = {}
 
@@ -146,7 +54,7 @@ class TestPrepareSearchSpaceWithLlamaStack:
         assert "foundation_model" in param_names
         assert "embedding_model" in param_names
 
-    def test_payload_with_custom_foundation_models(self):
+    def test_payload_with_custom_foundation_models(self, mocker):
         """Test preparation with custom foundation models."""
         mock_client = MagicMock(spec=LlamaStackClient)
 
@@ -161,11 +69,17 @@ class TestPrepareSearchSpaceWithLlamaStack:
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
 
-        payload = {
-            "foundation_models": [
-                {"model_id": "custom-llm", "parameters": {"max_completion_tokens": 1024, "temperature": 0.7}}
-            ]
-        }
+        # Mock validation functions to always return True
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        payload = {"foundation_models": [{"model_id": "custom-llm"}]}
 
         result = prepare_search_space_with_llama_stack(payload, mock_client)
 
@@ -180,7 +94,7 @@ class TestPrepareSearchSpaceWithLlamaStack:
         assert len(foundation_param.values) == 1
         assert foundation_param.values[0].model_id == "custom-llm"
 
-    def test_payload_with_custom_embedding_models(self):
+    def test_payload_with_custom_embedding_models(self, mocker):
         """Test preparation with custom embedding models."""
         mock_client = MagicMock(spec=LlamaStackClient)
 
@@ -194,6 +108,16 @@ class TestPrepareSearchSpaceWithLlamaStack:
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 1024}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
+
+        # Mock validation functions to always return True
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
 
         payload = {"embedding_models": [{"model_id": "custom-embedding"}]}
 
@@ -210,7 +134,7 @@ class TestPrepareSearchSpaceWithLlamaStack:
         assert len(embedding_param.values) == 1
         assert embedding_param.values[0].model_id == "custom-embedding"
 
-    def test_invalid_payload_raises_validation_error(self):
+    def test_invalid_payload_raises_validation_error(self, mocker):
         """Test that invalid payload raises validation error."""
         mock_client = MagicMock(spec=LlamaStackClient)
 
@@ -224,6 +148,16 @@ class TestPrepareSearchSpaceWithLlamaStack:
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
         mock_client.models.list.return_value = [mock_llm, mock_embedding]
+
+        # Mock validation functions to always return True
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
 
         # Invalid payload with unrecognized parameter
         payload = {"invalid_parameter": "value"}

--- a/tests/ai4rag/search_space/src/test_search_space.py
+++ b/tests/ai4rag/search_space/src/test_search_space.py
@@ -11,6 +11,7 @@ from ai4rag.search_space.src.search_space import (
     SearchSpaceValueError,
     _rule_adjust_window_to_retrieval_method,
     _rule_chunk_size_bigger_than_chunk_overlap,
+    _rule_chunk_size_within_embedding_context_length,
 )
 
 
@@ -57,6 +58,88 @@ def test_rule_adjust_window_to_retrieval_method(combination, expected_value):
 def test_rule_adjust_window_to_retrieval_method_raises():
     with pytest.raises(SearchSpaceValueError):
         _ = _rule_adjust_window_to_retrieval_method({"retrieval_method": "simple"})
+
+
+class _MockEmbeddingModelWithParams:
+    """Mock embedding model with params as a dataclass-like object."""
+
+    def __init__(self, context_length):
+        self.params = type("Params", (), {"context_length": context_length})()
+
+
+class _MockEmbeddingModelWithDictParams:
+    """Mock embedding model with params as a dict."""
+
+    def __init__(self, context_length):
+        self.params = {"context_length": context_length}
+
+
+@pytest.mark.parametrize(
+    "combination, expected_value",
+    (
+        # chunk_size=512 → estimated_tokens = 512 / 4 = 128, context=256 → True
+        (
+            {
+                "chunk_size": 512,
+                "chunk_overlap": 64,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            True,
+        ),
+        # chunk_size=2048 → estimated_tokens = 2048 / 4 = 512, context=256 → False
+        (
+            {
+                "chunk_size": 2048,
+                "chunk_overlap": 512,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            False,
+        ),
+        # Exact boundary: chunk_size=1024 → estimated_tokens = 256, context=256 → True
+        (
+            {
+                "chunk_size": 1024,
+                "chunk_overlap": 0,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            True,
+        ),
+        # Dict-style params: chunk_size=512 → estimated_tokens = 128, context=256 → True
+        (
+            {
+                "chunk_size": 512,
+                "chunk_overlap": 0,
+                "embedding_model": _MockEmbeddingModelWithDictParams(256),
+            },
+            True,
+        ),
+        # Dict-style params: chunk_size=2048 → estimated_tokens = 512, context=256 → False
+        (
+            {
+                "chunk_size": 2048,
+                "chunk_overlap": 512,
+                "embedding_model": _MockEmbeddingModelWithDictParams(256),
+            },
+            False,
+        ),
+    ),
+)
+def test_rule_chunk_size_within_embedding_context_length(combination, expected_value):
+    val = _rule_chunk_size_within_embedding_context_length(combination)
+    assert val == expected_value
+
+
+def test_rule_chunk_size_within_embedding_context_length_no_context_length():
+    """Rule returns True when context_length is not available on the embedding model."""
+    mock_model = type("Model", (), {"params": type("Params", (), {"context_length": None})()})()
+    combination = {"chunk_size": 2048, "chunk_overlap": 512, "embedding_model": mock_model}
+    assert _rule_chunk_size_within_embedding_context_length(combination) is True
+
+
+def test_rule_chunk_size_within_embedding_context_length_missing_fields():
+    """Rule returns True when chunk_size, chunk_overlap or embedding_model are missing."""
+    assert _rule_chunk_size_within_embedding_context_length({"chunk_size": 512}) is True
+    assert _rule_chunk_size_within_embedding_context_length({}) is True
 
 
 class TestSearchSpace:


### PR DESCRIPTION
## 0.3.0

### Added
- Auto-detection of embedding model `embedding_dimension` and `context_length` when not explicitly provided
- Model availability validation against the Llama Stack server during search space preparation
- Search space validation rule ensuring `chunk_size` respects embedding model context length
- New `prepare_search_space_with_llama_stack` utility for streamlined search space setup

### Changed
- Foundation model `chat()` API now accepts structured message list instead of separate system/user message strings
- Default search space expanded with additional `chunk_size` (512) and `chunk_overlap` (128) values
- Chunk size validation rule now requires `chunk_size > 2 * chunk_overlap`
- `LSEmbeddingParams` refactored from `TypedDict` to `@dataclass`

### Fixed
- Embedding model backwards compatibility in vector store for both legacy dict and new dataclass params
