### PR TITLE
Switch to ogx 1.0.0

### DIFF
--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -180,29 +180,33 @@ class OGXVectorStore(BaseVectorStore):
             List of chunks as Document instances with or without scores, depending on the input.
         """
         self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
-        params = {
-            "max_chunks": k,
-            "mode": search_mode,
-        }
 
+        ranking_options = None
         if search_mode == "hybrid" and ranker_strategy:
-            params["reranker_type"] = ranker_strategy
-            reranker_params = {}
+            ranking_options = {"ranker": ranker_strategy}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
-                reranker_params["impact_factor"] = ranker_k
+                ranking_options["impact_factor"] = ranker_k
             if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
-                reranker_params["alpha"] = ranker_alpha
-            params["reranker_params"] = reranker_params
+                ranking_options["alpha"] = ranker_alpha
 
-        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
+        resp = self.client.vector_stores.search(
+            vector_store_id=self._ogx_vs.id,
+            query=query,
+            max_num_results=k,
+            search_mode=search_mode,
+            ranking_options=ranking_options,
+        )
 
         if include_scores:
-            return [
-                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
-                for chunk, score in zip(resp.chunks, resp.scores)
-            ]
+            return [(self._data_item_to_document(item), item.score) for item in resp.data]
 
-        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
+        return [self._data_item_to_document(item) for item in resp.data]
+
+    @staticmethod
+    def _data_item_to_document(item) -> Document:
+        """Convert a VectorStoreSearchResponse.Data item to a LangChain Document."""
+        metadata = dict(item.attributes) if item.attributes else {}
+        return Document(page_content=item.content[0].text, metadata=metadata)
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -180,33 +180,29 @@ class OGXVectorStore(BaseVectorStore):
             List of chunks as Document instances with or without scores, depending on the input.
         """
         self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
+        params = {
+            "max_chunks": k,
+            "mode": search_mode,
+        }
 
-        ranking_options = None
         if search_mode == "hybrid" and ranker_strategy:
-            ranking_options = {"ranker": ranker_strategy}
+            params["reranker_type"] = ranker_strategy
+            reranker_params = {}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
-                ranking_options["impact_factor"] = ranker_k
+                reranker_params["impact_factor"] = ranker_k
             if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
-                ranking_options["alpha"] = ranker_alpha
+                reranker_params["alpha"] = ranker_alpha
+            params["reranker_params"] = reranker_params
 
-        resp = self.client.vector_stores.search(
-            vector_store_id=self._ogx_vs.id,
-            query=query,
-            max_num_results=k,
-            search_mode=search_mode,
-            ranking_options=ranking_options,
-        )
+        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
 
         if include_scores:
-            return [(self._data_item_to_document(item), item.score) for item in resp.data]
+            return [
+                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
+                for chunk, score in zip(resp.chunks, resp.scores)
+            ]
 
-        return [self._data_item_to_document(item) for item in resp.data]
-
-    @staticmethod
-    def _data_item_to_document(item) -> Document:
-        """Convert a VectorStoreSearchResponse.Data item to a LangChain Document."""
-        metadata = dict(item.attributes) if item.attributes else {}
-        return Document(page_content=item.content[0].text, metadata=metadata)
+        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "langchain~=1.1.3",
     "langchain_chroma~=1.1.0",
     "langchain-text-splitters~=1.1.0",
-    "ogx-client~=0.8.0",
-
+    "ogx-client~=1.0.0",
     "pandas==2.2.*",
     "pydantic==2.11.*",
     "pygam~=0.12.0",

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -137,6 +137,18 @@ class TestOGXVectorStoreCollectionName:
         assert vector_store.collection_name == vector_store._ogx_vs.id
 
 
+def _make_mock_search_data_item(text: str, metadata: dict, score: float) -> MagicMock:
+    """Build a mock VectorStoreSearchResponse.Data item."""
+    mock_content_item = MagicMock()
+    mock_content_item.text = text
+
+    mock_data_item = MagicMock()
+    mock_data_item.content = [mock_content_item]
+    mock_data_item.score = score
+    mock_data_item.attributes = metadata
+    return mock_data_item
+
+
 class TestOGXVectorStoreSearch:
     """Test suite for OGXVectorStore.search method."""
 
