### PR TITLE
Update logging during models selection and validation

### DIFF
--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -160,8 +160,10 @@ class AI4RAGExperiment:
             "evaluator",
             UnitxtEvaluator(),
         )
-        self.n_mps_foundation_models = kwargs.pop("n_mps_fm", ModelsPreSelector.DEFAULT_N_FOUNDATION_MODELS)
-        self.n_mps_embedding_models = kwargs.pop("n_mps_em", ModelsPreSelector.DEFAULT_N_EMBEDDING_MODELS)
+        self.n_mps_foundation_models = kwargs.pop(
+            "n_mps_foundation_models", ModelsPreSelector.DEFAULT_N_FOUNDATION_MODELS
+        )
+        self.n_mps_embedding_models = kwargs.pop("n_mps_embedding_models", ModelsPreSelector.DEFAULT_N_EMBEDDING_MODELS)
         self.known_observations: list[dict] | None = kwargs.pop("known_observations", None)
 
         self.results: ExperimentResults = ExperimentResults()

--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -10,8 +10,6 @@ from ogx_client import OgxClient
 
 from .base_model import BaseEmbeddingModel
 
-# pylint: disable=duplicate-code
-
 __all__ = ["OGXEmbeddingModel", "OGXEmbeddingParams"]
 
 

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -5,19 +5,17 @@
 from typing import TypedDict
 
 from ogx_client import OgxClient
+from ogx_client.types import Model
 
 from ai4rag import logger
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel, OGXEmbeddingParams
 from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
-from ai4rag.search_space.prepare.input_payload_types import AI4RAGEmbeddingModel, AI4RAGFoundationModel
 from ai4rag.search_space.src.exceptions import SearchSpaceValueError
 
 
 class _DefaultModelsResponseType(TypedDict):
-    foundation_models: list[OGXFoundationModel]
-    embedding_models: list[OGXEmbeddingModel]
-    not_responding_foundation_models: list[OGXFoundationModel]
-    not_responding_embedding_models: list[OGXEmbeddingModel]
+    foundation_models: list[Model]
+    embedding_models: list[Model]
 
 
 def _validate_foundation_model(model: OGXFoundationModel) -> bool:
@@ -41,9 +39,8 @@ def _validate_foundation_model(model: OGXFoundationModel) -> bool:
         return True
     except Exception:  # pylint: disable=broad-exception-caught
         logger.warning(
-            "Foundation model '%s' does not respond and will be excluded from search space.",
+            "Foundation model '%s' is registered in OGX, but does not respond.",
             model.model_id,
-            exc_info=True,
         )
         return False
 
@@ -68,126 +65,125 @@ def _validate_embedding_model(model: OGXEmbeddingModel) -> bool:
         return True
     except Exception:  # pylint: disable=broad-exception-caught
         logger.warning(
-            "Embedding model '%s' does not respond and will be excluded from search space.",
+            "Embedding model '%s' is registered in OGX, but does not respond.",
             model.model_id,
-            exc_info=True,
         )
         return False
 
 
 def _get_default_ogx_models(client: OgxClient) -> _DefaultModelsResponseType:
-    """Get list of default foundation models based on the available ones in OGX."""
+    """Return registered foundation and embedding model objects from OGX without validating them."""
 
-    logger.info("Selecting default foundation models...")
-    available_models = client.models.list()
-    llms = [model for model in available_models if model.custom_metadata.get("model_type") == "llm"]
-    embeddings = [model for model in available_models if model.custom_metadata.get("model_type") == "embedding"]
+    logger.info("Checking registered embedding and foundation models...")
+    available_models = client.models.list().data
 
