### PR TITLE
Update MPS logging

### DIFF
--- a/ai4rag/core/experiment/mps.py
+++ b/ai4rag/core/experiment/mps.py
@@ -319,7 +319,9 @@ class ModelsPreSelector:
         """
 
         logger.info(
-            "Selecting the best %s embedding models and %s foundation models.", n_embedding_models, n_foundation_models
+            "Search space contains %s foundation model(s) and %s embedding model(s). Starting models pre-selection...",
+            len(self.foundation_models),
+            len(self.embedding_models),
         )
         top_models_with_scores = self._mean_based_scoring()
 
@@ -340,6 +342,12 @@ class ModelsPreSelector:
             "foundation_models": foundation_models[:n_foundation_models],
             "embedding_models": embedding_models[:n_embedding_models],
         }
+
+        logger.info(
+            "Selected the best %s embedding model(s) and %s foundation model(s).",
+            len(ret["embedding_models"]),
+            len(ret["foundation_models"]),
+        )
 
         return ret
 

--- a/tests/unit/ai4rag/core/experiment/test_mps.py
+++ b/tests/unit/ai4rag/core/experiment/test_mps.py
@@ -250,4 +250,5 @@ class TestModelsPreSelector:
         models = pre_selector.select_models(n_embedding_models=n_em, n_foundation_models=n_fm)
         assert len(models.get("foundation_models")) == n_fm
         assert len(models.get("embedding_models")) == n_em
-        assert f"Selecting the best {n_em} embedding models and {n_fm} foundation models." in caplog.text
+        assert "Starting models pre-selection..." in caplog.text
+        assert f"Selected the best {n_em} embedding model(s) and {n_fm} foundation model(s)." in caplog.text


### PR DESCRIPTION
Assisted-by: Claude Code

## Description

  Fix MPS logging to report actual model counts instead of hardcoded requested values.

## Motivation

  [RHOAIENG-59819] The MPS stage logs "Selecting the best 2 embedding models and 3 foundation models" using the requested
  counts, but the actual number of models returned can be lower due to model unavailability or network errors. This is
  misleading and makes debugging harder.

## Changes

  - Replace the pre-selection log with a "Search space contains N foundation model(s) and M embedding model(s). Starting
  models pre-selection..." message that reflects the actual input size
  - Add a post-selection log "Selected the best X embedding model(s) and Y foundation model(s)." using len() of the actually
  returned lists
  - Update test assertions to match the new log messages

## Testing

  - pytest tests/unit/ai4rag/core/experiment/test_mps.py — all 9 tests pass
  - pylint ai4rag/core/experiment/mps.py — 10/10

## Checklist

  - Tests added/updated
  - Documentation updated
  - Code follows style guide
  - All checks passing
