### PR TITLE
Release 0.5.1

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/rag/embedding/llama_stack.py
+++ b/ai4rag/rag/embedding/llama_stack.py
@@ -129,6 +129,8 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embeds given list of strings.
+        For llama-stack the maximum batch size supported is 2048 chunks,
+        hence we need to do it iteratively.
 
         Parameters
         ----------
@@ -140,7 +142,11 @@ class LSEmbeddingModel(BaseEmbeddingModel[LlamaStackClient, LSEmbeddingParams]):
         list[list[float]]
             Embeddings made from the list of texts.
         """
-        return self._embed_text(text_input=texts)
+        resp = []
+        for idx in range(0, len(texts), 2048):
+            resp.extend(self._embed_text(text_input=texts[idx : idx + 2048]))
+
+        return resp
 
     def embed_query(self, query: str) -> list[float]:
         """Embeds given query.

--- a/ai4rag/rag/vector_store/chroma.py
+++ b/ai4rag/rag/vector_store/chroma.py
@@ -210,12 +210,7 @@ class ChromaVectorStore(BaseVectorStore):
         list[str]
             List of documents IDs.
         """
-        max_batch_size = kwargs.get("max_batch_size")
-        if max_batch_size is None:
-            try:
-                max_batch_size = self._vector_store._client.get_max_batch_size()  # pylint: disable=protected-access
-            except AttributeError:
-                max_batch_size = 10_000
+        max_batch_size = kwargs.get("max_batch_size", 2048)
 
         ids, docs = self._process_documents(documents)
         if len(docs) > max_batch_size:
@@ -263,10 +258,7 @@ class ChromaVectorStore(BaseVectorStore):
         window_documents = [
             Document(
                 page_content=text,
-                metadata={
-                    self._chunk_sequence_number_field: metadata[self._chunk_sequence_number_field],
-                    self._document_name_field: doc_id,
-                },
+                metadata=metadata,
             )
             for text, metadata in zip(texts, metadatas)
         ]

--- a/ai4rag/rag/vector_store/llama_stack.py
+++ b/ai4rag/rag/vector_store/llama_stack.py
@@ -204,7 +204,7 @@ class LSVectorStore(BaseVectorStore):
 
         return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
 
-    def add_documents(self, documents: list[Document]) -> None:
+    def add_documents(self, documents: list[Document], **kwargs) -> None:
         """
         Add documents to the collection.
 