@@ -153,16 +165,9 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        # Mock search response
-        mock_chunk = MagicMock()
-        mock_chunk.content = "Test content"
-        mock_chunk.chunk_metadata.to_dict.return_value = {"doc_id": "doc1", "seq": 1}
-
         mock_response = MagicMock()
-        mock_response.chunks = [mock_chunk]
-        mock_response.scores = [0.95]
-
-        mock_client.vector_io.query.return_value = mock_response
+        mock_response.data = [_make_mock_search_data_item("Test content", {"doc_id": "doc1", "seq": 1}, 0.95)]
+        mock_client.vector_stores.search.return_value = mock_response
         return mock_client
 
     def test_search_without_scores(self, mock_embedding_model, mock_ogx_client):
@@ -209,11 +214,12 @@ class TestOGXVectorStoreSearch:
 
         vector_store.search("test query", k=10)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
         assert call_kwargs["query"] == "test query"
         assert call_kwargs["vector_store_id"] == "test-vs-id"
-        assert call_kwargs["params"]["max_chunks"] == 10
-        assert call_kwargs["params"]["mode"] == "vector"
+        assert call_kwargs["max_num_results"] == 10
+        assert call_kwargs["search_mode"] == "vector"
+        assert call_kwargs["ranking_options"] is None
 
     def test_search_with_multiple_results(self, mock_embedding_model):
         """Test search with multiple results."""
@@ -222,20 +228,11 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        # Create multiple chunks
-        chunks = []
-        scores = []
-        for i in range(3):
-            mock_chunk = MagicMock()
-            mock_chunk.content = f"Content {i}"
-            mock_chunk.chunk_metadata.to_dict.return_value = {"id": i}
-            chunks.append(mock_chunk)
-            scores.append(0.9 - i * 0.1)
+        data_items = [_make_mock_search_data_item(f"Content {i}", {"id": i}, 0.9 - i * 0.1) for i in range(3)]
 
         mock_response = MagicMock()
-        mock_response.chunks = chunks
-        mock_response.scores = scores
-        mock_client.vector_io.query.return_value = mock_response
+        mock_response.data = data_items
+        mock_client.vector_stores.search.return_value = mock_response
 
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -267,15 +264,9 @@ class TestOGXVectorStoreHybridSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        mock_chunk = MagicMock()
-        mock_chunk.content = "Test content"
-        mock_chunk.chunk_metadata.to_dict.return_value = {"doc_id": "doc1"}
-
         mock_response = MagicMock()
-        mock_response.chunks = [mock_chunk]
-        mock_response.scores = [0.95]
-
-        mock_client.vector_io.query.return_value = mock_response
+        mock_response.data = [_make_mock_search_data_item("Test content", {"doc_id": "doc1"}, 0.95)]
+        mock_client.vector_stores.search.return_value = mock_response
         return mock_client
 
     def test_search_default_vector_mode(self, mock_embedding_model, mock_ogx_client):
