### PR TITLE
Switch OGX vector store from vector_io.query() to vector_stores.search()

### DIFF
--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -198,19 +198,15 @@ class OGXVectorStore(BaseVectorStore):
         )
 
         if include_scores:
-            return [
-                (self._data_item_to_document(item), item.score)
-                for item in resp.data
-            ]
+            return [(self._data_item_to_document(item), item.score) for item in resp.data]
 
         return [self._data_item_to_document(item) for item in resp.data]
 
     @staticmethod
     def _data_item_to_document(item) -> Document:
         """Convert a VectorStoreSearchResponse.Data item to a LangChain Document."""
-        content_item = item.content[0]
-        metadata = content_item.chunk_metadata.model_dump(exclude_none=True) if content_item.chunk_metadata else {}
-        return Document(page_content=content_item.text, metadata=metadata)
+        metadata = dict(item.attributes) if item.attributes else {}
+        return Document(page_content=item.content[0].text, metadata=metadata)
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -180,29 +180,37 @@ class OGXVectorStore(BaseVectorStore):
             List of chunks as Document instances with or without scores, depending on the input.
         """
         self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
-        params = {
-            "max_chunks": k,
-            "mode": search_mode,
-        }
 
+        ranking_options = None
         if search_mode == "hybrid" and ranker_strategy:
-            params["reranker_type"] = ranker_strategy
-            reranker_params = {}
+            ranking_options = {"ranker": ranker_strategy}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
-                reranker_params["impact_factor"] = ranker_k
+                ranking_options["impact_factor"] = ranker_k
             if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
-                reranker_params["alpha"] = ranker_alpha
-            params["reranker_params"] = reranker_params
+                ranking_options["alpha"] = ranker_alpha
 
-        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
+        resp = self.client.vector_stores.search(
+            vector_store_id=self._ogx_vs.id,
+            query=query,
+            max_num_results=k,
+            search_mode=search_mode,
+            ranking_options=ranking_options,
+        )
 
         if include_scores:
             return [
-                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
-                for chunk, score in zip(resp.chunks, resp.scores)
+                (self._data_item_to_document(item), item.score)
+                for item in resp.data
             ]
 
-        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
+        return [self._data_item_to_document(item) for item in resp.data]
+
+    @staticmethod
+    def _data_item_to_document(item) -> Document:
+        """Convert a VectorStoreSearchResponse.Data item to a LangChain Document."""
+        content_item = item.content[0]
+        metadata = content_item.chunk_metadata.model_dump(exclude_none=True) if content_item.chunk_metadata else {}
+        return Document(page_content=content_item.text, metadata=metadata)
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -139,16 +139,13 @@ class TestOGXVectorStoreCollectionName:
 
 def _make_mock_search_data_item(text: str, metadata: dict, score: float) -> MagicMock:
     """Build a mock VectorStoreSearchResponse.Data item."""
-    mock_chunk_metadata = MagicMock()
-    mock_chunk_metadata.model_dump.return_value = metadata
-
     mock_content_item = MagicMock()
     mock_content_item.text = text
-    mock_content_item.chunk_metadata = mock_chunk_metadata
 
     mock_data_item = MagicMock()
     mock_data_item.content = [mock_content_item]
     mock_data_item.score = score
+    mock_data_item.attributes = metadata
     return mock_data_item
 
 
@@ -231,10 +228,7 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        data_items = [
-            _make_mock_search_data_item(f"Content {i}", {"id": i}, 0.9 - i * 0.1)
-            for i in range(3)
-        ]
+        data_items = [_make_mock_search_data_item(f"Content {i}", {"id": i}, 0.9 - i * 0.1) for i in range(3)]
 
         mock_response = MagicMock()
         mock_response.data = data_items

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -137,6 +137,21 @@ class TestOGXVectorStoreCollectionName:
         assert vector_store.collection_name == vector_store._ogx_vs.id
 
 
+def _make_mock_search_data_item(text: str, metadata: dict, score: float) -> MagicMock:
+    """Build a mock VectorStoreSearchResponse.Data item."""
+    mock_chunk_metadata = MagicMock()
+    mock_chunk_metadata.model_dump.return_value = metadata
+
+    mock_content_item = MagicMock()
+    mock_content_item.text = text
+    mock_content_item.chunk_metadata = mock_chunk_metadata
+
+    mock_data_item = MagicMock()
+    mock_data_item.content = [mock_content_item]
+    mock_data_item.score = score
+    return mock_data_item
+
+
 class TestOGXVectorStoreSearch:
     """Test suite for OGXVectorStore.search method."""
 
@@ -153,16 +168,9 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        # Mock search response
-        mock_chunk = MagicMock()
-        mock_chunk.content = "Test content"
-        mock_chunk.chunk_metadata.to_dict.return_value = {"doc_id": "doc1", "seq": 1}
-
         mock_response = MagicMock()
-        mock_response.chunks = [mock_chunk]
-        mock_response.scores = [0.95]
-
-        mock_client.vector_io.query.return_value = mock_response
+        mock_response.data = [_make_mock_search_data_item("Test content", {"doc_id": "doc1", "seq": 1}, 0.95)]
+        mock_client.vector_stores.search.return_value = mock_response
         return mock_client
 
     def test_search_without_scores(self, mock_embedding_model, mock_ogx_client):
@@ -209,11 +217,12 @@ class TestOGXVectorStoreSearch:
 
         vector_store.search("test query", k=10)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
         assert call_kwargs["query"] == "test query"
         assert call_kwargs["vector_store_id"] == "test-vs-id"
-        assert call_kwargs["params"]["max_chunks"] == 10
-        assert call_kwargs["params"]["mode"] == "vector"
+        assert call_kwargs["max_num_results"] == 10
+        assert call_kwargs["search_mode"] == "vector"
+        assert call_kwargs["ranking_options"] is None
 
     def test_search_with_multiple_results(self, mock_embedding_model):
         """Test search with multiple results."""
@@ -222,20 +231,14 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        # Create multiple chunks
-        chunks = []
-        scores = []
-        for i in range(3):
-            mock_chunk = MagicMock()
-            mock_chunk.content = f"Content {i}"
-            mock_chunk.chunk_metadata.to_dict.return_value = {"id": i}
-            chunks.append(mock_chunk)
-            scores.append(0.9 - i * 0.1)
+        data_items = [
+            _make_mock_search_data_item(f"Content {i}", {"id": i}, 0.9 - i * 0.1)
+            for i in range(3)
+        ]
 
         mock_response = MagicMock()
-        mock_response.chunks = chunks
-        mock_response.scores = scores
-        mock_client.vector_io.query.return_value = mock_response
+        mock_response.data = data_items
+        mock_client.vector_stores.search.return_value = mock_response
 
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -267,15 +270,9 @@ class TestOGXVectorStoreHybridSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        mock_chunk = MagicMock()
-        mock_chunk.content = "Test content"
-        mock_chunk.chunk_metadata.to_dict.return_value = {"doc_id": "doc1"}
-
         mock_response = MagicMock()
-        mock_response.chunks = [mock_chunk]
-        mock_response.scores = [0.95]
-
-        mock_client.vector_io.query.return_value = mock_response
+        mock_response.data = [_make_mock_search_data_item("Test content", {"doc_id": "doc1"}, 0.95)]
+        mock_client.vector_stores.search.return_value = mock_response
         return mock_client
 
     def test_search_default_vector_mode(self, mock_embedding_model, mock_ogx_client):
@@ -288,9 +285,9 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        assert call_kwargs["params"]["mode"] == "vector"
-        assert "reranker_type" not in call_kwargs["params"]
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "vector"
+        assert call_kwargs["ranking_options"] is None
 
     def test_search_with_hybrid_mode_rrf(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and RRF ranker."""