@@ -213,6 +213,7 @@ class LSVectorStore(BaseVectorStore):
         documents : Sequence[Document]
             Documents to add to the collection.
         """
+        batch_size = kwargs.get("batch_size", 2048)
 
         # Handle both dict and LSEmbeddingParams for backward compatibility
         if isinstance(self.embedding_model.params, dict):
@@ -232,10 +233,12 @@ class LSVectorStore(BaseVectorStore):
         ]
         embeddings = self.embedding_model.embed_documents([doc.page_content for doc in documents])
         full_chunks = [chunk | {"embedding": embedding} for chunk, embedding in zip(chunks, embeddings)]
-        self.client.vector_io.insert(
-            vector_store_id=self._ls_vs.id,
-            chunks=full_chunks,
-        )
+
+        for idx in range(0, len(full_chunks), batch_size):
+            self.client.vector_io.insert(
+                vector_store_id=self._ls_vs.id,
+                chunks=full_chunks[idx : idx + batch_size],
+            )
 
     def clean_collection(self):
         """Remove content of the collection and remove vector store instance."""

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -11,8 +11,8 @@ __all__ = [
 
 # Note: "" and 0 are sentinels for unused params; ranker_alpha uses 1 as sentinel (0 means 100% sparse)
 _default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (512, 1024, 2048, 4096)
-_default_chunk_overlaps = (128, 256, 512)
+_default_chunk_sizes = (1024, 2048)
+_default_chunk_overlaps = (128, 256)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
 _default_chroma_retrieval_methods = ("simple", "window")
@@ -63,7 +63,10 @@ def get_default_ai4rag_search_space_parameters(vector_store_type: str = "ls_milv
     else:
         default_search_space_parameters.extend(
             [
-                Parameter(name=AI4RAGParamNames.SEARCH_MODE, values=("vector",)),
+                Parameter(name=AI4RAGParamNames.SEARCH_MODE, values=_default_search_modes),
+                Parameter(name=AI4RAGParamNames.RANKER_STRATEGY, values=_default_ranker_strategies),
+                Parameter(name=AI4RAGParamNames.RANKER_K, values=_default_ranker_k),
+                Parameter(name=AI4RAGParamNames.RANKER_ALPHA, values=_default_ranker_alpha),
             ]
         )
 

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -18,10 +18,10 @@ _default_window_sizes = (0,)
 _default_chroma_retrieval_methods = ("simple", "window")
 _default_chroma_window_sizes = (0, 1, 3, 5)
 _default_numbers_of_chunks = (3, 5, 10)
-_default_search_modes = ("vector", "hybrid")  # currently off as llama stack has issue with hybrid search mode
-_default_ranker_strategies = ("", "rrf", "weighted")  # to extend with normalized
-_default_ranker_k = (0, 60)  # currently off as llama stack has issue with hybrid search mode
-_default_ranker_alpha = (1, 0.5)  # currently off as llama stack has issue with hybrid search mode
+_default_search_modes = ("vector", "hybrid")
+_default_ranker_strategies = ("", "rrf", "weighted")
+_default_ranker_k = (0, 60)
+_default_ranker_alpha = (1, 0.5)
 
 
 def get_default_ai4rag_search_space_parameters(vector_store_type: str = "ls_milvus") -> list[Parameter]:

--- a/dev_utils/file_store.py
+++ b/dev_utils/file_store.py
@@ -2,24 +2,21 @@
 # Copyright IBM Corp. 2025-2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-import io
+import logging
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Sequence
 
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.document_converter import DocumentConverter, PdfFormatOption, settings
 from langchain_core.documents import Document
-from pypdf import PdfReader
 
+logger = logging.getLogger(__name__)
 
-def _txt_to_string(binary_data: bytes) -> str:
-    return binary_data.decode("utf-8", errors="ignore")
-
-
-def _pdf_to_string(binary_data: bytes) -> str:
-    with io.BytesIO(binary_data) as open_pdf_file:
-        reader = PdfReader(open_pdf_file)
-        full_text = [page.extract_text() for page in reader.pages]
-        return "\n".join(full_text)
+SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".pptx", ".md", ".html", ".txt"}
 
 
 class FileStoreException(Exception):
@@ -29,70 +26,96 @@ class FileStoreException(Exception):
 class FileStore:
     """
     Class used to load locally saved input files.
-    This class reused logics from the TextLoader class in ibm_watsonx_ai package
+    Uses docling library to extract content from documents as markdown.
     """
 
-    suffix_to_func = {
-        ".txt": _txt_to_string,
-        ".pdf": _pdf_to_string,
-    }
-
-    def __init__(self, path: str | Path | Sequence[str] | Sequence[Path]):
+    def __init__(self, path: str | Path | Sequence[str] | Sequence[Path], save_dir: str | Path | None = None):
+        """
+        Parameters
+        ----------
+        path : str | Path | Sequence[str] | Sequence[Path]
+            Path to a single file or a directory of files.
+        save_dir : str | Path | None
+            Optional directory to save extracted markdown files. If None, no files are saved.
+        """
         self.path = Path(path)
-        self.is_dir = path.is_dir()
+        self.is_dir = self.path.is_dir()
+        self.save_dir = Path(save_dir) if save_dir is not None else None
         self.files = {}
 
+        pipeline_options = PdfPipelineOptions()
+        pipeline_options.do_ocr = False
+        pipeline_options.do_table_structure = False
+        pipeline_options.accelerator_options = AcceleratorOptions(device="auto")
+
+        num_workers = os.cpu_count() or 1
+        settings.perf.doc_batch_size = num_workers
+        settings.perf.doc_batch_concurrency = num_workers
+
+        self._converter = DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
+        )
+
     def __repr__(self) -> str:
-        ret = f"{self.__class__.__name__}(path={self.path})"
-        return ret
+        return f"{self.__class__.__name__}(path={self.path})"
 
     def load_as_documents(self) -> list[Document]:
         """Read files as langchain documents"""
         contents = self._load_content()
-        documents = [Document(page_content=content[0], metadata={"document_id": content[1]}) for content in contents]
-
-        return documents
+        return [Document(page_content=content[0], metadata={"document_id": content[1]}) for content in contents]
 
     @lru_cache(maxsize=2)
     def _load_content(self) -> list[tuple[str, str]]:
         """Load file(s) from given path"""
         if self.is_dir:
-            contents = [(self._read_single_content(file), file.name) for file in self.path.iterdir()]
+            all_files = [f for f in self.path.iterdir() if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS]
+            txt_files = [f for f in all_files if f.suffix.lower() == ".txt"]
+            docling_files = [f for f in all_files if f.suffix.lower() != ".txt"]
+
+            contents = [(self._read_txt(f), f.name) for f in txt_files]
+            contents.extend(self._convert_batch(docling_files))
             return contents
 
-        return [(self._read_single_content(self.path), self.path.name)]
+        if self.path.suffix.lower() == ".txt":
+            return [(self._read_txt(self.path), self.path.name)]
 
-    def _process_file(self, filepath: Path, file_content: bytes | None) -> str:
-        """
-        Extracts text from bytes for various file types.
+        return self._convert_batch([self.path])
 