-    # Create model instances
-    foundation_models_unvalidated = [OGXFoundationModel(model_id=m.id, client=client) for m in llms]
-    embedding_models_unvalidated = [
-        OGXEmbeddingModel(
-            model_id=m.id,
-            client=client,
-            params=OGXEmbeddingParams(
-                embedding_dimension=getattr(m, "custom_metadata", {}).get("embedding_dimension"),
-                context_length=getattr(m, "custom_metadata", {}).get("context_length"),
-            ),
-        )
-        for m in embeddings
+    registered_foundation_models = [
+        model for model in available_models if model.custom_metadata.get("model_type") == "llm"
+    ]
+    registered_embedding_models = [
+        model for model in available_models if model.custom_metadata.get("model_type") == "embedding"
     ]
 
-    # Validate each model
-    foundation_models = []
-    not_responding_foundation_models = []
-    logger.info("Validating foundation models...")
-    for fm_el in foundation_models_unvalidated:
-        if _validate_foundation_model(fm_el):
-            foundation_models.append(fm_el)
-        else:
-            not_responding_foundation_models.append(fm_el)
+    if not registered_foundation_models:
+        raise SearchSpaceValueError("There are no registered models of type 'llm' in the OGX.")
+    if not registered_embedding_models:
+        raise SearchSpaceValueError("There are no registered models of type 'embedding' in the OGX.")
 
-    embedding_models = []
-    not_responding_embedding_models = []
-    logger.info("Validating embedding models...")
-    for em_el in embedding_models_unvalidated:
-        if _validate_embedding_model(em_el):
-            embedding_models.append(em_el)
-        else:
-            not_responding_embedding_models.append(em_el)
-
-    if not foundation_models:
-        raise SearchSpaceValueError(
-            "There are no available models of type 'llm' or the ones registered are not responding: "
-            f"{[m.model_id for m in not_responding_foundation_models]}. "
-            "Please look at the full logs."
-        )
-    if not embedding_models:
-        raise SearchSpaceValueError(
-            "There are no available models of type 'embedding' or the ones registered are not responding: "
-            f"{[m.model_id for m in not_responding_embedding_models]}. "
-            "Please look at the full logs."
-        )
-
-    logger.info("Available foundation models: %s.", foundation_models)
-    logger.info("Available embedding models: %s.", embedding_models)
+    logger.info("Found registered foundation models: %s.", [model.id for model in registered_foundation_models])
+    logger.info("Found registered embedding models: %s.", [model.id for model in registered_embedding_models])
 
     return {
-        "foundation_models": foundation_models,
-        "embedding_models": embedding_models,
-        "not_responding_foundation_models": not_responding_foundation_models,
-        "not_responding_embedding_models": not_responding_embedding_models,
+        "foundation_models": registered_foundation_models,
+        "embedding_models": registered_embedding_models,
     }
 
 
-def _are_provided_models_available(
-    provided_models: list[AI4RAGFoundationModel] | list[AI4RAGEmbeddingModel],
-    available_models: list[OGXFoundationModel | OGXEmbeddingModel],
-    not_responding_models: list[OGXFoundationModel | OGXEmbeddingModel],
-) -> None:
+def _validate_availability_and_create_models(
+    provided_models_ids: list[str],
+    registered_models: list[Model],
+    models_type: str,
+    client: OgxClient,
+) -> list[OGXFoundationModel | OGXEmbeddingModel]:
     """
-    Check whether models provided by the user are available for the experiment.
+    Validate that the requested models are registered and responding, then instantiate them.
 
     Parameters
     ----------
-    provided_models : list[AI4RAGFoundationModel] | list[AI4RAGEmbeddingModel]
-        Models provided by the user in the input payload.
+    provided_models_ids : list[str]
+        Model IDs requested by the user (or all registered IDs when no user selection).
 
-    available_models : list[OGXFoundationModel | OGXEmbeddingModel]
-        Models registered within OGX that passed validation (respond to requests).
+    registered_models : list[Model]
+        OGX model objects returned by ``client.models.list().data``, pre-filtered by type.
 
-    not_responding_models : list[OGXFoundationModel | OGXEmbeddingModel]
-        Models that are registered within OGX but do not respond.
+    models_type : str
+        ``'llm'`` or ``'embedding'``.
+
+    client : OgxClient
+        OGX client used to instantiate model objects.
+
+    Returns
+    -------
+    list[OGXFoundationModel | OGXEmbeddingModel]
+        Validated and instantiated models.
 
     Raises
     ------
     SearchSpaceValueError
-        When some of the models provided by the user are not available for the experiment
-        or some of the models do not respond.
+        When some of the requested models are not registered in OGX or do not respond.
     """
-
-    available_model_ids = [m.model_id for m in available_models]
-    not_responding_model_ids = [m.model_id for m in not_responding_models]
-
-    user_not_responding_models = [m.model_id for m in provided_models if m.model_id in not_responding_model_ids]
-    user_unavailable_models = [
-        m.model_id
-        for m in provided_models
-        if m.model_id not in available_model_ids and m.model_id not in not_responding_model_ids
-    ]
-
     error_messages = []
-    if user_not_responding_models:
+    registered_models_ids = [model.id for model in registered_models]
+    _registered_models_as_dict = {m.id: m for m in registered_models}
+
+    provided_not_registered_models_ids = [pm_id for pm_id in provided_models_ids if pm_id not in registered_models_ids]
+    if provided_not_registered_models_ids:
         error_messages.append(
-            f"Provided models: {user_not_responding_models} are registered but do not respond. "
-            "Remove these models from the experiment configuration and try again."
+            f"Provided models of type '{models_type}' are not registered in OGX: '{provided_not_registered_models_ids}'."
         )
 
-    if user_unavailable_models:
+    provided_and_registered_models_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_ids]
+    invalid_model_ids = []
+    valid_model_instances = []
+    for prm_id in provided_and_registered_models_ids:
+        if models_type == "embedding":
+            custom_metadata = _registered_models_as_dict[prm_id].custom_metadata
+            try:
+                # If params is not provided model is trying to estimate parameters by sending some queries.
+                # If it fails it means that model is not available
+                embedding_dimension = custom_metadata.get("embedding_dimension", None) if custom_metadata else None
+                context_length = custom_metadata.get("context_length", None) if custom_metadata else None
+                _model = OGXEmbeddingModel(
+                    model_id=prm_id,
+                    client=client,
+                    params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
+                )
+                is_valid = _validate_embedding_model(_model)
+                if is_valid:
+                    valid_model_instances.append(_model)
+                else:
+                    invalid_model_ids.append(prm_id)
+            except Exception as exc:
+                logger.warning("Embedding model '%s' is registered in OGX, but does not respond.", prm_id, exc_info=exc)
+                invalid_model_ids.append(prm_id)
+
+        else:
+            _model = OGXFoundationModel(
+                model_id=prm_id,
+                client=client,
+            )
+            is_valid = _validate_foundation_model(_model)
+            if is_valid:
+                valid_model_instances.append(_model)
+            else:
+                invalid_model_ids.append(prm_id)
+
+    if invalid_model_ids:
         error_messages.append(
-            f"Provided models: {user_unavailable_models} are not registered within OGX. "
-            "Register these models or try a different model for the experiment."
+            f"Provided models of type '{models_type}' are registered in OGX but do not respond. "
+            f"Please validate these models are correctly registered and respond: '{invalid_model_ids}'."
         )
 
     if error_messages:
         raise SearchSpaceValueError("\n".join(error_messages))
+
+    return valid_model_instances

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -98,6 +98,46 @@ def _get_default_ogx_models(client: OgxClient) -> _DefaultModelsResponseType:
     }
 
 
