### PR TITLE
Support multiple llama-stack vector stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,8 @@ ruff_cache/
 
 # --- Local data ---
 data/
-local
+local/
+tmp/
 *.sqlite3
 
 # --- Misc ---

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ optimizer_settings = GAMOptSettings(
 Using the information from the previous steps, create an experiment and run the ai4rag optimization engine.
 
 > [!note]
-> To use Milvus via Llama Stack, specify `"ls_milvus"` as the `vector_store_type`.
+> For Llama Stack vector stores, use the `"ls_<provider_id>"` format where `<provider_id>` matches your Llama Stack
+> provider configuration (e.g., `"ls_milvus"`, `"ls_qdrant"`).
 > To use ChromaDB in-memory, specify `"chroma"`.
 
 ```python

--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 import time
 from dataclasses import asdict, is_dataclass
-from typing import Any, Literal, Sequence
+from typing import Any, Sequence
 
 import pandas as pd
 from langchain_core.documents import Document
@@ -75,7 +75,7 @@ class AI4RAGExperiment:
     search_space : AI4RAGSearchSpace
         Grid of parameters used during hyperparameter optimization.
 
-    vector_store_type : Literal["chroma", "ls_milvus"]
+    vector_store_type : str
         Specific type of Vector Data Base that will be used during the experiment.
 
     optimizer_settings : OptimizerSettings
@@ -129,7 +129,7 @@ class AI4RAGExperiment:
         documents: list[Document],
         benchmark_data: pd.DataFrame,
         search_space: AI4RAGSearchSpace,
-        vector_store_type: Literal["chroma", "ls_milvus"],
+        vector_store_type: str,
         optimizer_settings: OptimizerSettings,
         event_handler: BaseEventHandler,
         client: LlamaStackClient | Any = None,

--- a/ai4rag/rag/vector_store/get_vector_store.py
+++ b/ai4rag/rag/vector_store/get_vector_store.py
@@ -45,7 +45,7 @@ def get_vector_store(
                 reuse_collection_name=reuse_collection_name,
             )
 
-        case str() as vs_type if vs_type.startswith("ls_"):
+        case str() as vs_type if vs_type.startswith("ls_") and len(vs_type) > 3:
             provider_id = vs_type[3:]
             vs = LSVectorStore(
                 embedding_model=embedding_model,

--- a/ai4rag/rag/vector_store/get_vector_store.py
+++ b/ai4rag/rag/vector_store/get_vector_store.py
@@ -45,7 +45,7 @@ def get_vector_store(
                 reuse_collection_name=reuse_collection_name,
             )
 
-        case str(vs_type) if vs_type.startswith("ls_"):
+        case str() as vs_type if vs_type.startswith("ls_"):
             provider_id = vs_type[3:]
             vs = LSVectorStore(
                 embedding_model=embedding_model,

--- a/ai4rag/rag/vector_store/get_vector_store.py
+++ b/ai4rag/rag/vector_store/get_vector_store.py
@@ -45,13 +45,14 @@ def get_vector_store(
                 reuse_collection_name=reuse_collection_name,
             )
 
-        case "ls_milvus":
+        case str(vs_type) if vs_type.startswith("ls_"):
+            provider_id = vs_type[3:]
             vs = LSVectorStore(
                 embedding_model=embedding_model,
                 reuse_collection_name=reuse_collection_name,
                 distance_metric="cosine",
                 client=client,
-                provider_id="milvus",
+                provider_id=provider_id,
             )
 
         case _:

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -40,8 +40,9 @@ def prepare_search_space_with_llama_stack(
         Client instance for listing and validating available models.
 
     vector_store_type : str, default="ls_milvus"
-        Type of vector store. When "chroma", hybrid search parameters are excluded
-        from the default search space since ChromaDB does not support hybrid search.
+        Type of vector store. Use "ls_<provider_id>" for Llama Stack vector stores
+        (e.g., "ls_milvus", "ls_qdrant"). When "chroma", hybrid search parameters
+        are excluded from the default search space since ChromaDB does not support hybrid search.
 
     Returns
     -------

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -31,8 +31,9 @@ def get_default_ai4rag_search_space_parameters(vector_store_type: str = "ls_milv
     Parameters
     ----------
     vector_store_type : str, default="ls_milvus"
-        Type of vector store. When "chroma", hybrid search parameters are excluded
-        since ChromaDB does not support hybrid search.
+        Type of vector store. Use "ls_<provider_id>" for Llama Stack vector stores
+        (e.g., "ls_milvus", "ls_qdrant"). When "chroma", hybrid search parameters
+        are excluded since ChromaDB does not support hybrid search.
 
     Returns
     -------

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -324,8 +324,9 @@ class AI4RAGSearchSpace(SearchSpace):
         List of functions - called "rules" - that will be applied on each combination in the search space.
 
     vector_store_type : str, default="ls_milvus"
-        Type of vector store. When "chroma", hybrid search parameters are excluded
-        from the default search space since ChromaDB does not support hybrid search.
+        Type of vector store. Use "ls_<provider_id>" for Llama Stack vector stores
+        (e.g., "ls_milvus", "ls_qdrant"). When "chroma", hybrid search parameters
+        are excluded from the default search space since ChromaDB does not support hybrid search.
     """
 
     _base_rules = (

--- a/dev_utils/run_experiment.py
+++ b/dev_utils/run_experiment.py
@@ -48,9 +48,7 @@ if __name__ == "__main__":
             Parameter(
                 name="foundation_model",
                 param_type="C",
-                values=[
-                    LSFoundationModel(model_id="vllm-inference-qwen/qwen25-7b-instruct", client=client)
-                ],
+                values=[LSFoundationModel(model_id="vllm-inference-qwen/qwen25-7b-instruct", client=client)],
             ),
             Parameter(
                 name="embedding_model",
@@ -63,10 +61,7 @@ if __name__ == "__main__":
                     )
                 ],
             ),
-            Parameter(
-                name="search_mode",
-                values=["hybrid"]
-            )
+            Parameter(name="search_mode", values=["hybrid"]),
         ],
     )
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.2](https://github.com/IBM/ai4rag/releases/tag/v0.5.2)
+
+### Changed
+- Vector store type now supports any Llama Stack provider via the `ls_<provider_id>` pattern (e.g., `ls_milvus`, `ls_qdrant`), instead of only the hardcoded `ls_milvus`
+- `vector_store_type` parameter on `AI4RAGExperiment` changed from `Literal["chroma", "ls_milvus"]` to `str` for flexibility
+
+### Fixed
+- Fixed `provider_id` extraction in `get_vector_store` — previously hardcoded to `"milvus"`, now correctly derived from the `ls_<provider_id>` vector store type
+
+---
+
 ## [0.5.1](https://github.com/IBM/ai4rag/releases/tag/v0.5.1)
 
 ### Added

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -175,7 +175,7 @@ Chunking (chunk_size, chunk_overlap)
     ↓
 Embedding Model (embedding_model)
     ↓
-Vector Store (ls_milvus or chroma)
+Vector Store (ls_<provider_id> or chroma)
 ```
 
 ### Query Phase (Per Configuration)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -203,7 +203,7 @@ experiment = AI4RAGExperiment(
     documents=documents,
     benchmark_data=benchmark_data,
     search_space=search_space,
-    vector_store_type="ls_milvus",  # or "chroma" for in-memory
+    vector_store_type="ls_milvus",  # "ls_<provider_id>" for Llama Stack, or "chroma" for in-memory
     optimizer_settings=optimizer_settings,
     event_handler=LocalEventHandler(output_path="<path_to_store_results>"),  # Tracks progress
 )