-        Parameters
-        ----------
-        filepath : Path
-            Path to file
+    def _read_txt(self, filepath: Path) -> str:
+        """Read a plain text file directly."""
+        content = filepath.read_text(encoding="utf-8", errors="ignore")
+        self.files[str(filepath)] = content
+        self._save_markdown(filepath, content)
+        return content
 
-        file_content : bytes | None
-            File content as bytes
+    def _convert_batch(self, filepaths: list[Path]) -> list[tuple[str, str]]:
+        """Convert multiple files to markdown using docling's batch processing."""
+        if not filepaths:
+            return []
 
-        Returns
-        -------
-        str
-            Extracted file text
-        """
-
-        handler = self.suffix_to_func.get(filepath.suffix, None)
-
+        results = []
         try:
-            text = handler(file_content)
+            for conv_result in self._converter.convert_all(filepaths, raises_on_error=False):
+                filepath = Path(conv_result.input.file)
+                if conv_result.errors:
+                    error_msgs = "; ".join(e.error_message for e in conv_result.errors)
+                    raise FileStoreException(f"Failed to convert file: {filepath.name}: {error_msgs}")
+
+                markdown_content = conv_result.document.export_to_markdown()
+                self.files[str(filepath)] = markdown_content
+                self._save_markdown(filepath, markdown_content)
+                results.append((markdown_content, filepath.name))
+        except FileStoreException:
+            raise
         except Exception as exc:
-            raise FileStoreException(f"Failed to load file.") from exc
+            raise FileStoreException(f"Failed to convert files") from exc
 
-        return text
+        return results
 
-    def _read_single_content(self, filepath: Path) -> str:
-        """Read single file"""
-        with open(filepath, "rb") as file:
-            content = file.read()
-        text = self._process_file(filepath=filepath, file_content=content)
-        self.files[str(filepath)] = text
-        return text
+    def _save_markdown(self, filepath: Path, content: str) -> None:
+        """Save extracted content as a markdown file if save_dir is set."""
+        if self.save_dir is not None:
+            self.save_dir.mkdir(parents=True, exist_ok=True)
+            output_file = self.save_dir / f"{filepath.stem}.md"
+            output_file.write_text(content, encoding="utf-8")
+            logger.info("Saved extracted markdown to %s", output_file)

--- a/dev_utils/run_experiment.py
+++ b/dev_utils/run_experiment.py
@@ -29,17 +29,17 @@ if __name__ == "__main__":
     client = LlamaStackClient()
 
     # change to direct to your local documents path
-    documents_path = _filepath.parents[1] / "local" / "data" / "watsonx_sample" / "documents"
+    documents_path = _filepath.parents[1] / "local" / "data" / "financial_ibm" / "documents"
 
     # change to direct to your benchmark_data.json
-    benchmark_data_path = _filepath.parents[1] / "local" / "data" / "watsonx_sample" / "benchmark_data.json"
+    benchmark_data_path = _filepath.parents[1] / "local" / "data" / "financial_ibm" / "benchmark_data.json"
 
     file_store = FileStore(documents_path)
     documents = file_store.load_as_documents()
     benchmark_data = read_benchmark_from_json(benchmark_data_path)
 
     # Configure optimizer
-    optimizer_settings = GAMOptSettings(max_evals=8, n_random_nodes=4)
+    optimizer_settings = GAMOptSettings(max_evals=6, n_random_nodes=4)
 
     # Edit configurations of search space
     search_space = AI4RAGSearchSpace(
@@ -49,7 +49,7 @@ if __name__ == "__main__":
                 name="foundation_model",
                 param_type="C",
                 values=[
-                    LSFoundationModel(model_id="vllm-inference-llama-3-1/redhataillama-31-8b-instruct", client=client)
+                    LSFoundationModel(model_id="vllm-inference-qwen/qwen25-7b-instruct", client=client)
                 ],
             ),
             Parameter(
@@ -57,12 +57,16 @@ if __name__ == "__main__":
                 param_type="C",
                 values=[
                     LSEmbeddingModel(
-                        model_id="vllm-embedding/granite-278m-multilingual-1",
+                        model_id="vllm-embedding/bge-m3",
                         client=client,
-                        params={"embedding_dimension": 768, "context_length": 512},
+                        params={"embedding_dimension": 1024, "context_length": 8192},
                     )
                 ],
             ),
+            Parameter(
+                name="search_mode",
+                values=["hybrid"]
+            )
         ],
     )
 
@@ -92,7 +96,7 @@ if __name__ == "__main__":
         benchmark_data=benchmark_data,
         search_space=search_space,
         optimizer_settings=optimizer_settings,
-        event_handler=LocalEventHandler(output_path=_filepath.parent / "local" / "ls_milvus_hybrid_off_narrowed_ss"),
+        event_handler=LocalEventHandler(output_path=_filepath.parent / "local" / "hybrid_test"),
         vector_store_type="ls_milvus",
     )
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1](https://github.com/IBM/ai4rag/releases/tag/v0.5.1)
+
+### Added
+- Batch processing for Llama Stack embeddings (2048 chunk limit) and vector store document insertion, preventing failures with large document sets
+
+### Changed
+- Hybrid search re-enabled by default in the `ls_milvus` default search space (was disabled in 0.5.0 due to upstream instability)
+- Default chunk sizes narrowed from `(512, 1024, 2048, 4096)` to `(1024, 2048)` and overlaps from `(128, 256, 512)` to `(128, 256)` for faster optimization
+- Chroma vector store batch size simplified to a fixed default of 2048 instead of querying client internals
+
+---
+
 ## [0.5.0](https://github.com/IBM/ai4rag/releases/tag/v0.5.0)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "beautifulsoup4",      # reading data from html
     "dotenv",
     "ipykernel",
-    "pypdf",               # reading data from pdf
+    "docling",             # document text extraction
 ]
 
 test = ["pytest", "pytest-cov", "pytest-mock", "psutil", "nbformat"]

--- a/tests/functional/test_experiment.py
+++ b/tests/functional/test_experiment.py
@@ -169,7 +169,7 @@ class TestExperimentChromaWithKnownObservations:
             {
                 "foundation_model": foundation_model,
                 "embedding_model": embedding_model,
-                "chunk_size": 512,
+                "chunk_size": 1024,
                 "chunk_overlap": 128,
                 "chunking_method": "recursive",
                 "retrieval_method": "simple",
@@ -181,7 +181,7 @@ class TestExperimentChromaWithKnownObservations:
             {
                 "foundation_model": foundation_model,
                 "embedding_model": embedding_model,
-                "chunk_size": 1024,
+                "chunk_size": 2048,
                 "chunk_overlap": 128,
                 "chunking_method": "recursive",
                 "retrieval_method": "simple",
@@ -193,7 +193,7 @@ class TestExperimentChromaWithKnownObservations:
             {
                 "foundation_model": foundation_model,
                 "embedding_model": embedding_model,
-                "chunk_size": 1024,
+                "chunk_size": 2048,
                 "chunk_overlap": 256,
                 "chunking_method": "recursive",
                 "retrieval_method": "simple",

--- a/tests/unit/ai4rag/rag/embedding/test_llama_stack.py
+++ b/tests/unit/ai4rag/rag/embedding/test_llama_stack.py
@@ -169,6 +169,24 @@ class TestLSEmbeddingModel:
         assert embeddings[0] == [0.1, 0.2, 0.3]
         assert embeddings[1] == [0.4, 0.5, 0.6]
 
+    def test_embed_documents_batches_large_input(self, mock_ls_client, mocker):
+        """Test embed_documents batches inputs exceeding 2048 texts."""
+        model = LSEmbeddingModel(
+            client=mock_ls_client,
+            model_id="all-MiniLM-L6-v2",
+            params=LSEmbeddingParams(embedding_dimension=3, context_length=512),
+        )
+
+        batch1_response = _make_mock_ls_embedding_response(mocker, [[0.1] for _ in range(2048)])
+        batch2_response = _make_mock_ls_embedding_response(mocker, [[0.2] for _ in range(100)])
+        mock_ls_client.embeddings.create.side_effect = [batch1_response, batch2_response]
+
+        texts = [f"text{i}" for i in range(2148)]
+        embeddings = model.embed_documents(texts)
+
+        assert len(embeddings) == 2148
+        assert mock_ls_client.embeddings.create.call_count == 2
+
     def test_embed_query(self, mock_ls_client, mocker):
         """Test embed_query method."""
         model = LSEmbeddingModel(

--- a/tests/unit/ai4rag/rag/vector_store/test_chroma.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_chroma.py
@@ -260,11 +260,6 @@ class TestChromaVectorStoreAddDocuments:
 
     def test_add_documents_basic(self, mocker, mock_embedding_model, mock_chroma_client):
         """Test add_documents with basic documents."""
-        # Configure mock to raise AttributeError when accessing _client.get_max_batch_size()
-        # This will cause the code to default to max_batch_size=10_000
-        mock_client_internal = MagicMock()
-        mock_client_internal.get_max_batch_size.side_effect = AttributeError("No get_max_batch_size")
-        mock_chroma_client._client = mock_client_internal
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
         content = [Document(page_content="Doc 1"), Document(page_content="Doc 2")]
@@ -275,11 +270,6 @@ class TestChromaVectorStoreAddDocuments:
 
     def test_add_documents_with_strings(self, mocker, mock_embedding_model, mock_chroma_client):
         """Test add_documents with string content."""
-        # Configure mock to raise AttributeError when accessing _client.get_max_batch_size()
-        # This will cause the code to default to max_batch_size=10_000
-        mock_client_internal = MagicMock()
-        mock_client_internal.get_max_batch_size.side_effect = AttributeError("No get_max_batch_size")
-        mock_chroma_client._client = mock_client_internal
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
         content = ["Doc 1", "Doc 2"]
@@ -291,12 +281,11 @@ class TestChromaVectorStoreAddDocuments:
         """Test add_documents with batching when exceeding max_batch_size."""
         mock_client = MagicMock()
         mock_client.get.return_value = {"ids": []}
-        mock_client._client.get_max_batch_size.return_value = 2
         mock_client.add_documents.return_value = ["id1", "id2"]
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
         content = ["Doc 1", "Doc 2", "Doc 3", "Doc 4", "Doc 5"]
-        result = vector_store.add_documents(content)
+        result = vector_store.add_documents(content, max_batch_size=2)
         # Should be called multiple times due to batching
         assert mock_client.add_documents.call_count >= 2
         assert isinstance(result, list)
@@ -311,18 +300,18 @@ class TestChromaVectorStoreAddDocuments:
         assert mock_chroma_client.add_documents.call_count >= 2
         assert isinstance(result, list)
 
-    def test_add_documents_with_no_max_batch_size_attribute(self, mocker, mock_embedding_model):
-        """Test add_documents when client doesn't have get_max_batch_size method."""
+    def test_add_documents_with_default_max_batch_size(self, mocker, mock_embedding_model):
+        """Test add_documents uses default max_batch_size of 2048."""
         mock_client = MagicMock()
         mock_client.get.return_value = {"ids": []}