@@ -288,9 +279,9 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        assert call_kwargs["params"]["mode"] == "vector"
-        assert "reranker_type" not in call_kwargs["params"]
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "vector"
+        assert call_kwargs["ranking_options"] is None
 
     def test_search_with_hybrid_mode_rrf(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and RRF ranker."""
@@ -302,11 +293,10 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        params = call_kwargs["params"]
-        assert params["mode"] == "hybrid"
-        assert params["reranker_type"] == "rrf"
-        assert params["reranker_params"]["impact_factor"] == 60
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "hybrid"
+        assert call_kwargs["ranking_options"]["ranker"] == "rrf"
+        assert call_kwargs["ranking_options"]["impact_factor"] == 60
 
     def test_search_with_hybrid_mode_weighted(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and weighted ranker including alpha."""
@@ -318,11 +308,10 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_alpha=0.7)
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        params = call_kwargs["params"]
-        assert params["mode"] == "hybrid"
-        assert params["reranker_type"] == "weighted"
-        assert params["reranker_params"]["alpha"] == 0.7
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "hybrid"
+        assert call_kwargs["ranking_options"]["ranker"] == "weighted"
+        assert call_kwargs["ranking_options"]["alpha"] == 0.7
 
     def test_search_with_hybrid_mode_normalized(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and normalized ranker."""
@@ -334,11 +323,9 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="normalized")
 
-        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
-        params = call_kwargs["params"]
-        assert params["mode"] == "hybrid"
-        assert params["reranker_type"] == "normalized"
-        assert params["reranker_params"] == {}
+        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        assert call_kwargs["search_mode"] == "hybrid"
+        assert call_kwargs["ranking_options"]["ranker"] == "normalized"
 
     def test_search_hybrid_empty_strategy_raises(self, mock_embedding_model, mock_ogx_client):
         """Test that empty ranker_strategy with hybrid mode raises ValueError."""

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -137,18 +137,6 @@ class TestOGXVectorStoreCollectionName:
         assert vector_store.collection_name == vector_store._ogx_vs.id
 
 
-def _make_mock_search_data_item(text: str, metadata: dict, score: float) -> MagicMock:
-    """Build a mock VectorStoreSearchResponse.Data item."""
-    mock_content_item = MagicMock()
-    mock_content_item.text = text
-
-    mock_data_item = MagicMock()
-    mock_data_item.content = [mock_content_item]
-    mock_data_item.score = score
-    mock_data_item.attributes = metadata
-    return mock_data_item
-
-
 class TestOGXVectorStoreSearch:
     """Test suite for OGXVectorStore.search method."""
 
@@ -165,9 +153,16 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
+        # Mock search response
+        mock_chunk = MagicMock()
+        mock_chunk.content = "Test content"
+        mock_chunk.chunk_metadata.to_dict.return_value = {"doc_id": "doc1", "seq": 1}
+
         mock_response = MagicMock()
-        mock_response.data = [_make_mock_search_data_item("Test content", {"doc_id": "doc1", "seq": 1}, 0.95)]
-        mock_client.vector_stores.search.return_value = mock_response
+        mock_response.chunks = [mock_chunk]
+        mock_response.scores = [0.95]
+
+        mock_client.vector_io.query.return_value = mock_response
         return mock_client
 
     def test_search_without_scores(self, mock_embedding_model, mock_ogx_client):
@@ -214,12 +209,11 @@ class TestOGXVectorStoreSearch:
 
         vector_store.search("test query", k=10)
 
-        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
+        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         assert call_kwargs["query"] == "test query"
         assert call_kwargs["vector_store_id"] == "test-vs-id"
-        assert call_kwargs["max_num_results"] == 10
-        assert call_kwargs["search_mode"] == "vector"
-        assert call_kwargs["ranking_options"] is None
+        assert call_kwargs["params"]["max_chunks"] == 10
+        assert call_kwargs["params"]["mode"] == "vector"
 
     def test_search_with_multiple_results(self, mock_embedding_model):
         """Test search with multiple results."""
@@ -228,11 +222,20 @@ class TestOGXVectorStoreSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
-        data_items = [_make_mock_search_data_item(f"Content {i}", {"id": i}, 0.9 - i * 0.1) for i in range(3)]
+        # Create multiple chunks
+        chunks = []
+        scores = []
+        for i in range(3):
+            mock_chunk = MagicMock()
+            mock_chunk.content = f"Content {i}"
+            mock_chunk.chunk_metadata.to_dict.return_value = {"id": i}
+            chunks.append(mock_chunk)
+            scores.append(0.9 - i * 0.1)
 
         mock_response = MagicMock()
-        mock_response.data = data_items
-        mock_client.vector_stores.search.return_value = mock_response
+        mock_response.chunks = chunks
+        mock_response.scores = scores
+        mock_client.vector_io.query.return_value = mock_response
 
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -264,9 +267,15 @@ class TestOGXVectorStoreHybridSearch:
         mock_vs.id = "test-vs-id"
         mock_client.vector_stores.create.return_value = mock_vs
 
+        mock_chunk = MagicMock()
+        mock_chunk.content = "Test content"
+        mock_chunk.chunk_metadata.to_dict.return_value = {"doc_id": "doc1"}
+
         mock_response = MagicMock()
-        mock_response.data = [_make_mock_search_data_item("Test content", {"doc_id": "doc1"}, 0.95)]
-        mock_client.vector_stores.search.return_value = mock_response
+        mock_response.chunks = [mock_chunk]
+        mock_response.scores = [0.95]
+
+        mock_client.vector_io.query.return_value = mock_response
         return mock_client
 
     def test_search_default_vector_mode(self, mock_embedding_model, mock_ogx_client):
@@ -279,9 +288,9 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5)
 
-        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
-        assert call_kwargs["search_mode"] == "vector"
-        assert call_kwargs["ranking_options"] is None
+        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
+        assert call_kwargs["params"]["mode"] == "vector"
+        assert "reranker_type" not in call_kwargs["params"]
 
     def test_search_with_hybrid_mode_rrf(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and RRF ranker."""
@@ -293,10 +302,11 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60)
 
