### PR TITLE
Release 0.5.0

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0](https://github.com/IBM/ai4rag/releases/tag/v0.5.0)
+
+### Added
+- `KFPEventHandler`: new event handler for Kubeflow Pipelines (KFP) integration, enabling experiment progress tracking inside KFP pipeline components
+- `known_observations` parameter on `GAMOptimiser` and `AI4RAGExperiment`, allowing the optimizer to be pre-seeded with prior evaluation results so redundant evaluations are skipped
+- `__hash__` method on `BaseFoundationModel` based on `model_id`
+- New functional test suite under `tests/functional/` with end-to-end experiment coverage using mocked models
+
+### Changed
+- `GAMOptSettings`: removed lower-bound constraints on `n_random_nodes` and `max_evals`; both now accept `0`, which is required for KFP pipeline component usage
+- Bumped `llama-stack-client` dependency from `~=0.5.0` to `~=0.6.0`
+- Hybrid search disabled by default in the default search space due to upstream Llama Stack instability
+- `BaseEventHandler` payload TypedDicts enriched with full structured types (`MetricCI`, `PatternScores`, `VectorStoreSettings`, `ChunkingSettings`, etc.)
+- Tests reorganized into `tests/unit/` and `tests/functional/` subdirectories
+- Documentation and development workflow guides updated
+
+### Fixed
+- Fixed crash when the `metadata` field is absent from the `models.list()` response returned by Llama Stack
+
+---
+
 ## [0.4.2](https://github.com/IBM/ai4rag/releases/tag/v0.4.2)
 
 ### Added

--- a/docs/user-guide/event-handlers.md
+++ b/docs/user-guide/event-handlers.md
@@ -1,17 +1,158 @@
 # Event Handlers
 
-Detailed documentation on event handlers for experiment tracking.
+Event handlers are the bridge between the optimization engine and your application. Every time ai4rag completes an iteration or changes its internal state, it notifies your handler — giving you full visibility into the experiment without coupling your code to the engine's internals.
 
-!!! note "Coming Soon"
-    This page is under development.
+## Core Concept
 
-## Topics Covered
+`BaseEventHandler` is an abstract class with two methods you must implement:
 
-- BaseEventHandler interface
-- Built-in handlers
-- Custom handler implementation
-- Production monitoring
-- Logging and telemetry
-- Integration examples
+| Method | When it fires |
+|---|---|
+| `on_status_change` | At each step of the experiment (indexing, retrieval, evaluation, …) |
+| `on_pattern_creation` | After every RAG pattern is fully evaluated |
 
-Check back soon for comprehensive event handler documentation.
+Your handler is passed to `AI4RAGExperiment` at construction time and called automatically throughout the run.
+
+```python
+from ai4rag import AI4RAGExperiment
+from ai4rag.utils.event_handler import BaseEventHandler
+
+experiment = AI4RAGExperiment(
+    ...
+    event_handler=MyEventHandler(),
+)
+```
+
+---
+
+## `on_status_change`
+
+Called whenever the engine transitions between steps. Use it for progress tracking, logging, or alerting.
+
+```python
+def on_status_change(self, level: LogLevel, message: str, step: str | None = None) -> None:
+    ...
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `level` | `LogLevel` | Severity: `INFO`, `WARNING`, or `ERROR` |
+| `message` | `str` | Human-readable description of what is happening |
+| `step` | `str | None` | Name of the current experiment step |
+
+---
+
+## `on_pattern_creation`
+
+Called once per evaluated RAG pattern. This is where you receive the full evaluation result and can persist, forward, or display it.
+
+```python
+def on_pattern_creation(
+    self, payload: PatternPayload, evaluation_results: list[EvaluationRecord], **kwargs
+) -> None:
+    ...
+```
+
+### `payload` — pattern summary
+
+```python
+{
+    "pattern_name": "Pattern1",
+    "iteration": 0,
+    "final_score": 0.72,
+    "execution_time": 134,           # seconds
+    "schema_version": "1.0",
+    "producer": "ai4rag",
+    "scores": {
+        "scores": {
+            "faithfulness":        {"mean": 0.72, "ci_low": 0.61, "ci_high": 0.83},
+            "answer_correctness":  {"mean": 0.68, "ci_low": 0.55, "ci_high": 0.81},
+            "context_correctness": {"mean": 0.80, "ci_low": 0.70, "ci_high": 0.90},
+        },
+        "question_scores": {
+            "faithfulness": {"q0": 0.71, "q1": 0.73, ...},
+            ...
+        },
+    },
+    "settings": {
+        "chunking":    {"method": "recursive", "chunk_size": 512, "chunk_overlap": 64},
+        "embedding":   {"model_id": "...", "distance_metric": "cosine", ...},
+        "retrieval":   {"method": "simple", "number_of_chunks": 5, "search_mode": "vector"},
+        "generation":  {"model_id": "...", ...},
+        "vector_store": {"datasource_type": "chroma", "collection_name": "..."},
+    },
+}
+```
+
+### `evaluation_results` — per-question breakdown
+
+```python
+[
+    {
+        "question": "What is ...?",
+        "answer": "According to the document ...",
+        "correct_answers": ["The correct answer is ..."],
+        "answer_contexts": [
+            {"text": "Retrieved chunk text ...", "document_id": "doc1.pdf"},
+        ],
+        "scores": {
+            "faithfulness": 0.71,
+            "answer_correctness": 0.65,
+            "context_correctness": 0.80,
+        },
+    },
+    ...
+]
+```
+
+---
+
+## Built-in Handlers
+
+Two ready-to-use implementations are provided:
+
+**`LocalEventHandler`** — saves each pattern's `payload` and `evaluation_results` as JSON files under a given output directory. Ideal for local development.
+
+```python
+from ai4rag.utils.event_handler import LocalEventHandler
+
+handler = LocalEventHandler(output_path="./results")
+```
+
+**`KFPEventHandler`** — accumulates all status changes and pattern results in memory (`.status_changes` and `.patterns` lists). Designed for Kubeflow Pipelines components where you need to access results after the experiment finishes.
+
+```python
+from ai4rag.utils.event_handler import KFPEventHandler
+
+handler = KFPEventHandler()
+experiment.run(...)
+print(handler.patterns)  # access after the run
+```
+
+---
+
+## Writing a Custom Handler
+
+Subclass `BaseEventHandler` and implement both methods. The example below forwards results to an external API:
+
+```python
+import requests
+from ai4rag.utils.event_handler import BaseEventHandler, LogLevel, PatternPayload, EvaluationRecord
+
+class MyEventHandler(BaseEventHandler):
+
+    def on_status_change(self, level: LogLevel, message: str, step: str | None = None) -> None:
+        if level == LogLevel.ERROR:
+            requests.post("https://my-service/alerts", json={"step": step, "message": message})
+
+    def on_pattern_creation(
+        self, payload: PatternPayload, evaluation_results: list[EvaluationRecord], **kwargs
+    ) -> None:
+        requests.post("https://my-service/patterns", json={
+            "name": payload["pattern_name"],
+            "score": payload["final_score"],
+            "settings": payload["settings"],
+        })
+```
+
+Your handler can do anything: write to a database, push metrics to a dashboard, send Slack notifications, or stream results to a frontend — the engine does not care.


### PR DESCRIPTION
Assisted-by: Claude Code

# Release v0.5.0

## Summary

This release introduces first-class support for Kubeflow Pipelines (KFP) through a new `KFPEventHandler`, making it easier to embed ai4rag experiments inside KFP pipeline components. It also adds the ability to pre-seed the optimizer with known observations, allowing subsequent runs to skip evaluations that have already been performed. Additionally, the `llama-stack-client` dependency is bumped to `~=0.6.0`.

## Changes

### Added
- `KFPEventHandler`: new event handler for Kubeflow Pipelines (KFP) integration, enabling experiment progress tracking inside KFP pipeline components
- `known_observations` parameter on `GAMOptimiser` and `AI4RAGExperiment`, allowing the optimizer to be pre-seeded with prior evaluation results so redundant evaluations are skipped
- `__hash__` method on `BaseFoundationModel` based on `model_id`
- New functional test suite under `tests/functional/` with end-to-end experiment coverage using mocked models

### Changed
- `GAMOptSettings`: removed lower-bound constraints on `n_random_nodes` and `max_evals`; both now accept `0`, which is required for KFP pipeline component usage
- Bumped `llama-stack-client` dependency from `~=0.5.0` to `~=0.6.0`
- Hybrid search disabled by default in the default search space due to upstream Llama Stack instability
- `BaseEventHandler` payload TypedDicts enriched with full structured types (`MetricCI`, `PatternScores`, `VectorStoreSettings`, `ChunkingSettings`, etc.)
- Tests reorganized into `tests/unit/` and `tests/functional/` subdirectories
- Documentation and development workflow guides updated

### Fixed
- Fixed crash when the `metadata` field is absent from the `models.list()` response returned by Llama Stack

## Migration notes

- **`llama-stack-client`**: upgrade to `~=0.6.0` (previously `~=0.5.0`). Ensure your Llama Stack server is compatible with client version 0.6.x before upgrading.
- **`GAMOptSettings`**: if you relied on the minimum value enforcement for `n_random_nodes` or `max_evals`, note that values of `0` are now accepted without error.
- **Hybrid search**: hybrid search mode is no longer included in the default search space. If you require hybrid search, add it explicitly to your `AI4RAGSearchSpace`.
- **Test layout**: if you reference test paths directly (e.g. in CI config), update paths from `tests/ai4rag/` to `tests/unit/ai4rag/`.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.5.0`
- [x] `docs/about/changelog.md` updated
- [x] All tests pass (`pytest`)
- [x] Docs build successfully