-        del mock_client._client  # Remove _client attribute
         mock_client.add_documents.return_value = ["id1"]
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
         content = ["Doc 1"]
         result = vector_store.add_documents(content)
-        # Should use default max_batch_size of 10_000
+        # Should use default max_batch_size of 2048
         assert isinstance(result, list)
+        mock_client.add_documents.assert_called_once()
 
 
 class TestChromaVectorStoreSearch:

--- a/tests/unit/ai4rag/rag/vector_store/test_llama_stack.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_llama_stack.py
@@ -493,6 +493,20 @@ class TestLSVectorStoreAddDocuments:
 
         mock_embed_model.embed_documents.assert_called_once_with(["Test"])
 
+    def test_add_documents_batches_large_input(self, mock_embedding_model, mock_llama_stack_client):
+        """Test that add_documents batches inserts exceeding batch_size."""
+        vector_store = LSVectorStore(
+            embedding_model=mock_embedding_model,
+            client=mock_llama_stack_client,
+            provider_id="milvus",
+        )
+
+        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
+
+        vector_store.add_documents(docs, batch_size=2)
+
+        assert mock_llama_stack_client.vector_io.insert.call_count == 3
+
 
 class TestLSVectorStoreCleanCollection:
     """Test suite for LSVectorStore.clean_collection method."""

