### PR TITLE
Release 0.6.0

### DIFF
--- a/ai4rag/search_space/src/model_props.py
+++ b/ai4rag/search_space/src/model_props.py
@@ -116,6 +116,25 @@ _DEFAULT_MISTRAL_USER_MESSAGE_TEXT = (
 )
 
 
+_DEFAULT_OPENAI_SYSTEM_MESSAGE_TEXT = (
+    "You are a AI language model designed to function as a specialized Retrieval Augmented Generation (RAG) assistant. "
+    "When generating responses, prioritize correctness, i.e., ensure that your response is correct given the context "
+    "and user query, and that it is grounded in the context. "
+    "Furthermore, make sure that the response is supported by the given document or context. "
+    "When the question cannot be answered using the context or document, output the following response: "
+    "'I am sorry, I do not have the information you are looking for in my knowledge base.'. "
+    "Always make sure that your response is relevant to the question. If an explanation is needed, "
+    "first provide the explanation or reasoning, and then give the final answer.\nAnswer Length: concise.\n\n"
+)
+
+
+_DEFAULT_OPENAI_USER_MESSAGE_TEXT = (
+    f"[Document]\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n[End]\n"
+    f"{{{QUESTION_PLACEHOLDER}}}. \n"
+    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
+)
+
+
 _model_name_to_system_message_text = {
     FoundationModels.META_LLAMA_3_1_70B_INSTRUCT: _DEFAULT_LLAMA_SYSTEM_MESSAGE_TEXT,
     FoundationModels.META_LLAMA_3_1_8B_INSTRUCT: _DEFAULT_LLAMA_SYSTEM_MESSAGE_TEXT,
@@ -126,6 +145,7 @@ _model_name_to_system_message_text = {
     FoundationModels.MISTRAL_SMALL_3_1_24B_INSTRUCT: _DEFAULT_MISTRAL_SYSTEM_MESSAGE_TEXT,
     FoundationModels.MISTRAL_MEDIUM_2505: _DEFAULT_MISTRAL_SYSTEM_MESSAGE_TEXT,
     FoundationModels.MISTRAL_MISTRAL_LARGE: _DEFAULT_MISTRAL_SYSTEM_MESSAGE_TEXT,
+    FoundationModels.OPENAI_GPT_OSS_120B: _DEFAULT_OPENAI_SYSTEM_MESSAGE_TEXT,
 }
 
 
@@ -139,6 +159,7 @@ _model_name_to_user_message_text = {
     FoundationModels.MISTRAL_SMALL_3_1_24B_INSTRUCT: _DEFAULT_MISTRAL_USER_MESSAGE_TEXT,
     FoundationModels.MISTRAL_MEDIUM_2505: _DEFAULT_MISTRAL_USER_MESSAGE_TEXT,
     FoundationModels.MISTRAL_MISTRAL_LARGE: _DEFAULT_MISTRAL_USER_MESSAGE_TEXT,
+    FoundationModels.OPENAI_GPT_OSS_120B: _DEFAULT_OPENAI_USER_MESSAGE_TEXT,
 }
 
 
@@ -156,6 +177,7 @@ _model_name_to_context_template_text = {
     FoundationModels.META_LLAMA_4_MAVERICK_17B_128E_INSTRUCT_FP8: _DEFAULT_LLAMA_CONTEXT_TEMPLATE,
     FoundationModels.GRANITE_3_8B_INSTRUCT: _DEFAULT_GRANITE_CONTEXT_TEMPLATE,
     FoundationModels.GRANITE_3_3_8B_INSTRUCT: _DEFAULT_GRANITE_CONTEXT_TEMPLATE,
+    FoundationModels.OPENAI_GPT_OSS_120B: _DEFAULT_CONTEXT_TEMPLATE,
 }
 
 

--- a/ai4rag/search_space/src/models.py
+++ b/ai4rag/search_space/src/models.py
@@ -109,6 +109,7 @@ class FoundationModels(Models):
     META_LLAMA_3_1_8B_INSTRUCT = "meta-llama/llama-3-1-8b-instruct"
     META_LLAMA_3_3_70B_INSTRUCT = "meta-llama/llama-3-3-70b-instruct"
     META_LLAMA_4_MAVERICK_17B_128E_INSTRUCT_FP8 = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+    OPENAI_GPT_OSS_120B = "openai/gpt-oss-120b"
 
     @classmethod
     def get_default_max_sequence_length(cls, model_id: str, default: int = DEFAULT_MAX_SEQUENCE_LENGTH) -> int:
@@ -141,6 +142,7 @@ class FoundationModels(Models):
             cls.META_LLAMA_4_MAVERICK_17B_128E_INSTRUCT_FP8: 131_072,
             cls.GRANITE_3_8B_INSTRUCT: 131_072,
             cls.GRANITE_3_3_8B_INSTRUCT: 131_072,
+            cls.OPENAI_GPT_OSS_120B: 131_072,
             cls.GRANITE_4H_SMALL: 131_072,
         }
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.0](https://github.com/IBM/ai4rag/releases/tag/v0.6.0)
+
+### Added
+- `uv` package manager support as an alternative to `pip` for dependency management and development workflows
+- `AGENTS.md` file with AI agent guidelines for contributing to the project
+
+### Changed
+- Rebranded all Llama Stack integrations to OGX: `LSEmbeddingModel` → `OGXEmbeddingModel`, `LSFoundationModel` → `OGXFoundationModel`, `LSVectorStore` → `OGXVectorStore`, `prepare_search_space_with_llama_stack` → `prepare_search_space_with_ogx` (and all related classes, modules, and configuration keys)
+- Replaced `llama-stack-client` dependency with `ogx-client`
+- Improved logging during model selection and validation — clearer messages when models are filtered or skipped
+- Updated CI/CD workflows to use `uv` for dependency installation and test execution
+- Updated all documentation to reflect the Llama Stack → OGX rebranding
+
+### Removed
+- OpenAI model wrappers (`OpenAIEmbeddingModel`, `OpenAIFoundationModel`)
+- `dev_utils/run_experiment_with_openai_models.py` example script
+- Llama Stack example notebooks from `dev_utils/llama_stack_examples/`
+
+---
+
 ## [0.5.5](https://github.com/IBM/ai4rag/releases/tag/v0.5.5)
 
 ### Changed


### PR DESCRIPTION
Assisted-by: Claude Code

# Release v0.6.0

## Summary

This release rebrands all Llama Stack integrations to OGX, reflecting the upstream project rename, and removes the OpenAI model wrappers to streamline the codebase around the OGX provider. It also introduces `uv` as a supported package manager for faster dependency management and improves logging during model selection and validation.

## Changes

### Added
- `uv` package manager support as an alternative to `pip` for dependency management and development workflows
- `AGENTS.md` file with AI agent guidelines for contributing to the project

### Changed
- Rebranded all Llama Stack integrations to OGX: `LSEmbeddingModel` -> `OGXEmbeddingModel`, `LSFoundationModel` -> `OGXFoundationModel`, `LSVectorStore` -> `OGXVectorStore`, `prepare_search_space_with_llama_stack` -> `prepare_search_space_with_ogx` (and all related classes, modules, and configuration keys)
- Replaced `llama-stack-client` dependency with `ogx-client`
- Improved logging during model selection and validation -- clearer messages when models are filtered or skipped
- Updated CI/CD workflows to use `uv` for dependency installation and test execution
- Updated all documentation to reflect the Llama Stack -> OGX rebranding

### Removed
- OpenAI model wrappers (`OpenAIEmbeddingModel`, `OpenAIFoundationModel`) and associated utilities (`model_props.py`)
- `dev_utils/run_experiment_with_openai_models.py` example script
- Llama Stack example notebooks from `dev_utils/llama_stack_examples/`

## Migration notes

**Breaking changes -- action required:**

1. **Llama Stack -> OGX rename**: All class names, module paths, and configuration keys have changed:
   - `LSEmbeddingModel` -> `OGXEmbeddingModel`
   - `LSFoundationModel` -> `OGXFoundationModel`
   - `LSVectorStore` -> `OGXVectorStore`
   - `prepare_search_space_with_llama_stack()` -> `prepare_search_space_with_ogx()`
   - `llama_stack_url` parameter -> `ogx_url`
   - Vector store types: `ls_milvus` -> `ogx_milvus`, `ls_qdrant` -> `ogx_qdrant`, etc.
   - Update all imports from `ai4rag.rag.embedding.llama_stack` to `ai4rag.rag.embedding.ogx` (same for `foundation_models` and `vector_store`)

2. **OpenAI models removed**: `OpenAIEmbeddingModel` and `OpenAIFoundationModel` are no longer available. Use the OGX-based model classes instead.

3. **Dependency change**: Replace `llama-stack-client` with `ogx-client` in your dependencies.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.6.0`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