--- a/docs/user-guide/hybrid-search.md
+++ b/docs/user-guide/hybrid-search.md
@@ -40,13 +40,13 @@ Consider enabling hybrid search when:
 ## Prerequisites
 
 !!! warning "Vector Store Requirement"
-    Hybrid search is **only supported with `ls_milvus`** (Milvus via Llama Stack). It is **NOT available with ChromaDB**.
+    Hybrid search is **only supported with Llama Stack vector stores** (i.e., `vector_store_type` with `ls_` prefix, e.g., `"ls_milvus"`). It is **NOT available with ChromaDB**.
 
 Ensure your experiment is configured with:
 
 ```python
 experiment = AI4RAGExperiment(
-    vector_store_type="ls_milvus",  # Required for hybrid search
+    vector_store_type="ls_milvus",  # Any "ls_<provider_id>" works; required for hybrid search
     # ... other parameters
 )
 ```
@@ -535,11 +535,11 @@ print("Hybrid avg score:", hybrid_results["objective_value"].mean())
 
 **Cause**: You're using `vector_store_type="chroma"`.
 
-**Solution**: Switch to Milvus via Llama Stack:
+**Solution**: Switch to a Llama Stack vector store:
 
 ```python
 experiment = AI4RAGExperiment(
-    vector_store_type="ls_milvus",  # Required
+    vector_store_type="ls_milvus",  # Any "ls_<provider_id>" format works
     # ...
 )
 ```