+def _build_valid_and_invalid_models(
+    candidate_ids: list[str],
+    registered_models_as_dict: dict,
+    models_type: str,
+    client: OgxClient,
+) -> tuple[list[OGXFoundationModel | OGXEmbeddingModel], list[str]]:
+    valid_model_instances: list[OGXFoundationModel | OGXEmbeddingModel] = []
+    invalid_model_ids: list[str] = []
+    for model_id in candidate_ids:
+        if models_type == "embedding":
+            custom_metadata = registered_models_as_dict[model_id].custom_metadata
+            try:
+                # If params is not provided model is trying to estimate parameters by sending some queries.
+                # If it fails it means that model is not available
+                embedding_dimension = custom_metadata.get("embedding_dimension", None) if custom_metadata else None
+                context_length = custom_metadata.get("context_length", None) if custom_metadata else None
+                _model = OGXEmbeddingModel(
+                    model_id=model_id,
+                    client=client,
+                    params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
+                )
+                is_valid = _validate_embedding_model(_model)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "Embedding model '%s' is registered in OGX, but does not respond.", model_id, exc_info=exc
+                )
+                invalid_model_ids.append(model_id)
+                continue
+        else:
+            _model = OGXFoundationModel(model_id=model_id, client=client)
+            is_valid = _validate_foundation_model(_model)
+
+        if is_valid:
+            valid_model_instances.append(_model)
+        else:
+            invalid_model_ids.append(model_id)
+
+    return valid_model_instances, invalid_model_ids
+
+
 def _validate_availability_and_create_models(
     provided_models_ids: list[str],
     registered_models: list[Model],
@@ -133,49 +173,19 @@ def _validate_availability_and_create_models(
     """
     error_messages = []
     registered_models_ids = [model.id for model in registered_models]
-    _registered_models_as_dict = {m.id: m for m in registered_models}
+    registered_models_as_dict = {m.id: m for m in registered_models}
 
     provided_not_registered_models_ids = [pm_id for pm_id in provided_models_ids if pm_id not in registered_models_ids]
     if provided_not_registered_models_ids:
         error_messages.append(
-            f"Provided models of type '{models_type}' are not registered in OGX: '{provided_not_registered_models_ids}'."
+            f"Provided models of type '{models_type}' are not registered in OGX: "
+            f"'{provided_not_registered_models_ids}'."
         )
 
-    provided_and_registered_models_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_ids]
-    invalid_model_ids = []
-    valid_model_instances = []
-    for prm_id in provided_and_registered_models_ids:
-        if models_type == "embedding":
-            custom_metadata = _registered_models_as_dict[prm_id].custom_metadata
-            try:
-                # If params is not provided model is trying to estimate parameters by sending some queries.
-                # If it fails it means that model is not available
-                embedding_dimension = custom_metadata.get("embedding_dimension", None) if custom_metadata else None
-                context_length = custom_metadata.get("context_length", None) if custom_metadata else None
-                _model = OGXEmbeddingModel(
-                    model_id=prm_id,
-                    client=client,
-                    params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
-                )
-                is_valid = _validate_embedding_model(_model)
-                if is_valid:
-                    valid_model_instances.append(_model)
-                else:
-                    invalid_model_ids.append(prm_id)
-            except Exception as exc:
-                logger.warning("Embedding model '%s' is registered in OGX, but does not respond.", prm_id, exc_info=exc)
-                invalid_model_ids.append(prm_id)
-
-        else:
-            _model = OGXFoundationModel(
-                model_id=prm_id,
-                client=client,
-            )
-            is_valid = _validate_foundation_model(_model)
-            if is_valid:
-                valid_model_instances.append(_model)
-            else:
-                invalid_model_ids.append(prm_id)
+    candidate_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_ids]
+    valid_model_instances, invalid_model_ids = _build_valid_and_invalid_models(
+        candidate_ids, registered_models_as_dict, models_type, client
+    )
 
     if invalid_model_ids:
         error_messages.append(

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -120,7 +120,7 @@ def _build_valid_and_invalid_models(
                     params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
                 )
                 is_valid = _validate_embedding_model(_model)
-            except RuntimeError as exc:
+            except RuntimeError:
                 logger.warning(
                     "Embedding model '%s' is registered in OGX, but does not respond.", model_id, exc_info=True
                 )
@@ -139,19 +139,16 @@ def _build_valid_and_invalid_models(
 
 
 def _validate_availability_and_create_models(
-    provided_models_ids: list[str],
     registered_models: list[Model],
     models_type: str,
     client: OgxClient,
+    provided_models_ids: list[str] | None = None,
 ) -> list[OGXFoundationModel | OGXEmbeddingModel]:
     """
     Validate that the requested models are registered and responding, then instantiate them.
 
     Parameters
     ----------
-    provided_models_ids : list[str]
-        Model IDs requested by the user (or all registered IDs when no user selection).
-
     registered_models : list[Model]
         OGX model objects returned by ``client.models.list().data``, pre-filtered by type.
 
@@ -160,6 +157,11 @@ def _validate_availability_and_create_models(
 
     client : OgxClient
         OGX client used to instantiate model objects.
+
+    provided_models_ids : list[str] | None, default None
+        Model IDs requested by the user.  When ``None``, all registered models
+        are validated (the registration check is skipped since the IDs come from
+        the registry itself).
 
     Returns
     -------
@@ -172,17 +174,21 @@ def _validate_availability_and_create_models(
         When some of the requested models are not registered in OGX or do not respond.
     """
     error_messages = []
-    registered_models_ids = [model.id for model in registered_models]
     registered_models_as_dict = {m.id: m for m in registered_models}
 
-    provided_not_registered_models_ids = [pm_id for pm_id in provided_models_ids if pm_id not in registered_models_ids]
-    if provided_not_registered_models_ids:
-        error_messages.append(
-            f"Provided models of type '{models_type}' are not registered in OGX: "
-            f"'{provided_not_registered_models_ids}'."
-        )
+    if provided_models_ids is None:
+        candidate_ids = list(registered_models_as_dict)
+    else:
+        provided_not_registered_models_ids = [
+            pm_id for pm_id in provided_models_ids if pm_id not in registered_models_as_dict
+        ]
+        if provided_not_registered_models_ids:
+            error_messages.append(
+                f"Provided models of type '{models_type}' are not registered in OGX: "
+                f"'{provided_not_registered_models_ids}'."
+            )
+        candidate_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_as_dict]
 
-    candidate_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_ids]
     valid_model_instances, invalid_model_ids = _build_valid_and_invalid_models(
         candidate_ids, registered_models_as_dict, models_type, client
     )

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -120,9 +120,9 @@ def _build_valid_and_invalid_models(
                     params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
                 )
                 is_valid = _validate_embedding_model(_model)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
+            except RuntimeError as exc:
                 logger.warning(
-                    "Embedding model '%s' is registered in OGX, but does not respond.", model_id, exc_info=exc
+                    "Embedding model '%s' is registered in OGX, but does not respond.", model_id, exc_info=True
                 )
                 invalid_model_ids.append(model_id)
                 continue

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -7,12 +7,10 @@ from typing import Any
 from ogx_client import OgxClient
 
 from ai4rag import logger
-from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
-from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
 from ai4rag.search_space.prepare.input_payload_types import AI4RAGConstraints
 from ai4rag.search_space.prepare.ogx_utils import (
-    _are_provided_models_available,
     _get_default_ogx_models,
+    _validate_availability_and_create_models,
 )
 from ai4rag.search_space.src.exceptions import SearchSpaceValueError
 from ai4rag.search_space.src.parameter import Parameter
@@ -58,60 +56,43 @@ def prepare_search_space_with_ogx(
 
     if isinstance(client, OgxClient):
         models = _get_default_ogx_models(client)
-        default_foundation_models = models["foundation_models"]
-        default_embedding_models = models["embedding_models"]
+        registered_foundation_models = models["foundation_models"]
+        registered_embedding_models = models["embedding_models"]
     else:
         raise SearchSpaceValueError(f"Unrecognized client type: '{client.__class__.__name__}'")
 
     if validated_payload.foundation_models:
-        _are_provided_models_available(
-            provided_models=validated_payload.foundation_models,
-            available_models=default_foundation_models,
-            not_responding_models=models["not_responding_foundation_models"],
+        foundation_models = _validate_availability_and_create_models(
+            provided_models_ids=[m.model_id for m in validated_payload.foundation_models],
+            registered_models=registered_foundation_models,
+            models_type="llm",
+            client=client,
         )
+    else:
+        foundation_models = _validate_availability_and_create_models(
+            provided_models_ids=[m.id for m in registered_foundation_models],
+            registered_models=registered_foundation_models,
+            models_type="llm",
+            client=client,
+        )
+
     if validated_payload.embedding_models:
-        _are_provided_models_available(
-            provided_models=validated_payload.embedding_models,
-            available_models=default_embedding_models,
-            not_responding_models=models["not_responding_embedding_models"],
-        )
-
-    # Transform user models into OGX based models
-    if validated_payload.foundation_models is not None:
-        fms_param = Parameter(
-            name="foundation_model",
-            values=[
-                OGXFoundationModel(
-                    model_id=fm.model_id,
-                    client=client,
-                )
-                for fm in validated_payload.foundation_models
-            ],
+        embedding_models = _validate_availability_and_create_models(
+            provided_models_ids=[m.model_id for m in validated_payload.embedding_models],
+            registered_models=registered_embedding_models,
+            models_type="embedding",
+            client=client,
         )
     else:
-        fms_param = Parameter(
-            name="foundation_model",
-            values=default_foundation_models,
+        embedding_models = _validate_availability_and_create_models(
+            provided_models_ids=[m.id for m in registered_embedding_models],
+            registered_models=registered_embedding_models,
+            models_type="embedding",
+            client=client,
         )
 
-    if validated_payload.embedding_models is not None:
-        embedding_models_values = []
-        for em in validated_payload.embedding_models:
-            matched_model = next(filter(lambda x, _id=em.model_id: x.model_id == _id, default_embedding_models), None)
-            if matched_model is None:
-                raise SearchSpaceValueError(f"Embedding model '{em.model_id}' not found among available models.")
-            embedding_models_values.append(
-                OGXEmbeddingModel(model_id=em.model_id, client=client, params=matched_model.params)
-            )
-        ems_param = Parameter(
-            name="embedding_model",
-            values=embedding_models_values,
-        )
-    else:
-        ems_param = Parameter(
-            name="embedding_model",
-            values=default_embedding_models,
-        )
+    fms_param = Parameter(name="foundation_model", values=foundation_models)
+    ems_param = Parameter(name="embedding_model", values=embedding_models)
 
     logger.info("Selected foundation models for the experiment: %s.", [m.model_id for m in fms_param.values])
     logger.info("Selected embedding models for the experiment: %s.", [m.model_id for m in ems_param.values])

--- a/ai4rag/search_space/prepare/prepare_search_space.py
+++ b/ai4rag/search_space/prepare/prepare_search_space.py
@@ -63,14 +63,13 @@ def prepare_search_space_with_ogx(
 
     if validated_payload.foundation_models:
         foundation_models = _validate_availability_and_create_models(
-            provided_models_ids=[m.model_id for m in validated_payload.foundation_models],
             registered_models=registered_foundation_models,
             models_type="llm",
             client=client,
+            provided_models_ids=[m.model_id for m in validated_payload.foundation_models],
         )
     else:
         foundation_models = _validate_availability_and_create_models(
-            provided_models_ids=[m.id for m in registered_foundation_models],
             registered_models=registered_foundation_models,
             models_type="llm",
             client=client,
@@ -78,14 +77,13 @@ def prepare_search_space_with_ogx(
 
     if validated_payload.embedding_models:
         embedding_models = _validate_availability_and_create_models(
-            provided_models_ids=[m.model_id for m in validated_payload.embedding_models],
             registered_models=registered_embedding_models,
             models_type="embedding",
             client=client,
+            provided_models_ids=[m.model_id for m in validated_payload.embedding_models],
         )
     else:
         embedding_models = _validate_availability_and_create_models(
-            provided_models_ids=[m.id for m in registered_embedding_models],
             registered_models=registered_embedding_models,
             models_type="embedding",
             client=client,

--- a/ai4rag/utils/event_handler/event_handler.py
+++ b/ai4rag/utils/event_handler/event_handler.py
@@ -24,12 +24,12 @@ class LocalEventHandler(BaseEventHandler):
         self.output_path = Path(output_path) if output_path else None
 
     def on_status_change(self, level: LogLevel, message: str, step: str | None = None) -> None:
-        logger.info("LocalEventHandler ::: %s ::: %s ::: %s", level, step, message)
+        logger.debug("LocalEventHandler ::: %s ::: %s ::: %s", level, step, message)
 
     def on_pattern_creation(
         self, payload: PatternPayload, evaluation_results: list[EvaluationRecord], **kwargs
     ) -> None:
-        logger.info("LocalEventHandler ::: Pattern creation ::: %s", payload)
+        logger.debug("LocalEventHandler ::: Pattern creation ::: %s", payload)
         pattern_name = payload.get("pattern_name", "default_pattern_name")
 
         if self.output_path:

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -12,11 +12,11 @@ echo "Running formatters on: ${TARGETS[*]}"
 
 echo ""
 echo "==> isort"
-isort "${TARGETS[@]}"
+uv run isort "${TARGETS[@]}"
 
 echo ""
 echo "==> black"
-black "${TARGETS[@]}"
+uv run black "${TARGETS[@]}"
 
 echo ""
 echo "==> copyright_check"

--- a/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
@@ -10,8 +10,8 @@ from ai4rag.rag.embedding.ogx import OGXEmbeddingModel, OGXEmbeddingParams
 from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
 from ai4rag.search_space.prepare.ogx_utils import (
     SearchSpaceValueError,
-    _are_provided_models_available,
     _get_default_ogx_models,
+    _validate_availability_and_create_models,
     _validate_embedding_model,
     _validate_foundation_model,
 )
@@ -69,20 +69,13 @@ class TestValidateEmbeddingModel:
     def test_returns_false_when_model_fails(self):
         """Test that validation returns False when model raises exception."""
         mock_client = MagicMock()
-        mock_response = Mock()
-        mock_data = Mock()
-        mock_data.embedding = [0.1, 0.2, 0.3]
-        mock_response.data = [mock_data]
 
-        # First call succeeds (for embed_query in validation), but we need to
-        # create the model first with context_length set to avoid detection.
         model = OGXEmbeddingModel(
             model_id="test-model",
             client=mock_client,
             params=OGXEmbeddingParams(embedding_dimension=768, context_length=512),
         )
 
-        # Now set embed to fail for validation
         mock_client.embeddings.create.side_effect = Exception("Model error")
 
         result = _validate_embedding_model(model)
@@ -93,284 +86,238 @@ class TestValidateEmbeddingModel:
 class TestGetDefaultOGXModels:
     """Test _get_default_ogx_models function."""
 
-    def test_returns_foundation_and_embedding_models(self, mocker):
-        """Test that function returns both foundation and embedding models."""
-        # Mock client
+    def _make_llm_mock(self, model_id: str) -> Mock:
+        m = Mock()
+        m.id = model_id
+        m.custom_metadata = {"model_type": "llm"}
+        return m
+
+    def _make_embedding_mock(self, model_id: str, dim: int = 768, ctx: int = 512) -> Mock:
+        m = Mock()
+        m.id = model_id
+        m.custom_metadata = {"model_type": "embedding", "embedding_dimension": dim, "context_length": ctx}
+        return m
+
+    def _client(self, *models) -> MagicMock:
         mock_client = MagicMock()
+        mock_client.models.list.return_value.data = list(models)
+        return mock_client
 
-        # Mock model list response
-        mock_llm = Mock()
-        mock_llm.id = "test-llm"
-        mock_llm.custom_metadata = {"model_type": "llm"}
+    def test_returns_registered_foundation_and_embedding_models(self):
+        """Returns model objects split by type without validating them."""
+        mock_llm = self._make_llm_mock("test-llm")
+        mock_emb = self._make_embedding_mock("test-emb")
+        client = self._client(mock_llm, mock_emb)
 
-        mock_embedding = Mock()
-        mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
-        mock_embedding.metadata = {}
+        result = _get_default_ogx_models(client)
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        assert result["foundation_models"] == [mock_llm]
+        assert result["embedding_models"] == [mock_emb]
 
-        # Mock validation functions to always return True
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
-            return_value=True,
-        )
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_embedding_model",
-            return_value=True,
-        )
+    def test_does_not_validate_models(self, mocker):
+        """_get_default_ogx_models must not call validation functions."""
+        mock_llm = self._make_llm_mock("test-llm")
+        mock_emb = self._make_embedding_mock("test-emb")
+        client = self._client(mock_llm, mock_emb)
 
-        # Call function
-        result = _get_default_ogx_models(mock_client)
+        validate_fm = mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_foundation_model")
+        validate_em = mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_embedding_model")
 
-        # Assertions
-        assert "foundation_models" in result
-        assert "embedding_models" in result
-        assert "not_responding_foundation_models" in result
-        assert "not_responding_embedding_models" in result
+        _get_default_ogx_models(client)
+
+        validate_fm.assert_not_called()
+        validate_em.assert_not_called()
+
+    def test_raises_when_no_llm_registered(self):
+        """Error when OGX has no models of type 'llm'."""
+        mock_emb = self._make_embedding_mock("test-emb")
+        client = self._client(mock_emb)
+
+        with pytest.raises(SearchSpaceValueError, match="no registered models of type 'llm'"):
+            _get_default_ogx_models(client)
+
+    def test_raises_when_no_embedding_registered(self):
+        """Error when OGX has no models of type 'embedding'."""
+        mock_llm = self._make_llm_mock("test-llm")
+        client = self._client(mock_llm)
+
+        with pytest.raises(SearchSpaceValueError, match="no registered models of type 'embedding'"):
+            _get_default_ogx_models(client)
+
+    def test_filters_by_model_type(self):
+        """Models with an unrecognised model_type are excluded from both lists."""
+        mock_llm = self._make_llm_mock("test-llm")
+        mock_emb = self._make_embedding_mock("test-emb")
+        untyped = Mock()
+        untyped.id = "unknown"
+        untyped.custom_metadata = {"model_type": "unknown_type"}
+        client = self._client(mock_llm, mock_emb, untyped)
+
+        result = _get_default_ogx_models(client)
+
         assert len(result["foundation_models"]) == 1
         assert len(result["embedding_models"]) == 1
-        assert result["foundation_models"][0].model_id == "test-llm"
-        assert result["embedding_models"][0].model_id == "test-embedding"
-        assert result["not_responding_foundation_models"] == []
-        assert result["not_responding_embedding_models"] == []
 
-    def test_raises_error_when_no_llm_models(self, mocker):
-        """Test that function raises error when no LLM models available."""
+
+class TestValidateAvailabilityAndCreateModels:
+    """Test _validate_availability_and_create_models function."""
+
+    def _make_llm_registry_mock(self, model_id: str) -> Mock:
+        m = Mock()
+        m.id = model_id
+        m.custom_metadata = {"model_type": "llm"}
+        return m
+
+    def _make_emb_registry_mock(self, model_id: str, dim: int = 768, ctx: int = 512) -> Mock:
+        m = Mock()
+        m.id = model_id
+        m.custom_metadata = {"model_type": "embedding", "embedding_dimension": dim, "context_length": ctx}
+        return m
+
+    def test_returns_llm_instances_for_valid_models(self, mocker):
+        """Returns OGXFoundationModel instances for each valid LLM."""
         mock_client = MagicMock()
+        registered = [self._make_llm_registry_mock("llm-1"), self._make_llm_registry_mock("llm-2")]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_foundation_model", return_value=True)
 
-        mock_embedding = Mock()
-        mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
-        mock_embedding.metadata = {}
-
-        mock_client.models.list.return_value = [mock_embedding]
-
-        # Mock validation to return True for embedding models
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_embedding_model",
-            return_value=True,
+        result = _validate_availability_and_create_models(
+            provided_models_ids=["llm-1", "llm-2"],
+            registered_models=registered,
+            models_type="llm",
+            client=mock_client,
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'.*not responding"):
-            _get_default_ogx_models(mock_client)
+        assert len(result) == 2
+        assert all(isinstance(m, OGXFoundationModel) for m in result)
+        assert {m.model_id for m in result} == {"llm-1", "llm-2"}
 
-    def test_raises_error_when_no_embedding_models(self, mocker):
-        """Test that function raises error when no embedding models available."""
+    def test_returns_embedding_instances_for_valid_models(self, mocker):
+        """Returns OGXEmbeddingModel instances for each valid embedding model."""
         mock_client = MagicMock()
+        registered = [self._make_emb_registry_mock("emb-1", dim=768, ctx=512)]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_embedding_model", return_value=True)
 
-        mock_llm = Mock()
-        mock_llm.id = "test-llm"
-        mock_llm.custom_metadata = {"model_type": "llm"}
-
-        mock_client.models.list.return_value = [mock_llm]
-
-        # Mock validation to return True for foundation models
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
-            return_value=True,
+        result = _validate_availability_and_create_models(
+            provided_models_ids=["emb-1"],
+            registered_models=registered,
+            models_type="embedding",
+            client=mock_client,
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'.*not responding"):
-            _get_default_ogx_models(mock_client)
+        assert len(result) == 1
+        assert isinstance(result[0], OGXEmbeddingModel)
+        assert result[0].model_id == "emb-1"
 
-    def test_excludes_models_that_fail_validation(self, mocker):
-        """Test that models failing validation are excluded from results."""
+    def test_raises_when_llm_not_registered(self, mocker):
+        """Error when a requested LLM ID is not in the registered list."""
         mock_client = MagicMock()
+        registered = [self._make_llm_registry_mock("llm-ok")]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_foundation_model", return_value=True)
 
-        # Create multiple models of each type
-        mock_llm1 = Mock()
-        mock_llm1.id = "test-llm-1"
-        mock_llm1.custom_metadata = {"model_type": "llm"}
+        with pytest.raises(SearchSpaceValueError, match=r"not registered in OGX.*llm-unknown"):
+            _validate_availability_and_create_models(
+                provided_models_ids=["llm-unknown"],
+                registered_models=registered,
+                models_type="llm",
+                client=mock_client,
+            )
 
-        mock_llm2 = Mock()
-        mock_llm2.id = "test-llm-2"
-        mock_llm2.custom_metadata = {"model_type": "llm"}
-
-        mock_embedding1 = Mock()
-        mock_embedding1.id = "test-embedding-1"
-        mock_embedding1.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
-        mock_embedding1.metadata = {}
-
-        mock_embedding2 = Mock()
-        mock_embedding2.id = "test-embedding-2"
-        mock_embedding2.custom_metadata = {
-            "model_type": "embedding",
-            "embedding_dimension": 1024,
-            "context_length": 512,
-        }
-        mock_embedding2.metadata = {}
-
-        mock_client.models.list.return_value = [mock_llm1, mock_llm2, mock_embedding1, mock_embedding2]
-
-        # Mock validation to fail for first model of each type
-        def mock_validate_foundation(model):
-            return model.model_id != "test-llm-1"
-
-        def mock_validate_embedding(model):
-            return model.model_id != "test-embedding-1"
-
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
-            side_effect=mock_validate_foundation,
-        )
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_embedding_model",
-            side_effect=mock_validate_embedding,
-        )
-
-        result = _get_default_ogx_models(mock_client)
-
-        # Only validated models should be included
-        assert len(result["foundation_models"]) == 1
-        assert result["foundation_models"][0].model_id == "test-llm-2"
-        assert len(result["embedding_models"]) == 1
-        assert result["embedding_models"][0].model_id == "test-embedding-2"
-
-        # Failed models should be in the not_responding lists
-        assert len(result["not_responding_foundation_models"]) == 1
-        assert result["not_responding_foundation_models"][0].model_id == "test-llm-1"
-        assert len(result["not_responding_embedding_models"]) == 1
-        assert result["not_responding_embedding_models"][0].model_id == "test-embedding-1"
-
-    def test_raises_error_when_all_foundation_models_fail_validation(self, mocker):
-        """Test that error is raised when all foundation models fail validation."""
+    def test_raises_when_embedding_not_registered(self, mocker):
+        """Error when a requested embedding ID is not in the registered list."""
         mock_client = MagicMock()
+        registered = [self._make_emb_registry_mock("emb-ok")]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_embedding_model", return_value=True)
 
-        mock_llm = Mock()
-        mock_llm.id = "test-llm"
-        mock_llm.custom_metadata = {"model_type": "llm"}
+        with pytest.raises(SearchSpaceValueError, match=r"not registered in OGX.*emb-unknown"):
+            _validate_availability_and_create_models(
+                provided_models_ids=["emb-unknown"],
+                registered_models=registered,
+                models_type="embedding",
+                client=mock_client,
+            )
 
-        mock_embedding = Mock()
-        mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
-        mock_embedding.metadata = {}
+    def test_raises_when_llm_does_not_respond(self, mocker):
+        """Error when a registered LLM fails validation."""
+        mock_client = MagicMock()
+        registered = [self._make_llm_registry_mock("llm-bad")]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_foundation_model", return_value=False)
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        with pytest.raises(SearchSpaceValueError, match=r"do not respond.*llm-bad"):
+            _validate_availability_and_create_models(
+                provided_models_ids=["llm-bad"],
+                registered_models=registered,
+                models_type="llm",
+                client=mock_client,
+            )
 
-        # Mock validation to fail for foundation model
+    def test_raises_when_embedding_does_not_respond(self, mocker):
+        """Error when a registered embedding model fails validation."""
+        mock_client = MagicMock()
+        registered = [self._make_emb_registry_mock("emb-bad")]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_embedding_model", return_value=False)
+
+        with pytest.raises(SearchSpaceValueError, match=r"do not respond.*emb-bad"):
+            _validate_availability_and_create_models(
+                provided_models_ids=["emb-bad"],
+                registered_models=registered,
+                models_type="embedding",
+                client=mock_client,
+            )
+
+    def test_raises_when_embedding_instantiation_fails(self, mocker):
+        """Exception during OGXEmbeddingModel.__init__ is treated as non-responding."""
+        mock_client = MagicMock()
+        registered = [self._make_emb_registry_mock("emb-broken")]
         mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
-            return_value=False,
-        )
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_embedding_model",
-            return_value=True,
+            "ai4rag.search_space.prepare.ogx_utils.OGXEmbeddingModel",
+            side_effect=Exception("Cannot connect"),
         )
 
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'llm'.*not responding"):
-            _get_default_ogx_models(mock_client)
+        with pytest.raises(SearchSpaceValueError, match=r"do not respond.*emb-broken"):
+            _validate_availability_and_create_models(
+                provided_models_ids=["emb-broken"],
+                registered_models=registered,
+                models_type="embedding",
+                client=mock_client,
+            )
 
-    def test_raises_error_when_all_embedding_models_fail_validation(self, mocker):
-        """Test that error is raised when all embedding models fail validation."""
+    def test_error_message_combines_unregistered_and_not_responding(self, mocker):
+        """A single exception lists both unregistered and non-responding model IDs."""
         mock_client = MagicMock()
-
-        mock_llm = Mock()
-        mock_llm.id = "test-llm"
-        mock_llm.custom_metadata = {"model_type": "llm"}
-
-        mock_embedding = Mock()
-        mock_embedding.id = "test-embedding"
-        mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
-        mock_embedding.metadata = {}
-
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
-
-        # Mock validation to fail for embedding model
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
-            return_value=True,
-        )
-        mocker.patch(
-            "ai4rag.search_space.prepare.ogx_utils._validate_embedding_model",
-            return_value=False,
-        )
-
-        with pytest.raises(SearchSpaceValueError, match="no available models of type 'embedding'.*not responding"):
-            _get_default_ogx_models(mock_client)
-
-
-class TestAreProvidedModelsAvailable:
-    """Test _are_provided_models_available function."""
-
-    def test_no_error_when_all_models_available(self):
-        """Test that function does not raise when all provided models are available."""
-        from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
-        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
-
-        mock_client = MagicMock()
-        available_models = [
-            OGXFoundationModel(model_id="model-1", client=mock_client),
-            OGXFoundationModel(model_id="model-2", client=mock_client),
-        ]
-
-        provided_models = [
-            AI4RAGFoundationModel(model_id="model-1"),
-            AI4RAGFoundationModel(model_id="model-2"),
-        ]
-
-        _are_provided_models_available(provided_models, available_models, not_responding_models=[])
-
-    def test_raises_error_when_model_not_registered(self):
-        """Test that function raises error when provided model is not registered."""
-        from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
-        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
-
-        mock_client = MagicMock()
-        available_models = [
-            OGXFoundationModel(model_id="model-1", client=mock_client),
-        ]
-
-        provided_models = [
-            AI4RAGFoundationModel(model_id="model-2"),
-        ]
-
-        with pytest.raises(SearchSpaceValueError, match="model-2.*not registered within OGX"):
-            _are_provided_models_available(provided_models, available_models, not_responding_models=[])
-
-    def test_raises_error_when_model_not_responding(self):
-        """Test that function raises error when provided model is registered but not responding."""
-        from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
-        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
-
-        mock_client = MagicMock()
-        available_models = [
-            OGXFoundationModel(model_id="model-1", client=mock_client),
-        ]
-        not_responding_models = [
-            OGXFoundationModel(model_id="model-2", client=mock_client),
-        ]
-
-        provided_models = [
-            AI4RAGFoundationModel(model_id="model-2"),
-        ]
-
-        with pytest.raises(SearchSpaceValueError, match="model-2.*registered but do not respond"):
-            _are_provided_models_available(provided_models, available_models, not_responding_models)
-
-    def test_raises_error_with_both_not_responding_and_unregistered(self):
-        """Test that error includes both not-responding and unregistered models."""
-        from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
-        from ai4rag.search_space.prepare.input_payload_types import AI4RAGFoundationModel
-
-        mock_client = MagicMock()
-        available_models = [
-            OGXFoundationModel(model_id="model-1", client=mock_client),
-        ]
-        not_responding_models = [
-            OGXFoundationModel(model_id="model-2", client=mock_client),
-        ]
-
-        provided_models = [
-            AI4RAGFoundationModel(model_id="model-2"),
-            AI4RAGFoundationModel(model_id="model-3"),
-        ]
+        registered = [self._make_llm_registry_mock("llm-bad")]
+        mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_foundation_model", return_value=False)
 
         with pytest.raises(SearchSpaceValueError) as exc_info:
-            _are_provided_models_available(provided_models, available_models, not_responding_models)
+            _validate_availability_and_create_models(
+                provided_models_ids=["llm-bad", "llm-unknown"],
+                registered_models=registered,
+                models_type="llm",
+                client=mock_client,
+            )
 
         error_msg = str(exc_info.value)
-        assert "model-2" in error_msg
-        assert "registered but do not respond" in error_msg
-        assert "model-3" in error_msg
-        assert "not registered within OGX" in error_msg
+        assert "llm-bad" in error_msg
+        assert "llm-unknown" in error_msg
+        assert "do not respond" in error_msg
+        assert "not registered in OGX" in error_msg
+
+    def test_only_validates_provided_models(self, mocker):
+        """Models that are registered but not requested must not be validated."""
+        mock_client = MagicMock()
+        registered = [
+            self._make_llm_registry_mock("llm-ok"),
+            self._make_llm_registry_mock("llm-not-requested"),
+        ]
+        validate_mock = mocker.patch(
+            "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model", return_value=True
+        )
+
+        _validate_availability_and_create_models(
+            provided_models_ids=["llm-ok"],
+            registered_models=registered,
+            models_type="llm",
+            client=mock_client,
+        )
+
+        assert validate_mock.call_count == 1
+        assert validate_mock.call_args[0][0].model_id == "llm-ok"

--- a/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
@@ -181,10 +181,10 @@ class TestValidateAvailabilityAndCreateModels:
         mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_foundation_model", return_value=True)
 
         result = _validate_availability_and_create_models(
-            provided_models_ids=["llm-1", "llm-2"],
             registered_models=registered,
             models_type="llm",
             client=mock_client,
+            provided_models_ids=["llm-1", "llm-2"],
         )
 
         assert len(result) == 2
@@ -198,10 +198,10 @@ class TestValidateAvailabilityAndCreateModels:
         mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_embedding_model", return_value=True)
 
         result = _validate_availability_and_create_models(
-            provided_models_ids=["emb-1"],
             registered_models=registered,
             models_type="embedding",
             client=mock_client,
+            provided_models_ids=["emb-1"],
         )
 
         assert len(result) == 1
@@ -216,10 +216,10 @@ class TestValidateAvailabilityAndCreateModels:
 
         with pytest.raises(SearchSpaceValueError, match=r"not registered in OGX.*llm-unknown"):
             _validate_availability_and_create_models(
-                provided_models_ids=["llm-unknown"],
                 registered_models=registered,
                 models_type="llm",
                 client=mock_client,
+                provided_models_ids=["llm-unknown"],
             )
 
     def test_raises_when_embedding_not_registered(self, mocker):
@@ -230,10 +230,10 @@ class TestValidateAvailabilityAndCreateModels:
 
         with pytest.raises(SearchSpaceValueError, match=r"not registered in OGX.*emb-unknown"):
             _validate_availability_and_create_models(
-                provided_models_ids=["emb-unknown"],
                 registered_models=registered,
                 models_type="embedding",
                 client=mock_client,
+                provided_models_ids=["emb-unknown"],
             )
 
     def test_raises_when_llm_does_not_respond(self, mocker):
@@ -244,10 +244,10 @@ class TestValidateAvailabilityAndCreateModels:
 
         with pytest.raises(SearchSpaceValueError, match=r"do not respond.*llm-bad"):
             _validate_availability_and_create_models(
-                provided_models_ids=["llm-bad"],
                 registered_models=registered,
                 models_type="llm",
                 client=mock_client,
+                provided_models_ids=["llm-bad"],
             )
 
     def test_raises_when_embedding_does_not_respond(self, mocker):
@@ -258,10 +258,10 @@ class TestValidateAvailabilityAndCreateModels:
 
         with pytest.raises(SearchSpaceValueError, match=r"do not respond.*emb-bad"):
             _validate_availability_and_create_models(
-                provided_models_ids=["emb-bad"],
                 registered_models=registered,
                 models_type="embedding",
                 client=mock_client,
+                provided_models_ids=["emb-bad"],
             )
 
     def test_raises_when_embedding_instantiation_fails(self, mocker):
@@ -275,10 +275,10 @@ class TestValidateAvailabilityAndCreateModels:
 
         with pytest.raises(SearchSpaceValueError, match=r"do not respond.*emb-broken"):
             _validate_availability_and_create_models(
-                provided_models_ids=["emb-broken"],
                 registered_models=registered,
                 models_type="embedding",
                 client=mock_client,
+                provided_models_ids=["emb-broken"],
             )
 
     def test_error_message_combines_unregistered_and_not_responding(self, mocker):
@@ -289,10 +289,10 @@ class TestValidateAvailabilityAndCreateModels:
 
         with pytest.raises(SearchSpaceValueError) as exc_info:
             _validate_availability_and_create_models(
-                provided_models_ids=["llm-bad", "llm-unknown"],
                 registered_models=registered,
                 models_type="llm",
                 client=mock_client,
+                provided_models_ids=["llm-bad", "llm-unknown"],
             )
 
         error_msg = str(exc_info.value)
@@ -313,10 +313,10 @@ class TestValidateAvailabilityAndCreateModels:
         )
 
         _validate_availability_and_create_models(
-            provided_models_ids=["llm-ok"],
             registered_models=registered,
             models_type="llm",
             client=mock_client,
+            provided_models_ids=["llm-ok"],
         )
 
         assert validate_mock.call_count == 1

--- a/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
@@ -270,7 +270,7 @@ class TestValidateAvailabilityAndCreateModels:
         registered = [self._make_emb_registry_mock("emb-broken")]
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils.OGXEmbeddingModel",
-            side_effect=Exception("Cannot connect"),
+            side_effect=RuntimeError("Cannot connect"),
         )
 
         with pytest.raises(SearchSpaceValueError, match=r"do not respond.*emb-broken"):

--- a/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
@@ -30,7 +30,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         # Mock validation functions to always return True
         mocker.patch(
@@ -68,7 +68,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         # Mock validation functions to always return True
         mocker.patch(
@@ -108,7 +108,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "custom-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 1024}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         # Mock validation functions to always return True
         mocker.patch(
@@ -148,7 +148,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         # Mock validation functions to always return True
         mocker.patch(
@@ -187,7 +187,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
@@ -221,7 +221,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
@@ -256,7 +256,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
@@ -291,7 +291,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm_ok, mock_llm_bad, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm_ok, mock_llm_bad, mock_embedding]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
@@ -304,7 +304,7 @@ class TestPrepareSearchSpaceWithOgx:
 
         payload = {"foundation_models": [{"model_id": "llm-bad"}]}
 
-        with pytest.raises(SearchSpaceValueError, match="llm-bad.*registered but do not respond"):
+        with pytest.raises(SearchSpaceValueError, match=r"do not respond.*llm-bad"):
             prepare_search_space_with_ogx(payload, mock_client)
 
     def test_user_specifies_not_responding_embedding_model(self, mocker):
@@ -325,7 +325,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_emb_bad.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
         mock_emb_bad.metadata = {}
 
-        mock_client.models.list.return_value = [mock_llm, mock_emb_ok, mock_emb_bad]
+        mock_client.models.list.return_value.data = [mock_llm, mock_emb_ok, mock_emb_bad]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
@@ -338,7 +338,7 @@ class TestPrepareSearchSpaceWithOgx:
 
         payload = {"embedding_models": [{"model_id": "emb-bad"}]}
 
-        with pytest.raises(SearchSpaceValueError, match="emb-bad.*registered but do not respond"):
+        with pytest.raises(SearchSpaceValueError, match=r"do not respond.*emb-bad"):
             prepare_search_space_with_ogx(payload, mock_client)
 
     def test_user_specifies_unregistered_foundation_model(self, mocker):
@@ -353,7 +353,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm, mock_embedding]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",
@@ -366,7 +366,7 @@ class TestPrepareSearchSpaceWithOgx:
 
         payload = {"foundation_models": [{"model_id": "llm-unknown"}]}
 
-        with pytest.raises(SearchSpaceValueError, match="llm-unknown.*not registered within OGX"):
+        with pytest.raises(SearchSpaceValueError, match=r"not registered in OGX.*llm-unknown"):
             prepare_search_space_with_ogx(payload, mock_client)
 
     def test_user_picks_available_model_while_others_fail(self, mocker):
@@ -385,7 +385,7 @@ class TestPrepareSearchSpaceWithOgx:
         mock_embedding.id = "default-embedding"
         mock_embedding.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768}
 
-        mock_client.models.list.return_value = [mock_llm_ok, mock_llm_bad, mock_embedding]
+        mock_client.models.list.return_value.data = [mock_llm_ok, mock_llm_bad, mock_embedding]
 
         mocker.patch(
             "ai4rag.search_space.prepare.ogx_utils._validate_foundation_model",

--- a/tests/unit/ai4rag/utils/event_handler/test_event_handler.py
+++ b/tests/unit/ai4rag/utils/event_handler/test_event_handler.py
@@ -88,13 +88,13 @@ class TestLocalEventHandlerOnStatusChange:
     """Tests for LocalEventHandler.on_status_change."""
 
     def test_on_status_change_logs_message(self, mocker):
-        """Calls logger.info with level, step and message."""
+        """Calls logger.debug with level, step and message."""
         mock_logger = mocker.patch("ai4rag.utils.event_handler.event_handler.logger")
         handler = LocalEventHandler()
 
         handler.on_status_change(level=LogLevel.INFO, message="test message", step="chunking")
 
-        mock_logger.info.assert_called_once()
+        mock_logger.debug.assert_called_once()
 
     def test_on_status_change_with_step(self, mocker):
         """Step value is forwarded to the log call."""
@@ -103,7 +103,7 @@ class TestLocalEventHandlerOnStatusChange:
 
         handler.on_status_change(level=LogLevel.INFO, message="msg", step="embedding")
 
-        call_args = mock_logger.info.call_args[0]
+        call_args = mock_logger.debug.call_args[0]
         assert "embedding" in call_args
 
     def test_on_status_change_without_step(self, mocker):
@@ -113,8 +113,8 @@ class TestLocalEventHandlerOnStatusChange:
 
         handler.on_status_change(level=LogLevel.WARNING, message="msg")
 
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args[0]
+        mock_logger.debug.assert_called_once()
+        call_args = mock_logger.debug.call_args[0]
         assert None in call_args
 
 
@@ -128,7 +128,7 @@ class TestLocalEventHandlerOnPatternCreationWithoutOutputPath:
 
         handler.on_pattern_creation(payload=PAYLOAD, evaluation_results=EVALUATION_RESULTS)
 
-        mock_logger.info.assert_called_once()
+        mock_logger.debug.assert_called_once()
 
     def test_does_not_raise(self):
         """Calling without output_path must not raise."""

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,6 @@ dependencies = [
     { name = "langchain-chroma" },
     { name = "langchain-text-splitters" },
     { name = "ogx-client" },
-    { name = "openai" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pygam" },
@@ -104,7 +103,6 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },
     { name = "nbformat", marker = "extra == 'test'" },
     { name = "ogx-client", specifier = "~=0.8.0" },
-    { name = "openai", specifier = "==2.23.*" },
     { name = "pandas", specifier = "==2.2.*" },
     { name = "psutil", marker = "extra == 'test'" },
     { name = "pydantic", specifier = "==2.11.*" },
@@ -1435,51 +1433,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jiter"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
-    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
-    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
-    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
-    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
-    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
-    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
-    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
-    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
-    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
-    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
-    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
-    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
-]
-
-[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2543,25 +2496,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/6c/a6c5aea47dc95fca7728f8a5af67c184ec9e7d4e7882125c7062e4bba8dd/onnxruntime-1.25.1-cp313-cp313-win_arm64.whl", hash = "sha256:84f8963d70e00167bae273ab7e80e9795bfc5eb94f6b23236a99c5c11af00844", size = 12634117, upload-time = "2026-04-27T22:00:29.15Z" },
     { url = "https://files.pythonhosted.org/packages/a8/8a/3b65e7911eec86c125e3d6f43d690a6f68671500543c0390ecd6eb59b771/onnxruntime-1.25.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03e800b3a4b48d9f3a2d23aacc4fa95486a3b406b14e51d1a9b8b6981d9adf9c", size = 15882935, upload-time = "2026-04-27T21:59:44.912Z" },
     { url = "https://files.pythonhosted.org/packages/3c/bb/410a760694f8ae7bbfc5fa81ccbeb7da241e6d520ee02a333a439cf462a2/onnxruntime-1.25.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd83ef5c10cfc051a1cb465db692d57b996a1bc75a2a97b161398e29cdbc47ff", size = 18021727, upload-time = "2026-04-27T22:00:13.846Z" },
-]
-
-[[package]]
-name = "openai"
-version = "2.23.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/4b/dc1d84b8237205ebe48a1b1c9c3a8e1ab9fd08b30811b6d787196df58fd6/openai-2.23.0.tar.gz", hash = "sha256:7d24cc8087d5e8eed58e98aaa823391d39d12f9a9a2755770f67c7bb2004d94c", size = 657323, upload-time = "2026-02-24T03:20:20.323Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/5f/bcdf0fb510c24f021e485f920677da363cd59d6e0310171bf2cad6e052b5/openai-2.23.0-py3-none-any.whl", hash = "sha256:1041d40bebf845053fda1946104f8bf9c3e2df957a41c3878c55c72c352630e9", size = 1118971, upload-time = "2026-02-24T03:20:18.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Assisted-by: Claude Code

## Description

Refactors the OGX model selection and validation pipeline to separate the concerns of "listing registered models"
from "validating and instantiating models". Also reduces log noise by downgrading internal event handler logs to
DEBUG level.

## Motivation

The previous implementation validated all registered OGX models upfront (even ones the user never requested), which
caused unnecessary network calls and made error messages harder to reason about. The new design validates only the
models actually needed for the experiment, and produces clearer error messages distinguishing between "not
registered" and "registered but not responding" failures.

## Changes

- ogx_utils.py: _get_default_ogx_models now only lists registered models without validating them; replaced _are_provided_models_available with _validate_availability_and_create_models, which combines registration check,
validation, and model instantiation into a single function
- ogx_utils.py: Return type of _get_default_ogx_models uses Model (from ogx_client.types) instead of instantiated
model objects; removed not_responding_* fields from the response
- ogx_utils.py: Improved warning log messages for non-responding models; removed exc_info=True from non-critical validation warnings
- prepare_search_space.py: Both user-specified and default model paths now go through
_validate_availability_and_create_models, eliminating a separate model-instantiation code path for the default case
- experiment.py: Renamed kwargs n_mps_fm → n_mps_foundation_models and n_mps_em → n_mps_embedding_models for clarity
- event_handler.py: Downgraded on_status_change and on_pattern_creation log calls from INFO to DEBUG to reduce noise
in default log output
- ogx.py: Removed stale pylint: disable=duplicate-code comment
- scripts/format.sh: Updated to use uv run isort / uv run black for consistency with the uv toolchain
- Tests: Updated all affected tests; replaced TestAreProvidedModelsAvailable with
TestValidateAvailabilityAndCreateModels; added tests verifying that _get_default_ogx_models no longer triggers
validation

## Testing

- Unit tests updated and extended to cover the new _validate_availability_and_create_models function, including:
  unregistered models, non-responding models, instantiation failures, and combined error messages
- Verified that _get_default_ogx_models no longer calls validation functions (new dedicated test)
##  Checklist

  - [ ] Tests added/updated
  - [ ] Documentation updated
  - [ ] Code follows style guide
  - [ ] All checks passing