--- a/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
@@ -208,8 +208,8 @@ class TestPrepareSearchSpaceWithLlamaStack:
         search_mode_param = result["search_mode"]
         assert search_mode_param.values == ("vector",)
 
-    def test_ls_milvus_vector_store_excludes_hybrid_params_by_default(self, mocker):
-        """Test that ls_milvus vector store type excludes hybrid search parameters by default."""
+    def test_ls_milvus_vector_store_includes_hybrid_params_by_default(self, mocker):
+        """Test that ls_milvus vector store type includes hybrid search parameters by default."""
         mock_client = MagicMock(spec=LlamaStackClient)
 
         mock_llm = Mock()
@@ -235,15 +235,16 @@ class TestPrepareSearchSpaceWithLlamaStack:
 
         param_names = [p.name for p in result.params]
         assert "search_mode" in param_names
-        assert "ranker_strategy" not in param_names
-        assert "ranker_k" not in param_names
-        assert "ranker_alpha" not in param_names
+        assert "ranker_strategy" in param_names
+        assert "ranker_k" in param_names
+        assert "ranker_alpha" in param_names
 
         search_mode_param = result["search_mode"]
-        assert search_mode_param.values == ("vector",)
+        assert "vector" in search_mode_param.values
+        assert "hybrid" in search_mode_param.values
 
     def test_default_vector_store_type_is_ls_milvus(self, mocker):