@@ -588,7 +588,7 @@ experiment = AI4RAGExperiment(
 
 Hybrid search in `ai4rag` combines the best of semantic and keyword-based retrieval:
 
-- **Use `search_mode="hybrid"`** to enable hybrid search (requires `ls_milvus`)
+- **Use `search_mode="hybrid"`** to enable hybrid search (requires a Llama Stack vector store, i.e., `ls_` prefix)
 - **Choose a ranker strategy**: `"rrf"` (general-purpose), `"weighted"` (fine control), or `"normalized"`
 - **Configure strategy parameters**: `ranker_k` for RRF, `ranker_alpha` for weighted
 - **Let the optimizer explore**: Include both vector and hybrid modes to find the best approach

--- a/samples/run_ai4rag.ipynb
+++ b/samples/run_ai4rag.ipynb
@@ -493,7 +493,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "### Prepare LlamaStackClient\n\nThe following sections allow you to run the `ai4rag` experiment using Llama Stack.\nTo do so, you need to provide an instance of the `LlamaStackClient`.\nTo instantiate the client, you must provide `LLAMA_STACK_CLIENT_API_KEY` and `LLAMA_STACK_CLIENT_BASE_URL` environment variables or provide them in the password prompt after running the cell below.\n\n🔖 **Note**: To use `ai4rag` with Llama Stack, at least 1 foundation model, 1 embedding model, and a connected Milvus instance should be available on the server side.",
+   "source": "### Prepare LlamaStackClient\n\nThe following sections allow you to run the `ai4rag` experiment using Llama Stack.\nTo do so, you need to provide an instance of the `LlamaStackClient`.\nTo instantiate the client, you must provide `LLAMA_STACK_CLIENT_API_KEY` and `LLAMA_STACK_CLIENT_BASE_URL` environment variables or provide them in the password prompt after running the cell below.\n\n🔖 **Note**: To use `ai4rag` with Llama Stack, at least 1 foundation model, 1 embedding model, and a connected vector store (e.g., Milvus) should be available on the server side.",
    "id": "5dfc1e443cd959c4"
   },
   {
@@ -586,7 +586,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "### Create and run the experiment\n\nNow you are ready to create and run your experiment. There are several parameters in the `AI4RAGExperiment` class:\n- `client`: expects an instance of `LlamaStackClient` that will be used for communication with the Milvus vector database\n- `documents`: documents with proper metadata used as a knowledge base for the LLM\n- `benchmark_data`: records to properly evaluate the LLM's responses\n- `search_space`: defined parameters that create the space of RAG patterns\n- `optimizer_settings`: controls the optimization process\n- `optimization_metric`: defines the metric for which the RAG pattern will be optimized\n- `event_handler`: allows you to monitor status updates and handle results after each iteration\n- `vector_store_type`: defines which vector database to use (`\"ls_milvus\"` uses Llama Stack Milvus)",
+   "source": "### Create and run the experiment\n\nNow you are ready to create and run your experiment. There are several parameters in the `AI4RAGExperiment` class:\n- `client`: expects an instance of `LlamaStackClient` that will be used for communication with the vector database\n- `documents`: documents with proper metadata used as a knowledge base for the LLM\n- `benchmark_data`: records to properly evaluate the LLM's responses\n- `search_space`: defined parameters that create the space of RAG patterns\n- `optimizer_settings`: controls the optimization process\n- `optimization_metric`: defines the metric for which the RAG pattern will be optimized\n- `event_handler`: allows you to monitor status updates and handle results after each iteration\n- `vector_store_type`: defines which vector database to use. Use `\"ls_<provider_id>\"` format for Llama Stack vector stores (e.g., `\"ls_milvus\"`, `\"ls_qdrant\"`), or `\"chroma\"` for in-memory ChromaDB",
    "id": "9f469e81f95bd3c9"
   },
   {

--- a/tests/unit/ai4rag/rag/vector_store/test_get_vector_store.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_get_vector_store.py
@@ -76,8 +76,8 @@ class TestGetVectorStoreChroma:
         assert isinstance(vector_store, ChromaVectorStore)
 
 
-class TestGetVectorStoreLSMilvus:
-    """Test suite for get_vector_store with ls_milvus type."""
+class TestGetVectorStoreLlamaStack:
+    """Test suite for get_vector_store with ls_ prefix types."""
 
     @pytest.fixture
     def mock_embedding_model(self):
@@ -124,7 +124,7 @@ class TestGetVectorStoreLSMilvus:
         mock_client.vector_stores.retrieve.assert_called_once_with("existing-collection")
 
     def test_get_vector_store_ls_milvus_uses_milvus_provider(self, mock_embedding_model, mock_llama_stack_client):
-        """Test that ls_milvus uses milvus provider_id."""
+        """Test that ls_milvus extracts milvus as provider_id."""
         vector_store = get_vector_store(
             vs_type="ls_milvus",
             embedding_model=mock_embedding_model,
@@ -134,11 +134,33 @@ class TestGetVectorStoreLSMilvus:
         call_kwargs = mock_llama_stack_client.vector_stores.create.call_args.kwargs
         assert call_kwargs["extra_body"]["provider_id"] == "milvus"
 
-    def test_get_vector_store_ls_milvus_requires_client(self, mock_embedding_model):
-        """Test that ls_milvus requires a client parameter."""
-        # This should raise an error or handle None client gracefully
+    @pytest.mark.parametrize(
+        "vs_type, expected_provider_id",
+        [
+            ("ls_qdrant", "qdrant"),
+            ("ls_faiss", "faiss"),
+            ("ls_chromadb", "chromadb"),
+            ("ls_milvus", "milvus"),
+        ],
+    )
+    def test_get_vector_store_ls_prefix_extracts_provider_id(
+        self, mock_embedding_model, mock_llama_stack_client, vs_type, expected_provider_id
+    ):
+        """Test that any ls_ prefix type extracts the correct provider_id."""
+        vector_store = get_vector_store(
+            vs_type=vs_type,
+            embedding_model=mock_embedding_model,
+            client=mock_llama_stack_client,
+        )
+
+        assert isinstance(vector_store, LSVectorStore)
+        call_kwargs = mock_llama_stack_client.vector_stores.create.call_args.kwargs
+        assert call_kwargs["extra_body"]["provider_id"] == expected_provider_id
+
+    def test_get_vector_store_ls_prefix_requires_client(self, mock_embedding_model):
+        """Test that ls_ prefix types require a client parameter."""
         with pytest.raises(AttributeError):
-            vector_store = get_vector_store(
+            get_vector_store(
                 vs_type="ls_milvus",
                 embedding_model=mock_embedding_model,
                 client=None,
@@ -221,7 +243,7 @@ class TestGetVectorStoreEdgeCases:
 
     def test_get_vector_store_similar_type_names(self, mock_embedding_model):
         """Test that similar but incorrect type names raise errors."""
-        invalid_types = ["chromadb", "chroma_db", "milvus", "ls_milvus_"]
+        invalid_types = ["chromadb", "chroma_db", "milvus"]
 
         for invalid_type in invalid_types:
             with pytest.raises(ValueError):
@@ -255,8 +277,8 @@ class TestGetVectorStoreReturnTypes:
         assert callable(vector_store.search)
         assert callable(vector_store.add_documents)
 
-    def test_ls_milvus_returns_base_vector_store_interface(self, mock_embedding_model):
-        """Test that ls_milvus vector store implements BaseVectorStore interface."""
+    def test_ls_prefix_returns_base_vector_store_interface(self, mock_embedding_model):
+        """Test that ls_ prefix vector store implements BaseVectorStore interface."""
         mock_client = MagicMock()
         mock_vs = MagicMock()
         mock_vs.id = "test-id"
@@ -298,8 +320,8 @@ class TestGetVectorStoreWithNoneParameters:
         # Should use auto-generated collection name
         assert vector_store.collection_name is not None
 
-    def test_get_vector_store_ls_milvus_with_none_collection_name(self, mock_embedding_model):
-        """Test ls_milvus with None collection name creates new store."""
+    def test_get_vector_store_ls_prefix_with_none_collection_name(self, mock_embedding_model):
+        """Test ls_ prefix type with None collection name creates new store."""
         mock_client = MagicMock()
         mock_vs = MagicMock()
         mock_vs.id = "new-vs-id"

--- a/tests/unit/ai4rag/rag/vector_store/test_get_vector_store.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_get_vector_store.py
@@ -166,6 +166,24 @@ class TestGetVectorStoreLlamaStack:
                 client=None,
             )
 
+    def test_get_vector_store_ls_empty_provider_id_raises_error(self, mock_embedding_model, mock_llama_stack_client):
+        """Test that ls_ with no provider_id raises ValueError."""
+        with pytest.raises(ValueError, match="not supported"):
+            get_vector_store(
+                vs_type="ls_",
+                embedding_model=mock_embedding_model,
+                client=mock_llama_stack_client,
+            )
+
+    def test_get_vector_store_ls_prefix_is_case_sensitive(self, mock_embedding_model, mock_llama_stack_client):
+        """Test that ls_ prefix matching is case-sensitive."""
+        with pytest.raises(ValueError):
+            get_vector_store(
+                vs_type="LS_MILVUS",
+                embedding_model=mock_embedding_model,
+                client=mock_llama_stack_client,
+            )
+
 
 class TestGetVectorStoreInvalidType:
     """Test suite for get_vector_store with invalid type."""


### PR DESCRIPTION
# Release v0.5.2

## Summary

This patch release generalizes Llama Stack vector store support so that any provider can be used via the `ls_<provider_id>` naming convention (e.g., `ls_milvus`, `ls_qdrant`), removing the previous hardcoded dependency on Milvus. Existing `ls_milvus` configurations continue to work without changes.

## Changes

### Changed
- Vector store type now supports any Llama Stack provider via the `ls_<provider_id>` pattern (e.g., `ls_milvus`, `ls_qdrant`), instead of only the hardcoded `ls_milvus`
- `vector_store_type` parameter on `AI4RAGExperiment` changed from `Literal["chroma", "ls_milvus"]` to `str` for flexibility

### Fixed
- Fixed `provider_id` extraction in `get_vector_store` — previously hardcoded to `"milvus"`, now correctly derived from the `ls_<provider_id>` vector store type

## Migration notes

No breaking changes. Existing configurations using `vector_store_type="ls_milvus"` or `vector_store_type="chroma"` continue to work identically. To use a different Llama Stack vector store, specify `vector_store_type="ls_<provider_id>"` where `<provider_id>` matches your Llama Stack server configuration.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.5.2`
- [ ] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