@@ -302,11 +299,10 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        params = call_kwargs["params"]
-        assert params["mode"] == "hybrid"
-        assert params["reranker_type"] == "rrf"
-        assert params["reranker_params"]["impact_factor"] == 60
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "hybrid"
+        assert call_kwargs["ranking_options"]["ranker"] == "rrf"
+        assert call_kwargs["ranking_options"]["impact_factor"] == 60
 
     def test_search_with_hybrid_mode_weighted(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and weighted ranker including alpha."""
@@ -318,11 +314,10 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_alpha=0.7)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        params = call_kwargs["params"]
-        assert params["mode"] == "hybrid"
-        assert params["reranker_type"] == "weighted"
-        assert params["reranker_params"]["alpha"] == 0.7
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "hybrid"
+        assert call_kwargs["ranking_options"]["ranker"] == "weighted"
+        assert call_kwargs["ranking_options"]["alpha"] == 0.7
 
     def test_search_with_hybrid_mode_normalized(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and normalized ranker."""
@@ -334,11 +329,9 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="normalized")
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        params = call_kwargs["params"]
-        assert params["mode"] == "hybrid"
-        assert params["reranker_type"] == "normalized"
-        assert params["reranker_params"] == {}
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "hybrid"
+        assert call_kwargs["ranking_options"]["ranker"] == "normalized"
 
     def test_search_hybrid_empty_strategy_raises(self, mock_embedding_model, mock_ogx_client):
         """Test that empty ranker_strategy with hybrid mode raises ValueError."""


