### PR TITLE
Release 0.4.2

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/evaluator/unitxt_evaluator.py
+++ b/ai4rag/evaluator/unitxt_evaluator.py
@@ -4,7 +4,6 @@
 # -----------------------------------------------------------------------------
 from typing import Sequence
 
-import numpy as np
 import pandas as pd
 from unitxt.eval_utils import evaluate
 
@@ -76,7 +75,7 @@ class UnitxtEvaluator(BaseEvaluator):
             Scores calculated for each question in the evaluation data.
         """
         reversed_metrics_mapping = {v: k for k, v in self.METRIC_TYPE_MAP.items()}
-        scores_df.replace("", np.nan, inplace=True)
+        scores_df = scores_df.mask(scores_df == "")
         raw_ret_dict = scores_df.round(4).to_dict()
         without_id = {
             reversed_metrics_mapping[key]: val for key, val in raw_ret_dict.items() if key in reversed_metrics_mapping
@@ -102,11 +101,10 @@ class UnitxtEvaluator(BaseEvaluator):
             Transformed confidence interval data that will be further processed.
         """
         reversed_metrics_mapping = {v: k for k, v in self.METRIC_TYPE_MAP.items()}
-        ci_table.replace(np.nan, None, inplace=True)
         ci_dict = ci_table.to_dict()
 
         def round_or_none(x: float | None) -> float | None:
-            return None if x is None else round(x, 4)
+            return None if x is None or pd.isna(x) else round(x, 4)
 
         returned_ci = {}
         for key, val in ci_dict.items():

--- a/ai4rag/rag/vector_store/llama_stack.py
+++ b/ai4rag/rag/vector_store/llama_stack.py
@@ -125,6 +125,11 @@ class LSVectorStore(BaseVectorStore):
                     f"Invalid ranker_strategy='{ranker_strategy}'. "
                     f"Must be one of {LSVectorStore._VALID_RANKER_STRATEGIES}."
                 )
