### PR TITLE
Update error message for search space preparation with not responding models

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,4 +63,4 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=ai4rag --cov-report=term --cov-report=html --cov-fail-under=90
+          pytest tests/unit --cov=ai4rag --cov-report=term --cov-report=html --cov-fail-under=90

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -15,6 +15,8 @@ from ai4rag.search_space.src.exceptions import SearchSpaceValueError
 class _DefaultModelsResponseType(TypedDict):
     foundation_models: list[LSFoundationModel]
     embedding_models: list[LSEmbeddingModel]
+    not_responding_foundation_models: list[LSFoundationModel]
+    not_responding_embedding_models: list[LSEmbeddingModel]
 
 
 def _validate_foundation_model(model: LSFoundationModel) -> bool:
@@ -95,32 +97,94 @@ def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsR
     ]
 
     # Validate each model
+    foundation_models = []
+    not_responding_foundation_models = []
     logger.info("Validating foundation models...")
-    foundation_models = [m for m in foundation_models_unvalidated if _validate_foundation_model(m)]
+    for fm_el in foundation_models_unvalidated:
+        if _validate_foundation_model(fm_el):
+            foundation_models.append(fm_el)
+        else:
+            not_responding_foundation_models.append(fm_el)
 
+    embedding_models = []
+    not_responding_embedding_models = []
     logger.info("Validating embedding models...")
-    embedding_models = [m for m in embedding_models_unvalidated if _validate_embedding_model(m)]
+    for em_el in embedding_models_unvalidated:
+        if _validate_embedding_model(em_el):
+            embedding_models.append(em_el)
+        else:
+            not_responding_embedding_models.append(em_el)
 
     if not foundation_models:
-        raise SearchSpaceValueError("There are no available models of type 'llm'.")
+        raise SearchSpaceValueError(
+            "There are no available models of type 'llm' or the ones registered are not responding. "
+            "Please look at the full logs."
+        )
     if not embedding_models:
-        raise SearchSpaceValueError("There are no available models of type 'embedding'.")
+        raise SearchSpaceValueError(
+            "There are no available models of type 'embedding' or the ones registered are not responding. "
+            "Please look at the full logs."
+        )
 
-    logger.info("Selected default foundation models: %s.", foundation_models)
-    logger.info("Selected default embedding models: %s.", embedding_models)
+    logger.info("Available foundation models: %s.", foundation_models)
+    logger.info("Available embedding models: %s.", embedding_models)
 