### PR DESCRIPTION
## Summary

  - Replace internal OGX API (`client.vector_io.query()`) with OpenAI-compatible search endpoint
  (`client.vector_stores.search()`) for chunk retrieval
  - Adapt response parsing from `QueryChunksResponse` (chunks + parallel scores) to `VectorStoreSearchResponse` (data
  items with nested scores and attributes)
  - Extract metadata from `item.attributes` instead of `item.content[0].chunk_metadata` since the search endpoint does
  not populate chunk_metadata by default

  ## Motivation

  The `vector_stores.search()` endpoint is the primary public OGX API going forward. It provides:
  - Server-managed reranker defaults via `VectorStoresConfig`
  - Over-retrieval with chunk multiplier before reranking (better hybrid results)
  - Future access to query rewriting and neural reranking capabilities

  ## Changes

  ### `ai4rag/rag/vector_store/ogx.py`
  - **Client call**: `client.vector_io.query(query, vector_store_id, params)` →
  `client.vector_stores.search(vector_store_id, query, max_num_results, search_mode, ranking_options)`
  - **Parameter mapping**: Flat `params` dict with `max_chunks`/`mode`/`reranker_type`/`reranker_params` → typed
  parameters (`max_num_results`, `search_mode`) and `ranking_options` dict (`ranker`, `impact_factor`, `alpha`)
  - **Response parsing**: Added `_data_item_to_document()` helper — reads `item.content[0].text` for page content and
  `item.attributes` for metadata
  - **Ranking options**: Only passed for hybrid mode to avoid server-side config defaults overriding pure vector search
   behavior

  ### `tests/unit/ai4rag/rag/vector_store/test_ogx.py`
  - Updated all mock fixtures from `vector_io.query` to `vector_stores.search` response shape
  - Added `_make_mock_search_data_item()` helper to construct `VectorStoreSearchResponse.Data` mocks
  - Updated all parameter assertions to verify `ranking_options` dict structure

  ## Known caveats

  - **"normalized" ranker strategy**: Passed through by the server's `_build_reranker_params` but not explicitly
  handled — needs integration testing
  - **Chunk multiplier**: Server retrieves `max_num_results × chunk_multiplier` (default 5×) candidates before
  reranking — hybrid results may differ from previous behavior
  - **Silent error handling**: The search endpoint catches exceptions and returns empty results instead of raising

  ## Test plan

  - [x] All 45 OGX vector store unit tests pass
  - [x] Full test suite (815 unit tests) passes — 3 pre-existing functional test failures (unrelated, caused by missing
   remote OGX server model)
  - [ ] Integration test: Run RAG experiment against live OGX server to verify metadata and result consistency
  - [ ] Verify `ranker_strategy="normalized"` works end-to-end via search endpoint
