### PR TITLE
Release 0.5.5

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.5](https://github.com/IBM/ai4rag/releases/tag/v0.5.5)
+
+### Changed
+- Improved error messages when models registered in Llama Stack do not respond — errors now distinguish between "not registered" and "registered but not responding" models, with actionable guidance
+- Improved pre-selector logging to show total model counts before selection and selected counts after
+- Added logging of selected foundation and embedding models during search space preparation
+- Removed `pydantic`-based payload validation overhead in `prepare_search_space_with_llama_stack` — replaced with direct dataclass instantiation
+- Removed `validation_error_decoder` module and `pydantic` dependency from search space preparation
+
+---
+
 ## [0.5.4](https://github.com/IBM/ai4rag/releases/tag/v0.5.4)
 
 ### Fixed


### PR DESCRIPTION
Assisted-by: Claude Code

# Release v0.5.5

## Summary

This patch release improves observability and developer experience when working with Llama Stack models. Error messages during search space preparation now clearly distinguish between models that are not registered and models that are registered but not responding, with actionable guidance. Validation overhead from pydantic has been removed in favor of direct dataclass instantiation, and logging throughout the model selection pipeline has been made more informative.

## Changes

### Changed
- Improved error messages when models registered in Llama Stack do not respond — errors now distinguish between "not registered" and "registered but not responding" models, with actionable guidance
- Improved pre-selector logging to show total model counts before selection and selected counts after
- Added logging of selected foundation and embedding models during search space preparation
- Removed `pydantic`-based payload validation overhead in `prepare_search_space_with_llama_stack` — replaced with direct dataclass instantiation
- Removed `validation_error_decoder` module and `pydantic` dependency from search space preparation

## Migration notes

No breaking changes. The `pydantic` dependency is no longer used for search space payload validation, but this is an internal change — the public API is unchanged.

## Checklist

- [ ] `__version__` in `ai4rag/__init__.py` updated to `0.5.5`
- [ ] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
