### PR TITLE
Update hybrid ranker for llama stack 0.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ It accepts a variety of RAG Templates and a search space definition, then return
 
 ai4RAG can run experiments using a [Llama Stack](https://github.com/llamastack/llama-stack) server for embeddings, vector storage, and text generation. Use the official client and API docs to connect and extend:
 
-- **Client:** [llama-stack-client](https://pypi.org/project/llama-stack-client/) (Python package used by ai4RAG; installs with this project).
+- **Client:** [llama-stack-client](https://pypi.org/project/llama-stack-client/) >= 0.5.0 (Python package used by ai4RAG; installs with this project).
+- **Server:** [Llama Stack](https://github.com/llamastack/llama-stack) >= 0.5.0.
 - **API reference:** [Llama Stack API docs](https://llamastack.github.io/docs/) — HTTP API used by the client.
 
 **Features used by ai4rag**

--- a/ai4rag/rag/vector_store/llama_stack.py
+++ b/ai4rag/rag/vector_store/llama_stack.py
@@ -181,12 +181,13 @@ class LSVectorStore(BaseVectorStore):
         }
 
         if search_mode == "hybrid" and ranker_strategy:
-            ranker = {"strategy": ranker_strategy, "params": {}}
-            if ranker_k is not None and ranker_k > 0:
-                ranker["params"]["k"] = ranker_k
+            params["reranker_type"] = ranker_strategy
+            reranker_params = {}
+            if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
+                reranker_params["impact_factor"] = ranker_k
             if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
-                ranker["params"]["alpha"] = ranker_alpha
-            params["ranker"] = ranker
+                reranker_params["alpha"] = ranker_alpha
+            params["reranker_params"] = reranker_params
 
         resp = self.client.vector_io.query(query=query, vector_store_id=self._ls_vs.id, params=params)
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@
 
 - **Python**: 3.12 or 3.13 (strictly required)
 - **Operating System**: macOS or Linux
-- **(Optional) Llama Stack Server**: With at least one foundation model, one embedding model, and vector database configured
+- **(Optional) Llama Stack Server** >= 0.5.0: With at least one foundation model, one embedding model, and vector database configured
 
 
 !!! note "External models and vector database integration"
@@ -64,7 +64,7 @@ Follow these steps:
 ### 1. Install Llama Stack
 
 ```bash
-pip install llama-stack
+pip install "llama-stack>=0.5.0"
 ```
 
 ### 2. Configure Your Stack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "langchain~=1.1.3",
     "langchain_chroma~=1.1.0",
     "langchain-text-splitters~=1.1.0",
-    "llama-stack-client~=0.4.2",
+    "llama-stack-client~=0.5.0",
     "openai==2.23.*",
     "pandas==2.2.*",
     "pydantic==2.11.*",

--- a/tests/ai4rag/rag/vector_store/test_llama_stack.py
+++ b/tests/ai4rag/rag/vector_store/test_llama_stack.py
@@ -290,7 +290,7 @@ class TestLSVectorStoreHybridSearch:
 
         call_kwargs = mock_llama_stack_client.vector_io.query.call_args.kwargs
         assert call_kwargs["params"]["mode"] == "vector"
-        assert "ranker" not in call_kwargs["params"]
+        assert "reranker_type" not in call_kwargs["params"]
 
     def test_search_with_hybrid_mode_rrf(self, mock_embedding_model, mock_llama_stack_client):
         """Test search with hybrid mode and RRF ranker."""
@@ -305,8 +305,8 @@ class TestLSVectorStoreHybridSearch:
         call_kwargs = mock_llama_stack_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
         assert params["mode"] == "hybrid"
-        assert params["ranker"]["strategy"] == "rrf"
-        assert params["ranker"]["params"]["k"] == 60
+        assert params["reranker_type"] == "rrf"
+        assert params["reranker_params"]["impact_factor"] == 60
 
     def test_search_with_hybrid_mode_weighted(self, mock_embedding_model, mock_llama_stack_client):
         """Test search with hybrid mode and weighted ranker including alpha."""
@@ -323,9 +323,8 @@ class TestLSVectorStoreHybridSearch:
         call_kwargs = mock_llama_stack_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
         assert params["mode"] == "hybrid"
-        assert params["ranker"]["strategy"] == "weighted"
-        assert params["ranker"]["params"]["k"] == 60
-        assert params["ranker"]["params"]["alpha"] == 0.7
+        assert params["reranker_type"] == "weighted"
+        assert params["reranker_params"]["alpha"] == 0.7
 
     def test_search_with_hybrid_mode_normalized(self, mock_embedding_model, mock_llama_stack_client):
         """Test search with hybrid mode and normalized ranker."""
@@ -340,8 +339,8 @@ class TestLSVectorStoreHybridSearch:
         call_kwargs = mock_llama_stack_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
         assert params["mode"] == "hybrid"
-        assert params["ranker"]["strategy"] == "normalized"
-        assert params["ranker"]["params"] == {}
+        assert params["reranker_type"] == "normalized"
+        assert params["reranker_params"] == {}
 
     def test_search_hybrid_empty_strategy_raises(self, mock_embedding_model, mock_llama_stack_client):
         """Test that empty ranker_strategy with hybrid mode raises ValueError."""


### PR DESCRIPTION
## Description
Changed params construction for `vector_io.query` for the proper use of hybrid ranker in llama stack >= 0.5.x

## Motivation
To properly utilise hybrid ranker in llama stack

## Changes
- properly handle hybrid ranker in llama stack
- update docs and tests

## Testing
How did you test this?

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