-        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
-        assert call_kwargs["search_mode"] == "hybrid"
-        assert call_kwargs["ranking_options"]["ranker"] == "rrf"
-        assert call_kwargs["ranking_options"]["impact_factor"] == 60
+        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
+        params = call_kwargs["params"]
+        assert params["mode"] == "hybrid"
+        assert params["reranker_type"] == "rrf"
+        assert params["reranker_params"]["impact_factor"] == 60
 
     def test_search_with_hybrid_mode_weighted(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and weighted ranker including alpha."""
@@ -308,10 +318,11 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_alpha=0.7)
 
-        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
-        assert call_kwargs["search_mode"] == "hybrid"
-        assert call_kwargs["ranking_options"]["ranker"] == "weighted"
-        assert call_kwargs["ranking_options"]["alpha"] == 0.7
+        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
+        params = call_kwargs["params"]
+        assert params["mode"] == "hybrid"
+        assert params["reranker_type"] == "weighted"
+        assert params["reranker_params"]["alpha"] == 0.7
 
     def test_search_with_hybrid_mode_normalized(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and normalized ranker."""
@@ -323,9 +334,11 @@ class TestOGXVectorStoreHybridSearch:
 
         vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="normalized")
 
-        call_kwargs = mock_ogx_client.vector_stores.search.call_args.kwargs
-        assert call_kwargs["search_mode"] == "hybrid"
-        assert call_kwargs["ranking_options"]["ranker"] == "normalized"
+        call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
+        params = call_kwargs["params"]
+        assert params["mode"] == "hybrid"
+        assert params["reranker_type"] == "normalized"
+        assert params["reranker_params"] == {}
 
     def test_search_hybrid_empty_strategy_raises(self, mock_embedding_model, mock_ogx_client):
         """Test that empty ranker_strategy with hybrid mode raises ValueError."""

--- a/uv.lock
+++ b/uv.lock
@@ -102,7 +102,7 @@ requires-dist = [
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.8.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },
     { name = "nbformat", marker = "extra == 'test'" },
-    { name = "ogx-client", specifier = "~=0.8.0" },
+    { name = "ogx-client", specifier = "~=1.0.0" },
     { name = "pandas", specifier = "==2.2.*" },
     { name = "psutil", marker = "extra == 'test'" },
     { name = "pydantic", specifier = "==2.11.*" },
@@ -2436,7 +2436,7 @@ wheels = [
 
 [[package]]
 name = "ogx-client"
-version = "0.8.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2455,9 +2455,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/07/24c3dfd2441902c6c6fd3bcb8e91f93b81df8a30b7aea5fa4faece240637/ogx_client-0.8.0.tar.gz", hash = "sha256:f6bc08112a1f0fd78660771e74e783511e6108609f4c72c57541a5ccae26f1f0", size = 436487, upload-time = "2026-05-01T20:03:38.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/bbcd77921d29dc0a84a4767cc3661d027bfc5db6a0c32a4f82dadc182542/ogx_client-1.0.0.tar.gz", hash = "sha256:a13133105149b77384ba804cc1fa340c1defce9ebb4820e3c593c36b103f0010", size = 435209, upload-time = "2026-05-12T13:58:58.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/9c/2350f0aac4400dc3f556ed68b348496ec48972f5f406e6f847d4074f8e88/ogx_client-0.8.0-py3-none-any.whl", hash = "sha256:7265cd2ff23e148eb2818e7063d13b68e83cb73796b640d158525e758972a80d", size = 311475, upload-time = "2026-05-01T20:03:36.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/95/2cafdc4e3ff4a89db82862c0e0ed10fed2154ba74c7b16c2a5e371bac5d9/ogx_client-1.0.0-py3-none-any.whl", hash = "sha256:d0ef468f3a46b5bf3af9de3540902aa0d4a0c9d4370444697ca710473843c439", size = 309279, upload-time = "2026-05-12T13:58:57.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Brief summary of changes

## Motivation
Scores improvement and support for official ogx 1.0.0

## Changes
- Restore vector_stores.search to vector-io query due to lower scores
- Update ogx client to 1.0.0

## Testing
Run unit tests and run experiment with locally started ogx server

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