-    return {"foundation_models": foundation_models, "embedding_models": embedding_models}
+    return {
+        "foundation_models": foundation_models,
+        "embedding_models": embedding_models,
+        "not_responding_foundation_models": not_responding_foundation_models,
+        "not_responding_embedding_models": not_responding_embedding_models,
+    }
 
 
 def _are_provided_models_available(
-    provided_models: list, available_models: list[LSFoundationModel | LSEmbeddingModel]
-) -> bool:
-    """Check whether models provided by the user are available for the experiment."""
+    provided_models: list,
+    available_models: list[LSFoundationModel | LSEmbeddingModel],
+    not_responding_models: list[LSFoundationModel | LSEmbeddingModel],
+) -> None:
+    """
+    Check whether models provided by the user are available for the experiment.
 
-    available_ids = [m.model_id for m in available_models]
+    Parameters
+    ----------
+    provided_models : list
+        Models provided by the user in the input payload.
 
-    for model in provided_models:
-        m_id = model.model_id
-        if m_id not in available_ids:
-            raise SearchSpaceValueError(f"Provided model with model_id: '{m_id}' is not available for the experiment.")
-    return True
+    available_models : list[LSFoundationModel | LSEmbeddingModel]
+        Models registered within llama-stack.
+
+    not_responding_models : list[LSFoundationModel | LSEmbeddingModel]
+        Models that are registered within llama-stack but do not respond.
+
+    Raises
+    ------
+    SearchSpaceValueError
+        When some of the models provided by the user are not available for the experiment
+        or some of the models do not respond.
+    """
+
+    available_model_ids = [m.model_id for m in available_models]
+    not_responding_model_ids = [m.model_id for m in not_responding_models]
+
+    user_not_responding_models = [m.model_id for m in provided_models if m.model_id in not_responding_model_ids]
+    user_unavailable_models = [
+        m.model_id
+        for m in provided_models
+        if m.model_id not in available_model_ids and m.model_id not in not_responding_model_ids
+    ]
+
+    log = []
+    if user_not_responding_models:
+        log.append(
+            f"Provided models: `{user_not_responding_models}` are registered but do not respond. "
+            f"Remove these models from the experiment configuration and try again."
+        )
+
+    if user_unavailable_models:
+        log.append(
+            f"Provided models: `{user_unavailable_models}` are not registered within llama-stack. "
+            f"Register these models or try different model for the experiment."
+        )
+
+    if log:
+        raise SearchSpaceValueError("\n".join(log))

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -179,14 +179,14 @@ def _are_provided_models_available(
     error_messages = []
     if user_not_responding_models:
         error_messages.append(
-            f"Provided models: `{user_not_responding_models}` are registered but do not respond. "
-            f"Remove these models from the experiment configuration and try again."
+            f"Provided models: {user_not_responding_models} are registered but do not respond. "
+            "Remove these models from the experiment configuration and try again."
         )
 
     if user_unavailable_models:
         error_messages.append(
-            f"Provided models: `{user_unavailable_models}` are not registered within llama-stack. "
-            f"Register these models or try a different model for the experiment."
+            f"Provided models: {user_unavailable_models} are not registered within llama-stack. "
+            "Register these models or try a different model for the experiment."
         )
 
     if error_messages:

--- a/ai4rag/search_space/prepare/llama_stack_utils.py
+++ b/ai4rag/search_space/prepare/llama_stack_utils.py
@@ -9,6 +9,7 @@ from llama_stack_client import LlamaStackClient
 from ai4rag import logger
 from ai4rag.rag.embedding.llama_stack import LSEmbeddingModel, LSEmbeddingParams
 from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+from ai4rag.search_space.prepare.input_payload_types import AI4RAGEmbeddingModel, AI4RAGFoundationModel
 from ai4rag.search_space.src.exceptions import SearchSpaceValueError
 
 
@@ -117,12 +118,14 @@ def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsR
 
     if not foundation_models:
         raise SearchSpaceValueError(
-            "There are no available models of type 'llm' or the ones registered are not responding. "
+            "There are no available models of type 'llm' or the ones registered are not responding: "
+            f"{[m.model_id for m in not_responding_foundation_models]}. "
             "Please look at the full logs."
         )
     if not embedding_models:
         raise SearchSpaceValueError(
-            "There are no available models of type 'embedding' or the ones registered are not responding. "
+            "There are no available models of type 'embedding' or the ones registered are not responding: "
+            f"{[m.model_id for m in not_responding_embedding_models]}. "
             "Please look at the full logs."
         )
 
@@ -138,7 +141,7 @@ def _get_default_llama_stack_models(client: LlamaStackClient) -> _DefaultModelsR
 
 
 def _are_provided_models_available(
-    provided_models: list,
+    provided_models: list[AI4RAGFoundationModel] | list[AI4RAGEmbeddingModel],
     available_models: list[LSFoundationModel | LSEmbeddingModel],
     not_responding_models: list[LSFoundationModel | LSEmbeddingModel],
 ) -> None:
@@ -147,11 +150,11 @@ def _are_provided_models_available(
 
     Parameters
     ----------
-    provided_models : list
+    provided_models : list[AI4RAGFoundationModel] | list[AI4RAGEmbeddingModel]
         Models provided by the user in the input payload.
 
     available_models : list[LSFoundationModel | LSEmbeddingModel]
-        Models registered within llama-stack.
+        Models registered within llama-stack that passed validation (respond to requests).
 
     not_responding_models : list[LSFoundationModel | LSEmbeddingModel]
         Models that are registered within llama-stack but do not respond.
@@ -173,18 +176,18 @@ def _are_provided_models_available(
         if m.model_id not in available_model_ids and m.model_id not in not_responding_model_ids
     ]
 
-    log = []
+    error_messages = []
     if user_not_responding_models:
-        log.append(
+        error_messages.append(
             f"Provided models: `{user_not_responding_models}` are registered but do not respond. "
             f"Remove these models from the experiment configuration and try again."
         )
 
     if user_unavailable_models:
-        log.append(
+        error_messages.append(
             f"Provided models: `{user_unavailable_models}` are not registered within llama-stack. "
-            f"Register these models or try different model for the experiment."
+            f"Register these models or try a different model for the experiment."
         )
 
-    if log:
-        raise SearchSpaceValueError("\n".join(log))
+    if error_messages:
+        raise SearchSpaceValueError("\n".join(error_messages))

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -72,9 +72,17 @@ def prepare_search_space_with_llama_stack(
         raise SearchSpaceValueError(f"Unrecognized client type: '{client.__class__.__name__}'")
 
     if validated_payload.foundation_models:
-        _are_provided_models_available(validated_payload.foundation_models, default_foundation_models)
+        _are_provided_models_available(
+            provided_models=validated_payload.foundation_models,
+            available_models=default_foundation_models,
+            not_responding_models=models["not_responding_foundation_models"],
+        )
     if validated_payload.embedding_models:
-        _are_provided_models_available(validated_payload.embedding_models, default_embedding_models)
+        _are_provided_models_available(
+            provided_models=validated_payload.embedding_models,
+            available_models=default_embedding_models,
+            not_responding_models=models["not_responding_embedding_models"],
+        )
 
     # Transform user models into llama-stack based models
     if validated_payload.foundation_models is not None:
@@ -112,6 +120,9 @@ def prepare_search_space_with_llama_stack(
             name="embedding_model",
             values=default_embedding_models,
         )
+
+    logger.info("Selected foundation models for the experiment: %s.", [m.model_id for m in fms_param.values])
+    logger.info("Selected embedding models for the experiment: %s.", [m.model_id for m in ems_param.values])
 
     return AI4RAGSearchSpace(
         params=[fms_param, ems_param],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ namespaces = false
 
 
 [tool.pytest.ini_options]
-python_files = ["tests/unit/*.py"]
+python_files = ["tests/*.py"]
 log_cli = false
 log_level = "INFO"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ namespaces = false
 
 
 [tool.pytest.ini_options]
-python_files = ["tests/*.py"]
+python_files = ["tests/**/*.py"]
 log_cli = false
 log_level = "INFO"
 

--- a/tests/functional/test_prepare_search_space.py
+++ b/tests/functional/test_prepare_search_space.py
@@ -1,0 +1,74 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+"""Functional tests for prepare_search_space_with_llama_stack against a live Llama Stack server."""
+
+import os
+
+import pytest
+from dotenv import find_dotenv, load_dotenv
+from llama_stack_client import LlamaStackClient
+
+from ai4rag.search_space.prepare import prepare_search_space_with_llama_stack
+from ai4rag.search_space.src.exceptions import SearchSpaceValueError
+
+load_dotenv(find_dotenv())
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("LLAMA_STACK_CLIENT_BASE_URL") is None,
+    reason="LLAMA_STACK_CLIENT_BASE_URL environment variable not set",
+)
+
+
+@pytest.fixture(scope="module")
+def client():
+    return LlamaStackClient(
+        base_url=os.environ["LLAMA_STACK_CLIENT_BASE_URL"],
+        api_key=os.environ.get("LLAMA_STACK_CLIENT_API_KEY", ""),
+    )
+
+
+class TestPrepareSearchSpaceWithLlamaStack:
+    """Prepare search space against a live Llama Stack server."""
+
+    def test_empty_payload_builds_search_space_with_discovered_models(self, client):
+        """Empty payload discovers and validates all server models, builds a complete search space."""
+        result = prepare_search_space_with_llama_stack({}, client)
+
+        param_names = [p.name for p in result.params]
+        assert "foundation_model" in param_names
+        assert "embedding_model" in param_names
+
+        assert len(result["foundation_model"].values) >= 1
+        assert len(result["embedding_model"].values) >= 1
+
+        assert "chunk_size" in param_names
+        assert "chunking_method" in param_names
+        assert "retrieval_method" in param_names
+
+    def test_user_payload_with_specific_models(self, client):
+        """User-specified models that exist on the server appear in the resulting search space."""
+        discovered = prepare_search_space_with_llama_stack({}, client)
+        fm_id = discovered["foundation_model"].values[0].model_id
+        em_id = discovered["embedding_model"].values[0].model_id
+
+        payload = {
+            "foundation_models": [{"model_id": fm_id}],
+            "embedding_models": [{"model_id": em_id}],
+        }
+
+        result = prepare_search_space_with_llama_stack(payload, client)
+
+        fm_ids = [m.model_id for m in result["foundation_model"].values]
+        em_ids = [m.model_id for m in result["embedding_model"].values]
+        assert fm_ids == [fm_id]
+        assert em_ids == [em_id]
+
+    def test_unregistered_model_raises_error(self, client):
+        """Requesting a model that does not exist on the server raises a clear error."""
+        payload = {"foundation_models": [{"model_id": "nonexistent-model-xyz"}]}
+
+        with pytest.raises(SearchSpaceValueError, match="nonexistent-model-xyz"):
+            prepare_search_space_with_llama_stack(payload, client)

--- a/tests/functional/test_prepare_search_space.py
+++ b/tests/functional/test_prepare_search_space.py
@@ -30,29 +30,32 @@ def client():
     )
 
 
+@pytest.fixture(scope="module")
+def discovered_search_space(client):
+    """Discover models once and reuse across tests that need valid model IDs."""
+    return prepare_search_space_with_llama_stack({}, client)
+
+
 class TestPrepareSearchSpaceWithLlamaStack:
     """Prepare search space against a live Llama Stack server."""
 
-    def test_empty_payload_builds_search_space_with_discovered_models(self, client):
+    def test_empty_payload_builds_search_space_with_discovered_models(self, discovered_search_space):
         """Empty payload discovers and validates all server models, builds a complete search space."""
-        result = prepare_search_space_with_llama_stack({}, client)
-
-        param_names = [p.name for p in result.params]
+        param_names = [p.name for p in discovered_search_space.params]
         assert "foundation_model" in param_names
         assert "embedding_model" in param_names
 
-        assert len(result["foundation_model"].values) >= 1
-        assert len(result["embedding_model"].values) >= 1
+        assert len(discovered_search_space["foundation_model"].values) >= 1
+        assert len(discovered_search_space["embedding_model"].values) >= 1
 
         assert "chunk_size" in param_names
         assert "chunking_method" in param_names
         assert "retrieval_method" in param_names
 
-    def test_user_payload_with_specific_models(self, client):
+    def test_user_payload_with_specific_models(self, client, discovered_search_space):
         """User-specified models that exist on the server appear in the resulting search space."""
-        discovered = prepare_search_space_with_llama_stack({}, client)
-        fm_id = discovered["foundation_model"].values[0].model_id
-        em_id = discovered["embedding_model"].values[0].model_id
+        fm_id = discovered_search_space["foundation_model"].values[0].model_id
+        em_id = discovered_search_space["embedding_model"].values[0].model_id
 
         payload = {
             "foundation_models": [{"model_id": fm_id}],

--- a/tests/unit/ai4rag/search_space/prepare/test_llama_stack_utils.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_llama_stack_utils.py
@@ -126,10 +126,14 @@ class TestGetDefaultLlamaStackModels:
         # Assertions
         assert "foundation_models" in result
         assert "embedding_models" in result
+        assert "not_responding_foundation_models" in result
+        assert "not_responding_embedding_models" in result
         assert len(result["foundation_models"]) == 1
         assert len(result["embedding_models"]) == 1
         assert result["foundation_models"][0].model_id == "test-llm"
         assert result["embedding_models"][0].model_id == "test-embedding"
+        assert result["not_responding_foundation_models"] == []
+        assert result["not_responding_embedding_models"] == []
 
     def test_raises_error_when_no_llm_models(self, mocker):
         """Test that function raises error when no LLM models available."""
@@ -148,7 +152,7 @@ class TestGetDefaultLlamaStackModels:
             return_value=True,
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'"):
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'.*not responding"):
             _get_default_llama_stack_models(mock_client)
 
     def test_raises_error_when_no_embedding_models(self, mocker):
@@ -167,7 +171,7 @@ class TestGetDefaultLlamaStackModels:
             return_value=True,
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'"):
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'.*not responding"):
             _get_default_llama_stack_models(mock_client)
 
     def test_excludes_models_that_fail_validation(self, mocker):
@@ -223,6 +227,12 @@ class TestGetDefaultLlamaStackModels:
         assert len(result["embedding_models"]) == 1
         assert result["embedding_models"][0].model_id == "test-embedding-2"
 
+        # Failed models should be in the not_responding lists
+        assert len(result["not_responding_foundation_models"]) == 1
+        assert result["not_responding_foundation_models"][0].model_id == "test-llm-1"
+        assert len(result["not_responding_embedding_models"]) == 1
+        assert result["not_responding_embedding_models"][0].model_id == "test-embedding-1"
+
     def test_raises_error_when_all_foundation_models_fail_validation(self, mocker):
         """Test that error is raised when all foundation models fail validation."""
         mock_client = MagicMock()
@@ -248,7 +258,7 @@ class TestGetDefaultLlamaStackModels:
             return_value=True,
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'"):
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'.*not responding"):
             _get_default_llama_stack_models(mock_client)
 
     def test_raises_error_when_all_embedding_models_fail_validation(self, mocker):
@@ -276,15 +286,15 @@ class TestGetDefaultLlamaStackModels:
             return_value=False,
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'"):
+        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'.*not responding"):
             _get_default_llama_stack_models(mock_client)
 
 
 class TestAreProvidedModelsAvailable:
     """Test _are_provided_models_available function."""
 
-    def test_returns_true_when_all_models_available(self):
-        """Test that function returns True when all provided models are available."""
+    def test_no_error_when_all_models_available(self):
+        """Test that function does not raise when all provided models are available."""
         from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
         from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
 
@@ -299,12 +309,10 @@ class TestAreProvidedModelsAvailable:
             AI4RAGFoundationModel(model_id="model-2"),
         ]
 
-        # Should return True without raising
-        result = _are_provided_models_available(provided_models, available_models)
-        assert result is True
+        _are_provided_models_available(provided_models, available_models, not_responding_models=[])
 
-    def test_raises_error_when_model_not_available(self):
-        """Test that function raises error when provided model is not available."""
+    def test_raises_error_when_model_not_registered(self):
+        """Test that function raises error when provided model is not registered."""
         from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
         from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
 
@@ -314,8 +322,55 @@ class TestAreProvidedModelsAvailable:
         ]
 
         provided_models = [
-            AI4RAGFoundationModel(model_id="model-2"),  # Not available
+            AI4RAGFoundationModel(model_id="model-2"),
         ]
 
-        with pytest.raises(SearchSpaceValueError, match="model-2.*not available"):
-            _are_provided_models_available(provided_models, available_models)
+        with pytest.raises(SearchSpaceValueError, match="model-2.*not registered within llama-stack"):
+            _are_provided_models_available(provided_models, available_models, not_responding_models=[])
+
+    def test_raises_error_when_model_not_responding(self):
+        """Test that function raises error when provided model is registered but not responding."""
+        from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
+
+        mock_client = MagicMock()
+        available_models = [
+            LSFoundationModel(model_id="model-1", client=mock_client),
+        ]
+        not_responding_models = [
+            LSFoundationModel(model_id="model-2", client=mock_client),
+        ]
+
+        provided_models = [
+            AI4RAGFoundationModel(model_id="model-2"),
+        ]
+
+        with pytest.raises(SearchSpaceValueError, match="model-2.*registered but do not respond"):
+            _are_provided_models_available(provided_models, available_models, not_responding_models)
+
+    def test_raises_error_with_both_not_responding_and_unregistered(self):
+        """Test that error includes both not-responding and unregistered models."""
+        from ai4rag.rag.foundation_models.llama_stack import LSFoundationModel
+        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
+
+        mock_client = MagicMock()
+        available_models = [
+            LSFoundationModel(model_id="model-1", client=mock_client),
+        ]
+        not_responding_models = [
+            LSFoundationModel(model_id="model-2", client=mock_client),
+        ]
+
+        provided_models = [
+            AI4RAGFoundationModel(model_id="model-2"),
+            AI4RAGFoundationModel(model_id="model-3"),
+        ]
+
+        with pytest.raises(SearchSpaceValueError) as exc_info:
+            _are_provided_models_available(provided_models, available_models, not_responding_models)
+
+        error_msg = str(exc_info.value)
+        assert "model-2" in error_msg
+        assert "registered but do not respond" in error_msg
+        assert "model-3" in error_msg
+        assert "not registered within llama-stack" in error_msg

--- a/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
@@ -273,3 +273,130 @@ class TestPrepareSearchSpaceWithLlamaStack:
         assert "ranker_strategy" in param_names
         assert "ranker_k" in param_names
         assert "ranker_alpha" in param_names
+
+    def test_user_specifies_not_responding_foundation_model(self, mocker):
+        """Error when user requests a foundation model that is registered but not responding."""
+        mock_client = MagicMock(spec=LlamaStackClient)
+
+        mock_llm_ok = Mock()
+        mock_llm_ok.id = "llm-ok"
+        mock_llm_ok.custom_metadata = {"model_type": "llm"}
+
+        mock_llm_bad = Mock()
+        mock_llm_bad.id = "llm-bad"
+        mock_llm_bad.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding = Mock()
+        mock_embedding.id = "default-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_llm_ok, mock_llm_bad, mock_embedding]
+
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            side_effect=lambda m: m.model_id != "llm-bad",
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        payload = {"foundation_models": [{"model_id": "llm-bad"}]}
+
+        with pytest.raises(SearchSpaceValueError, match="llm-bad.*registered but do not respond"):
+            prepare_search_space_with_llama_stack(payload, mock_client)
+
+    def test_user_specifies_not_responding_embedding_model(self, mocker):
+        """Error when user requests an embedding model that is registered but not responding."""
+        mock_client = MagicMock(spec=LlamaStackClient)
+
+        mock_llm = Mock()
+        mock_llm.id = "default-llm"
+        mock_llm.custom_metadata = {"model_type": "llm"}
+
+        mock_emb_ok = Mock()
+        mock_emb_ok.id = "emb-ok"
+        mock_emb_ok.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_emb_ok.metadata = {}
+
+        mock_emb_bad = Mock()
+        mock_emb_bad.id = "emb-bad"
+        mock_emb_bad.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_emb_bad.metadata = {}
+
+        mock_client.models.list.return_value = [mock_llm, mock_emb_ok, mock_emb_bad]
+
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            side_effect=lambda m: m.model_id != "emb-bad",
+        )
+
+        payload = {"embedding_models": [{"model_id": "emb-bad"}]}
+
+        with pytest.raises(SearchSpaceValueError, match="emb-bad.*registered but do not respond"):
+            prepare_search_space_with_llama_stack(payload, mock_client)
+
+    def test_user_specifies_unregistered_foundation_model(self, mocker):
+        """Error when user requests a foundation model not registered in llama-stack."""
+        mock_client = MagicMock(spec=LlamaStackClient)
+
+        mock_llm = Mock()
+        mock_llm.id = "llm-ok"
+        mock_llm.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding = Mock()
+        mock_embedding.id = "default-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            return_value=True,
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        payload = {"foundation_models": [{"model_id": "llm-unknown"}]}
+
+        with pytest.raises(SearchSpaceValueError, match="llm-unknown.*not registered within llama-stack"):
+            prepare_search_space_with_llama_stack(payload, mock_client)
+
+    def test_user_picks_available_model_while_others_fail(self, mocker):
+        """User selects a responding model — succeeds even when other registered models fail."""
+        mock_client = MagicMock(spec=LlamaStackClient)
+
+        mock_llm_ok = Mock()
+        mock_llm_ok.id = "llm-ok"
+        mock_llm_ok.custom_metadata = {"model_type": "llm"}
+
+        mock_llm_bad = Mock()
+        mock_llm_bad.id = "llm-bad"
+        mock_llm_bad.custom_metadata = {"model_type": "llm"}
+
+        mock_embedding = Mock()
+        mock_embedding.id = "default-embedding"
+        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
+
+        mock_client.models.list.return_value = [mock_llm_ok, mock_llm_bad, mock_embedding]
+
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_foundation_model",
+            side_effect=lambda m: m.model_id != "llm-bad",
+        )
+        mocker.patch(
+            "ai4rag.search_space.prepare.llama_stack_utils._validate_embedding_model",
+            return_value=True,
+        )
+
+        payload = {"foundation_models": [{"model_id": "llm-ok"}]}
+        result = prepare_search_space_with_llama_stack(payload, mock_client)
+
+        fm_ids = [m.model_id for m in result["foundation_model"].values]
+        assert fm_ids == ["llm-ok"]


### PR DESCRIPTION
Assisted-by: Claude Code

  ---
  Description

  Improve error messages and logging when models registered in Llama Stack are unavailable or not responding during
  search space preparation.

  Motivation

  Previously, when a user-specified model was not responding or unregistered, the error messages were generic ("not
  available for the experiment") with no distinction between the two failure modes. This made it difficult to diagnose
  whether the issue was a typo in the model ID, a missing registration, or a server-side model failure. The improved
  messages now clearly tell users whether to fix their configuration or check the server.

  Changes

  - Track not-responding models separately from available models in _get_default_llama_stack_models, returning them in
  the response dict
  - Rewrite _are_provided_models_available to distinguish between "registered but not responding" and "not registered
  within llama-stack", with actionable error messages for each case
  - Update error messages when no models of a given type are available to mention that registered models may not be
  responding
  - Add selected model logging in prepare_search_space_with_llama_stack
  - Scope CI pytest run to tests/unit only and broaden python_files pattern to discover functional tests
  - Add functional tests against a live Llama Stack server for prepare_search_space_with_llama_stack
  - Update and expand unit tests for the new not-responding vs unregistered model distinction

  Testing

  - 833 unit tests passing (pytest tests/unit)
  - 3 functional tests passing against a live Llama Stack server (skipped when LLAMA_STACK_CLIENT_BASE_URL is not set)
  - New unit test coverage for:
    - _get_default_llama_stack_models: not-responding model tracking in result dict
    - _are_provided_models_available: not-responding, unregistered, and combined error scenarios
    - prepare_search_space_with_llama_stack: user specifies not-responding/unregistered models, user picks available
  model while others fail

  Checklist

  - Tests added/updated
  - Documentation updated
  - Code follows style guide
  - All checks passing