-        """Test that default vector_store_type is ls_milvus (excludes hybrid params by default)."""
+        """Test that default vector_store_type is ls_milvus (includes hybrid params by default)."""
         mock_client = MagicMock(spec=LlamaStackClient)
 
         mock_llm = Mock()
@@ -269,4 +270,6 @@ class TestPrepareSearchSpaceWithLlamaStack:
 
         param_names = [p.name for p in result.params]
         assert "search_mode" in param_names
-        assert "ranker_strategy" not in param_names
+        assert "ranker_strategy" in param_names
+        assert "ranker_k" in param_names
+        assert "ranker_alpha" in param_names

--- a/tests/unit/ai4rag/search_space/src/test_search_space.py
+++ b/tests/unit/ai4rag/search_space/src/test_search_space.py
@@ -273,17 +273,18 @@ _REQUIRED_PARAMS = [
 
 
 class TestGetDefaultSearchSpaceParameters:
-    def test_ls_milvus_excludes_hybrid_params_by_default(self):
+    def test_ls_milvus_includes_hybrid_params_by_default(self):
         params = get_default_ai4rag_search_space_parameters(vector_store_type="ls_milvus")
         param_names = {p.name for p in params}
 
         assert "search_mode" in param_names
-        assert "ranker_strategy" not in param_names
-        assert "ranker_k" not in param_names
-        assert "ranker_alpha" not in param_names
+        assert "ranker_strategy" in param_names
+        assert "ranker_k" in param_names
+        assert "ranker_alpha" in param_names
 
         search_mode_param = next(p for p in params if p.name == "search_mode")
-        assert search_mode_param.values == ("vector",)
+        assert "vector" in search_mode_param.values
+        assert "hybrid" in search_mode_param.values
 
     def test_chroma_excludes_hybrid_params(self):
         params = get_default_ai4rag_search_space_parameters(vector_store_type="chroma")
@@ -320,13 +321,10 @@ class TestGetDefaultSearchSpaceParameters:
 
 
 class TestAI4RAGSearchSpaceVectorStoreType:
-    def test_ls_milvus_excludes_hybrid_params_by_default(self):
+    def test_ls_milvus_includes_hybrid_params_by_default(self):
         ss = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS), vector_store_type="ls_milvus")
         param_names = {p.name for p in ss.params}