+            if has_k and ranker_strategy != "rrf":
+                raise ValueError(
+                    f"ranker_k={ranker_k} is only valid when ranker_strategy='rrf', "
+                    f"but ranker_strategy='{ranker_strategy}'."
+                )
             if has_alpha and ranker_strategy != "weighted":
                 raise ValueError(
                     f"ranker_alpha={ranker_alpha} is only valid when ranker_strategy='weighted', "

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -11,7 +11,7 @@ __all__ = [
 
 # Note: "" and 0 are sentinels for unused params; ranker_alpha uses 1 as sentinel (0 means 100% sparse)
 _default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (512, 1024, 2048)
+_default_chunk_sizes = (512, 1024, 2048, 4096)
 _default_chunk_overlaps = (128, 256, 512)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
@@ -19,9 +19,9 @@ _default_chroma_retrieval_methods = ("simple", "window")
 _default_chroma_window_sizes = (0, 1, 3, 5)
 _default_numbers_of_chunks = (3, 5, 10)
 _default_search_modes = ("vector", "hybrid")
-_default_ranker_strategies = ("", "rrf", "weighted", "normalized")
-_default_ranker_k = (0, 20, 60, 100)
-_default_ranker_alpha = (1, 0.3, 0.5, 0.7)
+_default_ranker_strategies = ("", "rrf", "weighted")  # to extend with normalized
+_default_ranker_k = (0, 60)
+_default_ranker_alpha = (1, 0.5)
 
 
 def get_default_ai4rag_search_space_parameters(vector_store_type: str = "ls_milvus") -> list[Parameter]:

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -135,6 +135,37 @@ def _rule_search_mode_ranker_consistency(combination: dict) -> bool:
     return True
 
 
+def _rule_ranker_k_for_rrf_only(combination: dict) -> bool:
+    """ranker_k is only applicable when ranker_strategy is 'rrf'.
+
+    For non-rrf strategies, ranker_k must be 0 (sentinel meaning unused).
+    For rrf strategy, ranker_k must not be 0.
+
+    Parameters
+    ----------
+    combination : dict
+        Single node in the solutions space represented as a dict.
+
+    Returns
+    -------
+    bool
+        Whether combination passes selected criterion.
+    """
+    ranker_strategy = combination.get(AI4RAGParamNames.RANKER_STRATEGY)
+    ranker_k = combination.get(AI4RAGParamNames.RANKER_K)
+
+    if ranker_strategy is None or ranker_k is None:
+        return True
+
+    if ranker_strategy != "rrf" and ranker_k != 0:
+        return False
+
+    if ranker_strategy == "rrf" and ranker_k == 0:
+        return False
+
+    return True
+
+
 def _rule_ranker_alpha_for_weighted_only(combination: dict) -> bool:
     """ranker_alpha is only applicable when ranker_strategy is 'weighted'.
 
@@ -305,6 +336,7 @@ class AI4RAGSearchSpace(SearchSpace):
 
     _hybrid_rules = (
         _rule_search_mode_ranker_consistency,
+        _rule_ranker_k_for_rrf_only,
         _rule_ranker_alpha_for_weighted_only,
     )
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.2](https://github.com/IBM/ai4rag/releases/tag/v0.4.2)
+
+### Added
+- Search space validation rule `_rule_ranker_k_for_rrf_only` ensuring `ranker_k` is only used with `rrf` ranker strategy
+- Vector store validation that `ranker_k` is only valid when `ranker_strategy='rrf'`
+
+### Changed
+- Removed `numpy` dependency from `UnitxtEvaluator`; replaced with pandas-native `DataFrame.mask()` and `pd.isna()`
+- Default search space: added `4096` to default chunk sizes
+- Default search space: simplified hybrid search defaults — removed `normalized` ranker strategy, reduced `ranker_k` values to `(0, 60)` and `ranker_alpha` values to `(1, 0.5)`
+
+---
+
 ## [0.4.1](https://github.com/IBM/ai4rag/releases/tag/v0.4.1)
 
 ### Changed

--- a/tests/ai4rag/rag/vector_store/test_llama_stack.py
+++ b/tests/ai4rag/rag/vector_store/test_llama_stack.py
@@ -316,9 +316,7 @@ class TestLSVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search(
-            "test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_k=60, ranker_alpha=0.7
-        )
+        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_alpha=0.7)
 
         call_kwargs = mock_llama_stack_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -620,6 +618,18 @@ class TestLSVectorStoreSearchValidation:
         with pytest.raises(ValueError, match="Invalid ranker_strategy='bogus'"):
             LSVectorStore._validate_search_params("hybrid", "bogus", None, None)
 
+    # --- ranker_k used with non-rrf strategy ---
+
+    def test_ranker_k_with_weighted_strategy_raises(self):
+        """Test that ranker_k > 0 with weighted strategy raises ValueError."""
+        with pytest.raises(ValueError, match="ranker_k=60 is only valid when ranker_strategy='rrf'"):
+            LSVectorStore._validate_search_params("hybrid", "weighted", 60, 0.7)
+
+    def test_ranker_k_with_normalized_strategy_raises(self):
+        """Test that ranker_k > 0 with normalized strategy raises ValueError."""
+        with pytest.raises(ValueError, match="ranker_k=20 is only valid when ranker_strategy='rrf'"):
+            LSVectorStore._validate_search_params("hybrid", "normalized", 20, None)
+
     # --- ranker_alpha used with non-weighted strategy ---
 
     def test_alpha_with_rrf_strategy_raises(self):
@@ -658,7 +668,7 @@ class TestLSVectorStoreSearchValidation:
 
     def test_valid_hybrid_weighted_with_alpha(self):
         """Test that hybrid mode with weighted strategy and alpha is valid."""
-        LSVectorStore._validate_search_params("hybrid", "weighted", 60, 0.7)
+        LSVectorStore._validate_search_params("hybrid", "weighted", None, 0.7)
 
     def test_valid_hybrid_normalized(self):
         """Test that hybrid mode with normalized strategy is valid."""
@@ -666,7 +676,7 @@ class TestLSVectorStoreSearchValidation:
 
     def test_valid_hybrid_weighted_zero_alpha(self):
         """Test that hybrid mode with weighted strategy and alpha=0 (100% sparse) is valid."""
-        LSVectorStore._validate_search_params("hybrid", "weighted", 60, 0)
+        LSVectorStore._validate_search_params("hybrid", "weighted", None, 0)
 
 
 class TestLSVectorStoreInitializeVectorStore:

--- a/tests/ai4rag/search_space/src/test_search_space.py
+++ b/tests/ai4rag/search_space/src/test_search_space.py
@@ -14,6 +14,7 @@ from ai4rag.search_space.src.search_space import (
     _rule_chunk_size_bigger_than_chunk_overlap,
     _rule_chunk_size_within_embedding_context_length,
     _rule_ranker_alpha_for_weighted_only,
+    _rule_ranker_k_for_rrf_only,
     _rule_search_mode_ranker_consistency,
 )
 
@@ -184,6 +185,37 @@ def test_rule_ranker_alpha_for_weighted_only_missing_fields():
     assert _rule_ranker_alpha_for_weighted_only({"ranker_strategy": "rrf"}) is True
 
 
+@pytest.mark.parametrize(
+    "combination, expected_value",
+    (
+        # rrf strategy: ranker_k must not be 0
+        ({"ranker_strategy": "rrf", "ranker_k": 20}, True),
+        ({"ranker_strategy": "rrf", "ranker_k": 60}, True),
+        ({"ranker_strategy": "rrf", "ranker_k": 100}, True),
+        # rrf strategy: ranker_k == 0 -> False
+        ({"ranker_strategy": "rrf", "ranker_k": 0}, False),
+        # non-rrf strategies: ranker_k must be 0 (sentinel)
+        ({"ranker_strategy": "weighted", "ranker_k": 0}, True),
+        ({"ranker_strategy": "normalized", "ranker_k": 0}, True),
+        ({"ranker_strategy": "", "ranker_k": 0}, True),
+        # non-rrf strategies: ranker_k != 0 -> False
+        ({"ranker_strategy": "weighted", "ranker_k": 60}, False),
+        ({"ranker_strategy": "normalized", "ranker_k": 20}, False),
+        ({"ranker_strategy": "", "ranker_k": 100}, False),
+    ),
+)
+def test_rule_ranker_k_for_rrf_only(combination, expected_value):
+    val = _rule_ranker_k_for_rrf_only(combination)
+    assert val == expected_value
+
+
+def test_rule_ranker_k_for_rrf_only_missing_fields():
+    """Rule returns True when fields are missing."""
+    assert _rule_ranker_k_for_rrf_only({}) is True
+    assert _rule_ranker_k_for_rrf_only({"ranker_strategy": "rrf"}) is True
+    assert _rule_ranker_k_for_rrf_only({"ranker_k": 60}) is True
+
+
 class TestSearchSpace:
     def test_initialization(self, mocked_params):
         search_space = SearchSpace(params=mocked_params)
@@ -324,8 +356,13 @@ class TestAI4RAGSearchSpaceVectorStoreType:
                 assert combination["ranker_alpha"] == 1
             elif search_mode == "hybrid":
                 assert combination["ranker_strategy"] in ("rrf", "weighted", "normalized")
-
-    def test_chroma_combinations_fewer_than_milvus(self):
-        ss_chroma = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS), vector_store_type="chroma")
-        ss_milvus = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS), vector_store_type="ls_milvus")
-        assert ss_chroma.max_combinations < ss_milvus.max_combinations
+                # ranker_k only for rrf
+                if combination["ranker_strategy"] == "rrf":
+                    assert combination["ranker_k"] > 0
+                else:
+                    assert combination["ranker_k"] == 0
+                # ranker_alpha only for weighted
+                if combination["ranker_strategy"] == "weighted":
+                    assert combination["ranker_alpha"] != 1
+                else:
+                    assert combination["ranker_alpha"] == 1


### PR DESCRIPTION
## 0.4.2

### Added
- Search space validation rule `_rule_ranker_k_for_rrf_only` ensuring `ranker_k` is only used with `rrf` ranker strategy
- Vector store validation that `ranker_k` is only valid when `ranker_strategy='rrf'`

### Changed
- Removed `numpy` dependency from `UnitxtEvaluator`; replaced with pandas-native `DataFrame.mask()` and `pd.isna()`
- Default search space: added `4096` to default chunk sizes
- Default search space: simplified hybrid search defaults — removed `normalized` ranker strategy, reduced `ranker_k` values to `(0, 60)` and `ranker_alpha` values to `(1, 0.5)`