### PR TITLE
Release 0.4.3

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -87,9 +87,8 @@ def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsR
             model_id=m.id,
             client=client,
             params=LSEmbeddingParams(
-                embedding_dimension=m.custom_metadata.get("embedding_dimension")
-                or m.metadata.get("embedding_dimension"),
-                context_length=m.custom_metadata.get("context_length") or m.metadata.get("context_length"),
+                embedding_dimension=getattr(m, "custom_metadata", {}).get("embedding_dimension"),
+                context_length=getattr(m, "custom_metadata", {}).get("context_length"),
             ),
         )
         for m in embeddings


### PR DESCRIPTION
Hotfix: missing `m.metadata` in `ls_client.models.list()` response