-        assert "search_mode" in param_names
-        assert not _HYBRID_PARAM_NAMES.intersection({"ranker_strategy", "ranker_k", "ranker_alpha"}).intersection(
-            param_names
-        )
+        assert _HYBRID_PARAM_NAMES.issubset(param_names)
 
     def test_chroma_excludes_hybrid_params(self):
         ss = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS), vector_store_type="chroma")
@@ -344,10 +342,7 @@ class TestAI4RAGSearchSpaceVectorStoreType:
     def test_default_vector_store_type_is_ls_milvus(self):
         ss = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS))
         param_names = {p.name for p in ss.params}
-        assert "search_mode" in param_names
-        assert not _HYBRID_PARAM_NAMES.intersection({"ranker_strategy", "ranker_k", "ranker_alpha"}).intersection(
-            param_names
-        )
+        assert _HYBRID_PARAM_NAMES.issubset(param_names)
 
     def test_chroma_does_not_apply_hybrid_rules(self):
         ss = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS), vector_store_type="chroma")
@@ -356,13 +351,27 @@ class TestAI4RAGSearchSpaceVectorStoreType:
             assert "ranker_k" not in combination
             assert "ranker_alpha" not in combination
 
-    def test_ls_milvus_default_only_vector_mode(self):
+    def test_ls_milvus_default_includes_hybrid_mode(self):
         ss = AI4RAGSearchSpace(params=list(_REQUIRED_PARAMS), vector_store_type="ls_milvus")
+        search_modes = {c["search_mode"] for c in ss.combinations}
+        assert "vector" in search_modes
+        assert "hybrid" in search_modes
         for combination in ss.combinations:
-            assert combination.get("search_mode") == "vector"
-            assert "ranker_strategy" not in combination
-            assert "ranker_k" not in combination
-            assert "ranker_alpha" not in combination
+            search_mode = combination.get("search_mode")
+            if search_mode == "vector":
+                assert combination["ranker_strategy"] == ""
+                assert combination["ranker_k"] == 0
+                assert combination["ranker_alpha"] == 1
+            elif search_mode == "hybrid":
+                assert combination["ranker_strategy"] in ("rrf", "weighted")
+                if combination["ranker_strategy"] == "rrf":
+                    assert combination["ranker_k"] > 0
+                else:
+                    assert combination["ranker_k"] == 0
+                if combination["ranker_strategy"] == "weighted":
+                    assert combination["ranker_alpha"] != 1
+                else:
+                    assert combination["ranker_alpha"] == 1
 
     def test_ls_milvus_user_provided_hybrid_params_apply_rules(self):
         hybrid_params = list(_REQUIRED_PARAMS) + [


### PR DESCRIPTION
# Release v0.5.1

## Summary

This patch re-enables hybrid search by default for the `ls_milvus` vector store, which was temporarily disabled in v0.5.0 due to upstream Llama Stack instability. It also introduces batch processing for embeddings and vector store inserts to handle large document sets, and streamlines the default search space for faster optimization runs.

## Changes

### Added
- Batch processing for Llama Stack embeddings (2048 chunk limit) and vector store document insertion, preventing failures with large document sets

### Changed
- Hybrid search re-enabled by default in the `ls_milvus` default search space (was disabled in 0.5.0 due to upstream instability)
- Default chunk sizes narrowed from `(512, 1024, 2048, 4096)` to `(1024, 2048)` and overlaps from `(128, 256, 512)` to `(128, 256)` for faster optimization
- Chroma vector store batch size simplified to a fixed default of 2048 instead of querying client internals
- Chroma window retrieval now preserves full chunk metadata

## Migration notes

No breaking changes. Users relying on the previous default search space (which excluded hybrid search for `ls_milvus`) will now see hybrid search combinations explored automatically. To restore the previous behavior, explicitly set `search_mode` to `("vector",)` in your search space parameters.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.5.1`
- [x] `docs/about/changelog.md` updated
- [x] All tests pass (`pytest`)
- [x] Docs build successfully
