### PR TITLE
Release 0.5.4

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/rag/vector_store/llama_stack.py
+++ b/ai4rag/rag/vector_store/llama_stack.py
@@ -224,8 +224,11 @@ class LSVectorStore(BaseVectorStore):
         chunks = [
             {
                 "content": doc.page_content,
-                "chunk_metadata": doc.metadata,
-                "chunk_id": doc.metadata["document_id"],
+                "chunk_metadata": {
+                    "document_id": doc.metadata["document_id"],
+                },
+                "metadata": doc.metadata,
+                "chunk_id": str(hash(doc.page_content)),
                 "embedding_model": self.embedding_model.model_id,
                 "embedding_dimension": embedding_dimension,
             }

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.4](https://github.com/IBM/ai4rag/releases/tag/v0.5.4)
+
+### Fixed
+- Fixed chunk ID collisions in `LSVectorStore` — chunks from the same document no longer share the same `chunk_id`; IDs are now derived from chunk content via hashing
+- Fixed `chunk_metadata` in `LSVectorStore` to only contain `document_id`, with full document metadata preserved in a separate `metadata` field
+
+---
+
 ## [0.5.3](https://github.com/IBM/ai4rag/releases/tag/v0.5.3)
 
 ### Changed

--- a/tests/unit/ai4rag/rag/vector_store/test_llama_stack.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_llama_stack.py
@@ -435,7 +435,9 @@ class TestLSVectorStoreAddDocuments:
         assert "content" in chunks[0]
         assert "embedding" in chunks[0]
         assert "chunk_id" in chunks[0]
-        assert chunks[0]["chunk_id"] == "doc1"
+        assert chunks[0]["chunk_id"] == str(hash("Test"))
+        assert chunks[0]["chunk_metadata"] == {"document_id": "doc1"}
+        assert chunks[0]["metadata"] == {"document_id": "doc1"}
 
     def test_add_documents_multiple(self, mock_embedding_model, mock_llama_stack_client):
         """Test adding multiple documents."""
@@ -474,7 +476,9 @@ class TestLSVectorStoreAddDocuments:
         call_kwargs = mock_llama_stack_client.vector_io.insert.call_args.kwargs
         chunks = call_kwargs["chunks"]
 
-        assert chunks[0]["chunk_metadata"]["custom_field"] == "value"
+        assert chunks[0]["chunk_metadata"] == {"document_id": "doc1"}
+        assert chunks[0]["metadata"]["custom_field"] == "value"
+        assert chunks[0]["metadata"]["document_id"] == "doc1"
 
     def test_add_documents_uses_embedding_model(self, mock_llama_stack_client):
         """Test that add_documents uses the embedding model."""


### PR DESCRIPTION
Assisted-by: Claude Code

# Release v0.5.4

## Summary

This patch release fixes a bug in the Llama Stack vector store where all chunks originating from the same document were assigned the same `chunk_id` (the document ID), causing chunk collisions during insertion. Chunk IDs are now derived from content hashing, ensuring uniqueness. The chunk metadata structure has also been cleaned up to separate chunk-level metadata from full document metadata.

## Changes

### Fixed
- Fixed chunk ID collisions in `LSVectorStore` — chunks from the same document no longer share the same `chunk_id`; IDs are now derived from chunk content via hashing
- Fixed `chunk_metadata` in `LSVectorStore` to only contain `document_id`, with full document metadata preserved in a separate `metadata` field

## Migration notes

No breaking changes. The `chunk_id` values stored in Llama Stack vector stores will differ from previous versions (content hash instead of document ID). If you have existing vector stores and rely on `chunk_id` values externally, be aware of this change. Re-indexing is recommended for consistency.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.5.4`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
