### PR TITLE
Migrate from chat.completions to Responses API

### DIFF
--- a/ai4rag/core/experiment/exception_handler.py
+++ b/ai4rag/core/experiment/exception_handler.py
@@ -115,4 +115,4 @@ class ExperimentExceptionHandler:
 
         error_content = next((er for er in self.errors if most_common_error_type_name in er.__class__.__name__))
 
-        return f"{error_content}. " f"To find more details please see generated logs file."
+        return f"{error_content}. To find more details please see generated logs file."

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -28,7 +28,11 @@ from ai4rag.core.experiment.utils import (
     get_retrieval_params,
     query_rag,
 )
-from ai4rag.core.hpo.base_optimizer import BaseOptimizer, OptimizationError, OptimizerSettings
+from ai4rag.core.hpo.base_optimizer import (
+    BaseOptimizer,
+    OptimizationError,
+    OptimizerSettings,
+)
 from ai4rag.core.hpo.gam_opt import GAMOptimizer
 from ai4rag.core.hpo.random_opt import FailedIterationError
 from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, MetricType
@@ -154,7 +158,12 @@ class AI4RAGExperiment:
 
         self.job_id = kwargs.pop("job_id", "ai4rag_job_a0b1c2d3").replace("-", "_")
         self.metrics: Sequence[str] = kwargs.pop(
-            "metrics", (MetricType.ANSWER_CORRECTNESS, MetricType.FAITHFULNESS, MetricType.CONTEXT_CORRECTNESS)
+            "metrics",
+            (
+                MetricType.ANSWER_CORRECTNESS,
+                MetricType.FAITHFULNESS,
+                MetricType.CONTEXT_CORRECTNESS,
+            ),
         )
         self.evaluator: BaseEvaluator = kwargs.pop(
             "evaluator",
@@ -163,8 +172,12 @@ class AI4RAGExperiment:
         self.n_mps_foundation_models = kwargs.pop(
             "n_mps_foundation_models", ModelsPreSelector.DEFAULT_N_FOUNDATION_MODELS
         )
-        self.n_mps_embedding_models = kwargs.pop("n_mps_embedding_models", ModelsPreSelector.DEFAULT_N_EMBEDDING_MODELS)
-        self.known_observations: list[dict] | None = kwargs.pop("known_observations", None)
+        self.n_mps_embedding_models = kwargs.pop(
+            "n_mps_embedding_models", ModelsPreSelector.DEFAULT_N_EMBEDDING_MODELS
+        )
+        self.known_observations: list[dict] | None = kwargs.pop(
+            "known_observations", None
+        )
 
         self.results: ExperimentResults = ExperimentResults()
         self._exception_handler = ExperimentExceptionHandler(self.event_handler)
@@ -193,12 +206,16 @@ class AI4RAGExperiment:
                         which_doc = doc.metadata.get("document_id") or idx
                         logger.warning("Empty document: %s", which_doc)
                     if not doc.metadata.get("document_id", None):
-                        logger.warning("document_id not provided for document at index: %s", idx)
+                        logger.warning(
+                            "document_id not provided for document at index: %s", idx
+                        )
 
                     proper_docs.append(doc)
 
                 else:
-                    raise ValueError(f"Incorrect type of document provided at index: {idx}.")
+                    raise ValueError(
+                        f"Incorrect type of document provided at index: {idx}."
+                    )
 
         self._documents = proper_docs
 
@@ -271,7 +288,9 @@ class AI4RAGExperiment:
         )
 
         mps = ModelsPreSelector(
-            benchmark_data=self.benchmark_data.get_random_sample(n_records=n_records, random_seed=random_seed),
+            benchmark_data=self.benchmark_data.get_random_sample(
+                n_records=n_records, random_seed=random_seed
+            ),
             documents=self.documents.copy(),
             foundation_models=foundation_models,
             embedding_models=embedding_models,
@@ -280,7 +299,8 @@ class AI4RAGExperiment:
         mps.evaluate_patterns()
 
         selected_models = mps.select_models(
-            n_embedding_models=self.n_mps_embedding_models, n_foundation_models=self.n_mps_foundation_models
+            n_embedding_models=self.n_mps_embedding_models,
+            n_foundation_models=self.n_mps_foundation_models,
         )
 
         logger.info(
@@ -316,7 +336,9 @@ class AI4RAGExperiment:
 
         distance_metric = EmbeddingModels.get_distance_metric(embedding_model.model_id)
         embedding_params_dict = (
-            asdict(embedding_model.params) if is_dataclass(embedding_model.params) else embedding_model.params
+            asdict(embedding_model.params)
+            if is_dataclass(embedding_model.params)
+            else embedding_model.params
         )
         indexing_params = {
             "chunking": chunking_params,
@@ -351,6 +373,9 @@ class AI4RAGExperiment:
                 "user_message_text": user_message_text,
                 "system_message_text": system_message_text,
             },
+            "vector_io_provider_type": self.client.providers.retrieve(
+                self.ogx_vector_io_provider_id
+            ).provider_type,
         }
 
         logger.info("Using retrieval and generation params: %s", rag_params)
@@ -362,9 +387,13 @@ class AI4RAGExperiment:
             return result_score
 
         pattern_name = self._create_pattern_name()
-        logger.info("Using name '%s' for the currently evaluated pattern.", pattern_name)
+        logger.info(
+            "Using name '%s' for the currently evaluated pattern.", pattern_name
+        )
 
-        reuse_collection_name = self._get_reusable_collection_name(indexing_params=indexing_params)
+        reuse_collection_name = self._get_reusable_collection_name(
+            indexing_params=indexing_params
+        )
 
         vector_store = get_vector_store(
             vs_type=self.vector_store_type,
@@ -381,7 +410,11 @@ class AI4RAGExperiment:
             chunk_size = chunking_params.get(AI4RAGParamNames.CHUNK_SIZE)
             chunk_overlap = chunking_params.get(AI4RAGParamNames.CHUNK_OVERLAP)
 
-            chunker = LangChainChunker(method=chunking_method, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+            chunker = LangChainChunker(
+                method=chunking_method,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+            )
             chunked_documents = chunker.split_documents(self.documents)
 
             if self.event_handler:
@@ -406,7 +439,9 @@ class AI4RAGExperiment:
             try:
                 vector_store.add_documents(chunked_documents)
             except Exception as exc:
-                raise IndexingError(exc, collection_name, embedding_model.model_id) from exc
+                raise IndexingError(
+                    exc, collection_name, embedding_model.model_id
+                ) from exc
 
         else:
             self.event_handler.on_status_change(
@@ -457,7 +492,9 @@ class AI4RAGExperiment:
 
         result_score = result_scores["scores"][self.optimization_metric]["mean"]
 
-        logger.info("Calculated optimization score for '%s': %s", pattern_name, result_score)
+        logger.info(
+            "Calculated optimization score for '%s': %s", pattern_name, result_score
+        )
 
         evaluation_result = EvaluationResult(
             pattern_name=pattern_name,
@@ -476,7 +513,11 @@ class AI4RAGExperiment:
 
         logger.info(
             "Evaluation scores: %s",
-            {el.get("question_id"): el.get("scores") for el in evaluation_results_json if isinstance(el, dict)},
+            {
+                el.get("question_id"): el.get("scores")
+                for el in evaluation_results_json
+                if isinstance(el, dict)
+            },
         )
 
         try:
@@ -515,20 +556,29 @@ class AI4RAGExperiment:
 
         # MPS - models pre-selection based on sample evaluation.
         # Run if there are more than 3 foundation models or more than 2 embedding models.
-        foundation_models = list(self.search_space[AI4RAGParamNames.FOUNDATION_MODEL].values)
-        embedding_models = list(self.search_space[AI4RAGParamNames.EMBEDDING_MODEL].values)
+        foundation_models = list(
+            self.search_space[AI4RAGParamNames.FOUNDATION_MODEL].values
+        )
+        embedding_models = list(
+            self.search_space[AI4RAGParamNames.EMBEDDING_MODEL].values
+        )
 
         if (
-            len(embedding_models) > self.n_mps_embedding_models or len(foundation_models) > self.n_mps_foundation_models
+            len(embedding_models) > self.n_mps_embedding_models
+            or len(foundation_models) > self.n_mps_foundation_models
         ) and not kwargs.get("skip_mps", False):
             selected_models = self.run_pre_selection(
                 foundation_models=foundation_models, embedding_models=embedding_models
             )
             self.search_space[AI4RAGParamNames.FOUNDATION_MODEL] = Parameter(
-                name=AI4RAGParamNames.FOUNDATION_MODEL, param_type="C", values=selected_models["foundation_models"]
+                name=AI4RAGParamNames.FOUNDATION_MODEL,
+                param_type="C",
+                values=selected_models["foundation_models"],
             )
             self.search_space[AI4RAGParamNames.EMBEDDING_MODEL] = Parameter(
-                name=AI4RAGParamNames.EMBEDDING_MODEL, param_type="C", values=selected_models["embedding_models"]
+                name=AI4RAGParamNames.EMBEDDING_MODEL,
+                param_type="C",
+                values=selected_models["embedding_models"],
             )
 
         optimizer_class: type[BaseOptimizer] = kwargs.get("optimizer", GAMOptimizer)
@@ -578,33 +628,44 @@ class AI4RAGExperiment:
             Prepared partial payload for the streamed content.
         """
         retrieval_payload = {
-            "method": evaluation_result.rag_params["retrieval"][AI4RAGParamNames.RETRIEVAL_METHOD],
-            "number_of_chunks": evaluation_result.rag_params["retrieval"][AI4RAGParamNames.NUMBER_OF_CHUNKS],
-            "search_mode": evaluation_result.rag_params["retrieval"].get(AI4RAGParamNames.SEARCH_MODE, "vector"),
+            "method": evaluation_result.rag_params["retrieval"][
+                AI4RAGParamNames.RETRIEVAL_METHOD
+            ],
+            "number_of_chunks": evaluation_result.rag_params["retrieval"][
+                AI4RAGParamNames.NUMBER_OF_CHUNKS
+            ],
+            "search_mode": evaluation_result.rag_params["retrieval"].get(
+                AI4RAGParamNames.SEARCH_MODE, "vector"
+            ),
         }
 
         if evaluation_result.rag_params["retrieval"][AI4RAGParamNames.WINDOW_SIZE]:
-            retrieval_payload["window_size"] = evaluation_result.rag_params["retrieval"][AI4RAGParamNames.WINDOW_SIZE]
+            retrieval_payload["window_size"] = evaluation_result.rag_params[
+                "retrieval"
+            ][AI4RAGParamNames.WINDOW_SIZE]
 
         if retrieval_payload["search_mode"] == "hybrid":
-            retrieval_payload["ranker_strategy"] = evaluation_result.rag_params["retrieval"].get(
-                AI4RAGParamNames.RANKER_STRATEGY
-            )
-            retrieval_payload["ranker_k"] = evaluation_result.rag_params["retrieval"].get(AI4RAGParamNames.RANKER_K)
-            retrieval_payload["ranker_alpha"] = evaluation_result.rag_params["retrieval"].get(
-                AI4RAGParamNames.RANKER_ALPHA
-            )
-
-        vector_store_payload = {
-            "datasource_type": self.ogx_vector_io_provider_id or "local_chroma",
-            "collection_name": evaluation_result.collection,
-        }
+            retrieval_payload["ranker_strategy"] = evaluation_result.rag_params[
+                "retrieval"
+            ].get(AI4RAGParamNames.RANKER_STRATEGY)
+            retrieval_payload["ranker_k"] = evaluation_result.rag_params[
+                "retrieval"
+            ].get(AI4RAGParamNames.RANKER_K)
+            retrieval_payload["ranker_alpha"] = evaluation_result.rag_params[
+                "retrieval"
+            ].get(AI4RAGParamNames.RANKER_ALPHA)
 
         indexing_payload = {
             "chunking": {
-                "method": evaluation_result.indexing_params["chunking"][AI4RAGParamNames.CHUNKING_METHOD],
-                "chunk_size": evaluation_result.indexing_params["chunking"][AI4RAGParamNames.CHUNK_SIZE],
-                "chunk_overlap": evaluation_result.indexing_params["chunking"][AI4RAGParamNames.CHUNK_OVERLAP],
+                "method": evaluation_result.indexing_params["chunking"][
+                    AI4RAGParamNames.CHUNKING_METHOD
+                ],
+                "chunk_size": evaluation_result.indexing_params["chunking"][
+                    AI4RAGParamNames.CHUNK_SIZE
+                ],
+                "chunk_overlap": evaluation_result.indexing_params["chunking"][
+                    AI4RAGParamNames.CHUNK_OVERLAP
+                ],
             },
             "embedding": evaluation_result.indexing_params.get("embedding"),
         }
@@ -624,10 +685,35 @@ class AI4RAGExperiment:
             "schema_version": "1.0",
             "producer": "ai4rag",
             "settings": {
-                "vector_store": vector_store_payload,
+                "vector_store_binding": {
+                    "provider_id": self.ogx_vector_io_provider_id,
+                    "provider_type": evaluation_result.rag_params[
+                        "vector_io_provider_type"
+                    ],
+                    "vector_store_id": evaluation_result.collection,
+                    "vector_store_name": "TBD",
+                },
                 **indexing_payload,
                 "retrieval": retrieval_payload,
                 "generation": generation_payload,
+                "responses_template": {
+                    "model": evaluation_result.rag_params["generation"]["model_id"],
+                    "stream": False,  # Not supported yet
+                    "store": True,  # Responses API default
+                    "input": evaluation_result.rag_params["generation"][
+                        "user_message_text"
+                    ],
+                    "instructions": evaluation_result.rag_params["generation"][
+                        "system_message_text"
+                    ],
+                    "tools": [
+                        {
+                            "type": "file_search",
+                            "vector_store_ids": evaluation_result.collection,
+                        }
+                    ],
+                    "include": ["file_search_call.results"],
+                },
             },
             "iteration": len(self.results) + n_known,
         }
@@ -669,7 +755,9 @@ class AI4RAGExperiment:
         """
 
         logger.info(
-            "Evaluating the RAG Pattern '%s' response using %s.", pattern_name, self.evaluator.__class__.__name__
+            "Evaluating the RAG Pattern '%s' response using %s.",
+            pattern_name,
+            self.evaluator.__class__.__name__,
         )
         self.event_handler.on_status_change(
             level=LogLevel.INFO,
@@ -677,8 +765,12 @@ class AI4RAGExperiment:
             step="evaluation",
         )
 
-        eval_data = build_evaluation_data(benchmark_data=self.benchmark_data, inference_response=inference_response)
-        result = self.evaluator.evaluate_metrics(evaluation_data=eval_data, metrics=self.metrics)
+        eval_data = build_evaluation_data(
+            benchmark_data=self.benchmark_data, inference_response=inference_response
+        )
+        result = self.evaluator.evaluate_metrics(
+            evaluation_data=eval_data, metrics=self.metrics
+        )
 
         logger.info("Response evaluation results for '%s': %s.", pattern_name, result)
         return result, eval_data
@@ -702,7 +794,9 @@ class AI4RAGExperiment:
         """
         return collection_name in self.results.collection_names
 
-    def _get_reusable_collection_name(self, indexing_params: dict[str, Any]) -> str | None:
+    def _get_reusable_collection_name(
+        self, indexing_params: dict[str, Any]
+    ) -> str | None:
         """
         This method returns name of the collection / vector_store_id (for OGX)
         if chosen indexing params have already been used to create an index / collection.
@@ -720,7 +814,9 @@ class AI4RAGExperiment:
             Collection name that is new or one of the previously created.
             None if there is no collection to reuse.
         """
-        collection = self.results.get_existing_collection(indexing_params=indexing_params)
+        collection = self.results.get_existing_collection(
+            indexing_params=indexing_params
+        )
         if collection is not None:
             collection_name = collection
             logger.info("Reusing existing collection: '%s'", collection_name)

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -361,8 +361,11 @@ class AI4RAGExperiment:
                 "user_message_text": user_message_text,
                 "system_message_text": system_message_text,
             },
-            "vector_io_provider_type": self.client.providers.retrieve(self.ogx_vector_io_provider_id).provider_type,
         }
+        if self.client:
+            rag_params["vector_io_provider_type"] = (
+                self.client.providers.retrieve(self.ogx_vector_io_provider_id).provider_type,
+            )
 
         logger.info("Using retrieval and generation params: %s", rag_params)
 
@@ -627,6 +630,21 @@ class AI4RAGExperiment:
 
         n_known = len(self.known_observations) if self.known_observations else 0
 
+        responses_template_payload = {
+            "model": evaluation_result.rag_params["generation"]["model_id"],
+            "stream": False,  # Not supported yet
+            "store": True,  # Responses API default
+            "input": evaluation_result.rag_params["generation"]["user_message_text"],
+            "instructions": evaluation_result.rag_params["generation"]["system_message_text"],
+            "tools": [
+                {
+                    "type": "file_search",
+                    "vector_store_ids": evaluation_result.collection,
+                }
+            ],
+            "include": ["file_search_call.results"],
+        }
+
         payload = {
             "pattern_name": evaluation_result.pattern_name,
             "scores": {
@@ -647,23 +665,12 @@ class AI4RAGExperiment:
                 **indexing_payload,
                 "retrieval": retrieval_payload,
                 "generation": generation_payload,
-                "responses_template": {
-                    "model": evaluation_result.rag_params["generation"]["model_id"],
-                    "stream": False,  # Not supported yet
-                    "store": True,  # Responses API default
-                    "input": evaluation_result.rag_params["generation"]["user_message_text"],
-                    "instructions": evaluation_result.rag_params["generation"]["system_message_text"],
-                    "tools": [
-                        {
-                            "type": "file_search",
-                            "vector_store_ids": evaluation_result.collection,
-                        }
-                    ],
-                    "include": ["file_search_call.results"],
-                },
             },
             "iteration": len(self.results) + n_known,
         }
+
+        if self.vector_store_type != "chroma":
+            payload["responses_template"] = responses_template_payload
 
         self.event_handler.on_pattern_creation(
             payload=payload,

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -172,12 +172,8 @@ class AI4RAGExperiment:
         self.n_mps_foundation_models = kwargs.pop(
             "n_mps_foundation_models", ModelsPreSelector.DEFAULT_N_FOUNDATION_MODELS
         )
-        self.n_mps_embedding_models = kwargs.pop(
-            "n_mps_embedding_models", ModelsPreSelector.DEFAULT_N_EMBEDDING_MODELS
-        )
-        self.known_observations: list[dict] | None = kwargs.pop(
-            "known_observations", None
-        )
+        self.n_mps_embedding_models = kwargs.pop("n_mps_embedding_models", ModelsPreSelector.DEFAULT_N_EMBEDDING_MODELS)
+        self.known_observations: list[dict] | None = kwargs.pop("known_observations", None)
 
         self.results: ExperimentResults = ExperimentResults()
         self._exception_handler = ExperimentExceptionHandler(self.event_handler)
@@ -206,16 +202,12 @@ class AI4RAGExperiment:
                         which_doc = doc.metadata.get("document_id") or idx
                         logger.warning("Empty document: %s", which_doc)
                     if not doc.metadata.get("document_id", None):
-                        logger.warning(
-                            "document_id not provided for document at index: %s", idx
-                        )
+                        logger.warning("document_id not provided for document at index: %s", idx)
 
                     proper_docs.append(doc)
 
                 else:
-                    raise ValueError(
-                        f"Incorrect type of document provided at index: {idx}."
-                    )
+                    raise ValueError(f"Incorrect type of document provided at index: {idx}.")
 
         self._documents = proper_docs
 
@@ -288,9 +280,7 @@ class AI4RAGExperiment:
         )
 
         mps = ModelsPreSelector(
-            benchmark_data=self.benchmark_data.get_random_sample(
-                n_records=n_records, random_seed=random_seed
-            ),
+            benchmark_data=self.benchmark_data.get_random_sample(n_records=n_records, random_seed=random_seed),
             documents=self.documents.copy(),
             foundation_models=foundation_models,
             embedding_models=embedding_models,
@@ -336,9 +326,7 @@ class AI4RAGExperiment:
 
         distance_metric = EmbeddingModels.get_distance_metric(embedding_model.model_id)
         embedding_params_dict = (
-            asdict(embedding_model.params)
-            if is_dataclass(embedding_model.params)
-            else embedding_model.params
+            asdict(embedding_model.params) if is_dataclass(embedding_model.params) else embedding_model.params
         )
         indexing_params = {
             "chunking": chunking_params,
@@ -373,9 +361,7 @@ class AI4RAGExperiment:
                 "user_message_text": user_message_text,
                 "system_message_text": system_message_text,
             },
-            "vector_io_provider_type": self.client.providers.retrieve(
-                self.ogx_vector_io_provider_id
-            ).provider_type,
+            "vector_io_provider_type": self.client.providers.retrieve(self.ogx_vector_io_provider_id).provider_type,
         }
 
         logger.info("Using retrieval and generation params: %s", rag_params)
@@ -387,13 +373,9 @@ class AI4RAGExperiment:
             return result_score
 
         pattern_name = self._create_pattern_name()
-        logger.info(
-            "Using name '%s' for the currently evaluated pattern.", pattern_name
-        )
+        logger.info("Using name '%s' for the currently evaluated pattern.", pattern_name)
 
-        reuse_collection_name = self._get_reusable_collection_name(
-            indexing_params=indexing_params
-        )
+        reuse_collection_name = self._get_reusable_collection_name(indexing_params=indexing_params)
 
         vector_store = get_vector_store(
             vs_type=self.vector_store_type,
@@ -439,9 +421,7 @@ class AI4RAGExperiment:
             try:
                 vector_store.add_documents(chunked_documents)
             except Exception as exc:
-                raise IndexingError(
-                    exc, collection_name, embedding_model.model_id
-                ) from exc
+                raise IndexingError(exc, collection_name, embedding_model.model_id) from exc
 
         else:
             self.event_handler.on_status_change(
@@ -492,9 +472,7 @@ class AI4RAGExperiment:
 
         result_score = result_scores["scores"][self.optimization_metric]["mean"]
 
-        logger.info(
-            "Calculated optimization score for '%s': %s", pattern_name, result_score
-        )
+        logger.info("Calculated optimization score for '%s': %s", pattern_name, result_score)
 
         evaluation_result = EvaluationResult(
             pattern_name=pattern_name,
@@ -513,11 +491,7 @@ class AI4RAGExperiment:
 
         logger.info(
             "Evaluation scores: %s",
-            {
-                el.get("question_id"): el.get("scores")
-                for el in evaluation_results_json
-                if isinstance(el, dict)
-            },
+            {el.get("question_id"): el.get("scores") for el in evaluation_results_json if isinstance(el, dict)},
         )
 
         try:
@@ -556,16 +530,11 @@ class AI4RAGExperiment:
 
         # MPS - models pre-selection based on sample evaluation.
         # Run if there are more than 3 foundation models or more than 2 embedding models.
-        foundation_models = list(
-            self.search_space[AI4RAGParamNames.FOUNDATION_MODEL].values
-        )
-        embedding_models = list(
-            self.search_space[AI4RAGParamNames.EMBEDDING_MODEL].values
-        )
+        foundation_models = list(self.search_space[AI4RAGParamNames.FOUNDATION_MODEL].values)
+        embedding_models = list(self.search_space[AI4RAGParamNames.EMBEDDING_MODEL].values)
 
         if (
-            len(embedding_models) > self.n_mps_embedding_models
-            or len(foundation_models) > self.n_mps_foundation_models
+            len(embedding_models) > self.n_mps_embedding_models or len(foundation_models) > self.n_mps_foundation_models
         ) and not kwargs.get("skip_mps", False):
             selected_models = self.run_pre_selection(
                 foundation_models=foundation_models, embedding_models=embedding_models
@@ -628,44 +597,28 @@ class AI4RAGExperiment:
             Prepared partial payload for the streamed content.
         """
         retrieval_payload = {
-            "method": evaluation_result.rag_params["retrieval"][
-                AI4RAGParamNames.RETRIEVAL_METHOD
-            ],
-            "number_of_chunks": evaluation_result.rag_params["retrieval"][
-                AI4RAGParamNames.NUMBER_OF_CHUNKS
-            ],
-            "search_mode": evaluation_result.rag_params["retrieval"].get(
-                AI4RAGParamNames.SEARCH_MODE, "vector"
-            ),
+            "method": evaluation_result.rag_params["retrieval"][AI4RAGParamNames.RETRIEVAL_METHOD],
+            "number_of_chunks": evaluation_result.rag_params["retrieval"][AI4RAGParamNames.NUMBER_OF_CHUNKS],
+            "search_mode": evaluation_result.rag_params["retrieval"].get(AI4RAGParamNames.SEARCH_MODE, "vector"),
         }
 
         if evaluation_result.rag_params["retrieval"][AI4RAGParamNames.WINDOW_SIZE]:
-            retrieval_payload["window_size"] = evaluation_result.rag_params[
-                "retrieval"
-            ][AI4RAGParamNames.WINDOW_SIZE]
+            retrieval_payload["window_size"] = evaluation_result.rag_params["retrieval"][AI4RAGParamNames.WINDOW_SIZE]
 
         if retrieval_payload["search_mode"] == "hybrid":
-            retrieval_payload["ranker_strategy"] = evaluation_result.rag_params[
-                "retrieval"
-            ].get(AI4RAGParamNames.RANKER_STRATEGY)
-            retrieval_payload["ranker_k"] = evaluation_result.rag_params[
-                "retrieval"
-            ].get(AI4RAGParamNames.RANKER_K)
-            retrieval_payload["ranker_alpha"] = evaluation_result.rag_params[
-                "retrieval"
-            ].get(AI4RAGParamNames.RANKER_ALPHA)
+            retrieval_payload["ranker_strategy"] = evaluation_result.rag_params["retrieval"].get(
+                AI4RAGParamNames.RANKER_STRATEGY
+            )
+            retrieval_payload["ranker_k"] = evaluation_result.rag_params["retrieval"].get(AI4RAGParamNames.RANKER_K)
+            retrieval_payload["ranker_alpha"] = evaluation_result.rag_params["retrieval"].get(
+                AI4RAGParamNames.RANKER_ALPHA
+            )
 
         indexing_payload = {
             "chunking": {
-                "method": evaluation_result.indexing_params["chunking"][
-                    AI4RAGParamNames.CHUNKING_METHOD
-                ],
-                "chunk_size": evaluation_result.indexing_params["chunking"][
-                    AI4RAGParamNames.CHUNK_SIZE
-                ],
-                "chunk_overlap": evaluation_result.indexing_params["chunking"][
-                    AI4RAGParamNames.CHUNK_OVERLAP
-                ],
+                "method": evaluation_result.indexing_params["chunking"][AI4RAGParamNames.CHUNKING_METHOD],
+                "chunk_size": evaluation_result.indexing_params["chunking"][AI4RAGParamNames.CHUNK_SIZE],
+                "chunk_overlap": evaluation_result.indexing_params["chunking"][AI4RAGParamNames.CHUNK_OVERLAP],
             },
             "embedding": evaluation_result.indexing_params.get("embedding"),
         }
@@ -687,9 +640,7 @@ class AI4RAGExperiment:
             "settings": {
                 "vector_store_binding": {
                     "provider_id": self.ogx_vector_io_provider_id,
-                    "provider_type": evaluation_result.rag_params[
-                        "vector_io_provider_type"
-                    ],
+                    "provider_type": evaluation_result.rag_params["vector_io_provider_type"],
                     "vector_store_id": evaluation_result.collection,
                     "vector_store_name": "TBD",
                 },
@@ -700,12 +651,8 @@ class AI4RAGExperiment:
                     "model": evaluation_result.rag_params["generation"]["model_id"],
                     "stream": False,  # Not supported yet
                     "store": True,  # Responses API default
-                    "input": evaluation_result.rag_params["generation"][
-                        "user_message_text"
-                    ],
-                    "instructions": evaluation_result.rag_params["generation"][
-                        "system_message_text"
-                    ],
+                    "input": evaluation_result.rag_params["generation"]["user_message_text"],
+                    "instructions": evaluation_result.rag_params["generation"]["system_message_text"],
                     "tools": [
                         {
                             "type": "file_search",
@@ -765,12 +712,8 @@ class AI4RAGExperiment:
             step="evaluation",
         )
 
-        eval_data = build_evaluation_data(
-            benchmark_data=self.benchmark_data, inference_response=inference_response
-        )
-        result = self.evaluator.evaluate_metrics(
-            evaluation_data=eval_data, metrics=self.metrics
-        )
+        eval_data = build_evaluation_data(benchmark_data=self.benchmark_data, inference_response=inference_response)
+        result = self.evaluator.evaluate_metrics(evaluation_data=eval_data, metrics=self.metrics)
 
         logger.info("Response evaluation results for '%s': %s.", pattern_name, result)
         return result, eval_data
@@ -794,9 +737,7 @@ class AI4RAGExperiment:
         """
         return collection_name in self.results.collection_names
 
-    def _get_reusable_collection_name(
-        self, indexing_params: dict[str, Any]
-    ) -> str | None:
+    def _get_reusable_collection_name(self, indexing_params: dict[str, Any]) -> str | None:
         """
         This method returns name of the collection / vector_store_id (for OGX)
         if chosen indexing params have already been used to create an index / collection.
@@ -814,9 +755,7 @@ class AI4RAGExperiment:
             Collection name that is new or one of the previously created.
             None if there is no collection to reuse.
         """
-        collection = self.results.get_existing_collection(
-            indexing_params=indexing_params
-        )
+        collection = self.results.get_existing_collection(indexing_params=indexing_params)
         if collection is not None:
             collection_name = collection
             logger.info("Reusing existing collection: '%s'", collection_name)

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -28,11 +28,7 @@ from ai4rag.core.experiment.utils import (
     get_retrieval_params,
     query_rag,
 )
-from ai4rag.core.hpo.base_optimizer import (
-    BaseOptimizer,
-    OptimizationError,
-    OptimizerSettings,
-)
+from ai4rag.core.hpo.base_optimizer import BaseOptimizer, OptimizationError, OptimizerSettings
 from ai4rag.core.hpo.gam_opt import GAMOptimizer
 from ai4rag.core.hpo.random_opt import FailedIterationError
 from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, MetricType
@@ -158,12 +154,7 @@ class AI4RAGExperiment:
 
         self.job_id = kwargs.pop("job_id", "ai4rag_job_a0b1c2d3").replace("-", "_")
         self.metrics: Sequence[str] = kwargs.pop(
-            "metrics",
-            (
-                MetricType.ANSWER_CORRECTNESS,
-                MetricType.FAITHFULNESS,
-                MetricType.CONTEXT_CORRECTNESS,
-            ),
+            "metrics", (MetricType.ANSWER_CORRECTNESS, MetricType.FAITHFULNESS, MetricType.CONTEXT_CORRECTNESS)
         )
         self.evaluator: BaseEvaluator = kwargs.pop(
             "evaluator",
@@ -289,8 +280,7 @@ class AI4RAGExperiment:
         mps.evaluate_patterns()
 
         selected_models = mps.select_models(
-            n_embedding_models=self.n_mps_embedding_models,
-            n_foundation_models=self.n_mps_foundation_models,
+            n_embedding_models=self.n_mps_embedding_models, n_foundation_models=self.n_mps_foundation_models
         )
 
         logger.info(
@@ -395,11 +385,7 @@ class AI4RAGExperiment:
             chunk_size = chunking_params.get(AI4RAGParamNames.CHUNK_SIZE)
             chunk_overlap = chunking_params.get(AI4RAGParamNames.CHUNK_OVERLAP)
 
-            chunker = LangChainChunker(
-                method=chunking_method,
-                chunk_size=chunk_size,
-                chunk_overlap=chunk_overlap,
-            )
+            chunker = LangChainChunker(method=chunking_method, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
             chunked_documents = chunker.split_documents(self.documents)
 
             if self.event_handler:
@@ -415,8 +401,7 @@ class AI4RAGExperiment:
             self.event_handler.on_status_change(
                 level=LogLevel.INFO,
                 message=(
-                    f"Embedding chunks using the {embedding_model.model_id} model. "
-                    f"Building index: {collection_name}."
+                    f"Embedding chunks using the {embedding_model.model_id} model. Building index: {collection_name}."
                 ),
                 step=ExperimentStep.EMBEDDING,
             )
@@ -543,14 +528,10 @@ class AI4RAGExperiment:
                 foundation_models=foundation_models, embedding_models=embedding_models
             )
             self.search_space[AI4RAGParamNames.FOUNDATION_MODEL] = Parameter(
-                name=AI4RAGParamNames.FOUNDATION_MODEL,
-                param_type="C",
-                values=selected_models["foundation_models"],
+                name=AI4RAGParamNames.FOUNDATION_MODEL, param_type="C", values=selected_models["foundation_models"]
             )
             self.search_space[AI4RAGParamNames.EMBEDDING_MODEL] = Parameter(
-                name=AI4RAGParamNames.EMBEDDING_MODEL,
-                param_type="C",
-                values=selected_models["embedding_models"],
+                name=AI4RAGParamNames.EMBEDDING_MODEL, param_type="C", values=selected_models["embedding_models"]
             )
 
         optimizer_class: type[BaseOptimizer] = kwargs.get("optimizer", GAMOptimizer)
@@ -709,9 +690,7 @@ class AI4RAGExperiment:
         """
 
         logger.info(
-            "Evaluating the RAG Pattern '%s' response using %s.",
-            pattern_name,
-            self.evaluator.__class__.__name__,
+            "Evaluating the RAG Pattern '%s' response using %s.", pattern_name, self.evaluator.__class__.__name__
         )
         self.event_handler.on_status_change(
             level=LogLevel.INFO,

--- a/ai4rag/rag/chunking/langchain_chunker.py
+++ b/ai4rag/rag/chunking/langchain_chunker.py
@@ -60,7 +60,6 @@ class LangChainChunker(BaseChunker[Document]):
 
         match self.method:
             case "recursive":
-
                 text_splitter = RecursiveCharacterTextSplitter(
                     chunk_size=self.chunk_size,
                     chunk_overlap=self.chunk_overlap,

--- a/ai4rag/rag/foundation_models/base_model.py
+++ b/ai4rag/rag/foundation_models/base_model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Generic, TypedDict, TypeVar
+from typing import Generic, TypeVar
 
 from ai4rag.rag.foundation_models.utils import RAGPromptTemplateString
 from ai4rag.search_space.src.model_props import (
@@ -16,18 +16,15 @@ FoundationModelClientT = TypeVar("FoundationModelClientT")
 FoundationModelParamsT = TypeVar("FoundationModelParamsT")
 
 
-class MessageTyped(TypedDict):
-    """Type of the messages used by the client."""
-
-    role: str
-    content: str
-
-
 class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT], ABC):
     """Interface definition for the foundation model used for `ai4rag`."""
 
-    user_message_text: RAGPromptTemplateString = RAGPromptTemplateString(template_name="user_message_text")
-    context_template_text: RAGPromptTemplateString = RAGPromptTemplateString(template_name="context_template_text")
+    user_message_text: RAGPromptTemplateString = RAGPromptTemplateString(
+        template_name="user_message_text"
+    )
+    context_template_text: RAGPromptTemplateString = RAGPromptTemplateString(
+        template_name="context_template_text"
+    )
 
     def __init__(
         self,
@@ -41,9 +38,13 @@ class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT
         self.client = client
         self.model_id = model_id
         self.params = params
-        self.system_message_text = system_message_text or get_system_message_text(model_name=model_id)
+        self.system_message_text = system_message_text or get_system_message_text(
+            model_name=model_id
+        )
         self.user_message_text = (
-            user_message_text if user_message_text is not None else get_user_message_text(model_name=model_id)
+            user_message_text
+            if user_message_text is not None
+            else get_user_message_text(model_name=model_id)
         )
         self.context_template_text = (
             context_template_text
@@ -72,5 +73,7 @@ class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT
         return self.model_id < other.model_id
 
     @abstractmethod
-    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
-        """Chat with the model base on the client capabilities."""
+    def create_response(
+        self, user_message: str, vector_store_id: str | None = None
+    ) -> str:
+        """Utilise Responses API (agent loop) to interact with the model."""

--- a/ai4rag/rag/foundation_models/base_model.py
+++ b/ai4rag/rag/foundation_models/base_model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, TypedDict
 
 from ai4rag.rag.foundation_models.utils import RAGPromptTemplateString
 from ai4rag.search_space.src.model_props import (
@@ -14,6 +14,13 @@ from ai4rag.search_space.src.model_props import (
 
 FoundationModelClientT = TypeVar("FoundationModelClientT")
 FoundationModelParamsT = TypeVar("FoundationModelParamsT")
+
+
+class MessageTyped(TypedDict):
+    """Type of the messages used by the client."""
+
+    role: str
+    content: str
 
 
 class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT], ABC):

--- a/ai4rag/rag/foundation_models/base_model.py
+++ b/ai4rag/rag/foundation_models/base_model.py
@@ -19,12 +19,8 @@ FoundationModelParamsT = TypeVar("FoundationModelParamsT")
 class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT], ABC):
     """Interface definition for the foundation model used for `ai4rag`."""
 
-    user_message_text: RAGPromptTemplateString = RAGPromptTemplateString(
-        template_name="user_message_text"
-    )
-    context_template_text: RAGPromptTemplateString = RAGPromptTemplateString(
-        template_name="context_template_text"
-    )
+    user_message_text: RAGPromptTemplateString = RAGPromptTemplateString(template_name="user_message_text")
+    context_template_text: RAGPromptTemplateString = RAGPromptTemplateString(template_name="context_template_text")
 
     def __init__(
         self,
@@ -38,13 +34,9 @@ class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT
         self.client = client
         self.model_id = model_id
         self.params = params
-        self.system_message_text = system_message_text or get_system_message_text(
-            model_name=model_id
-        )
+        self.system_message_text = system_message_text or get_system_message_text(model_name=model_id)
         self.user_message_text = (
-            user_message_text
-            if user_message_text is not None
-            else get_user_message_text(model_name=model_id)
+            user_message_text if user_message_text is not None else get_user_message_text(model_name=model_id)
         )
         self.context_template_text = (
             context_template_text
@@ -73,7 +65,5 @@ class BaseFoundationModel(Generic[FoundationModelClientT, FoundationModelParamsT
         return self.model_id < other.model_id
 
     @abstractmethod
-    def create_response(
-        self, user_message: str, vector_store_id: str | None = None
-    ) -> str:
+    def create_response(self, user_message: str, vector_store_id: str | None = None) -> str:
         """Utilise Responses API (agent loop) to interact with the model."""

--- a/ai4rag/rag/foundation_models/base_model.py
+++ b/ai4rag/rag/foundation_models/base_model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, TypedDict
+from typing import Generic, TypedDict, TypeVar
 
 from ai4rag.rag.foundation_models.utils import RAGPromptTemplateString
 from ai4rag.search_space.src.model_props import (

--- a/ai4rag/rag/foundation_models/ogx.py
+++ b/ai4rag/rag/foundation_models/ogx.py
@@ -8,7 +8,7 @@ from annotated_types import Ge, Gt, Le
 from ogx_client import OgxClient
 from pydantic import BaseModel
 
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
 from ai4rag.utils.constants import ChatGenerationConstants
 
 # pylint: disable=duplicate-code
@@ -57,6 +57,30 @@ class OGXFoundationModel(BaseFoundationModel[OgxClient, dict[str, Any] | OGXMode
             self._params = params
         else:
             self._params = OGXModelParameters()
+
+    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
+        """
+        Chat completion for communication with selected foundation model.
+
+        Parameters
+        ----------
+        messages : list[MessageTyped]
+            Messages to be included in the chat completion.
+
+        Returns
+        -------
+        str
+            Chat response from the model.
+        """
+        response_chat = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=messages,
+            max_completion_tokens=self.params.max_completion_tokens,
+            temperature=self.params.temperature,
+        )
+        response_choices = response_chat.choices
+
+        return response_choices
 
     def create_response(self, user_message: str, vector_store_id: str | None = None) -> str:
         """

--- a/ai4rag/rag/foundation_models/ogx.py
+++ b/ai4rag/rag/foundation_models/ogx.py
@@ -10,21 +10,18 @@ from pydantic import BaseModel
 
 from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 from ai4rag.utils.constants import ChatGenerationConstants
+
 # pylint: disable=duplicate-code
 
 
 class OGXModelParameters(BaseModel):
     """Parameters to use for OGXFoundationModel."""
 
-    max_completion_tokens: Annotated[int, Gt(0)] = (
-        ChatGenerationConstants.MAX_COMPLETION_TOKENS
-    )
+    max_completion_tokens: Annotated[int, Gt(0)] = ChatGenerationConstants.MAX_COMPLETION_TOKENS
     temperature: Annotated[float, Ge(0), Le(1)] = ChatGenerationConstants.TEMPERATURE
 
 
-class OGXFoundationModel(
-    BaseFoundationModel[OgxClient, dict[str, Any] | OGXModelParameters | None]
-):
+class OGXFoundationModel(BaseFoundationModel[OgxClient, dict[str, Any] | OGXModelParameters | None]):
     """Integration point to use any model via OGX API / client"""
 
     def __init__(
@@ -61,9 +58,7 @@ class OGXFoundationModel(
         else:
             self._params = OGXModelParameters()
 
-    def create_response(
-        self, user_message: str, vector_store_id: str | None = None
-    ) -> str:
+    def create_response(self, user_message: str, vector_store_id: str | None = None) -> str:
         """
         Utilise Responses API (agent loop) to interact with the model.
 

--- a/ai4rag/rag/foundation_models/ogx.py
+++ b/ai4rag/rag/foundation_models/ogx.py
@@ -17,7 +17,7 @@ from ai4rag.utils.constants import ChatGenerationConstants
 class OGXModelParameters(BaseModel):
     """Parameters to use for OGXFoundationModel."""
 
-    max_completion_tokens: Annotated[int, Gt(0)] = ChatGenerationConstants.MAX_COMPLETION_TOKENS
+    max_tokens: Annotated[int, Gt(0)] = ChatGenerationConstants.MAX_TOKENS
     temperature: Annotated[float, Ge(0), Le(1)] = ChatGenerationConstants.TEMPERATURE
 
 
@@ -75,7 +75,7 @@ class OGXFoundationModel(BaseFoundationModel[OgxClient, dict[str, Any] | OGXMode
         response_chat = self.client.chat.completions.create(
             model=self.model_id,
             messages=messages,
-            max_completion_tokens=self.params.max_completion_tokens,
+            max_completion_tokens=self.params.max_tokens,
             temperature=self.params.temperature,
         )
         response_choices = response_chat.choices
@@ -115,7 +115,7 @@ class OGXFoundationModel(BaseFoundationModel[OgxClient, dict[str, Any] | OGXMode
             model=self.model_id,
             instructions=self.system_message_text,
             input=user_message,
-            max_completion_tokens=self.params.max_completion_tokens,
+            max_output_tokens=self.params.max_tokens,
             temperature=self.params.temperature,
             tools=tools,
         )

--- a/ai4rag/rag/foundation_models/ogx.py
+++ b/ai4rag/rag/foundation_models/ogx.py
@@ -8,20 +8,23 @@ from annotated_types import Ge, Gt, Le
 from ogx_client import OgxClient
 from pydantic import BaseModel
 
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 from ai4rag.utils.constants import ChatGenerationConstants
-
 # pylint: disable=duplicate-code
 
 
 class OGXModelParameters(BaseModel):
     """Parameters to use for OGXFoundationModel."""
 
-    max_completion_tokens: Annotated[int, Gt(0)] = ChatGenerationConstants.MAX_COMPLETION_TOKENS
+    max_completion_tokens: Annotated[int, Gt(0)] = (
+        ChatGenerationConstants.MAX_COMPLETION_TOKENS
+    )
     temperature: Annotated[float, Ge(0), Le(1)] = ChatGenerationConstants.TEMPERATURE
 
 
-class OGXFoundationModel(BaseFoundationModel[OgxClient, dict[str, Any] | OGXModelParameters | None]):
+class OGXFoundationModel(
+    BaseFoundationModel[OgxClient, dict[str, Any] | OGXModelParameters | None]
+):
     """Integration point to use any model via OGX API / client"""
 
     def __init__(
@@ -58,26 +61,44 @@ class OGXFoundationModel(BaseFoundationModel[OgxClient, dict[str, Any] | OGXMode
         else:
             self._params = OGXModelParameters()
 
-    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
+    def create_response(
+        self, user_message: str, vector_store_id: str | None = None
+    ) -> str:
         """
-        Chat completion for communication with selected foundation model.
+        Utilise Responses API (agent loop) to interact with the model.
 
         Parameters
         ----------
-        messages : list[MessageTyped]
-            Messages to be included in the chat completion.
+        user_message : str
+            User message for the model to answer.
+
+        vector_store_id : str | None
+            If provided then references the vector store to search against using
+            the built-int `file_search` tool.
 
         Returns
         -------
         str
-            Chat response from the model.
+            Response text from the model.
+
+        Notes
+        -----
+        For the time being the only supported input type is a string representing the user's message.
+        For more input types please refer to:
+        https://developers.openai.com/api/reference/resources/responses/methods/create
         """
-        response_chat = self.client.chat.completions.create(
+
+        tools = None
+        if vector_store_id:
+            tools = [{"type": "file_search", "vector_store_ids": vector_store_id}]
+
+        response = self.client.responses.create(
             model=self.model_id,
-            messages=messages,
+            instructions=self.system_message_text,
+            input=user_message,
             max_completion_tokens=self.params.max_completion_tokens,
             temperature=self.params.temperature,
+            tools=tools,
         )
-        response_choices = response_chat.choices
 
-        return response_choices
+        return response.output_text

--- a/ai4rag/rag/retrieval/retriever.py
+++ b/ai4rag/rag/retrieval/retriever.py
@@ -52,6 +52,11 @@ class Retriever:
         self.ranker_k = ranker_k
         self.ranker_alpha = ranker_alpha
 
+    @property
+    def collection_name(self):
+        """Exposes the collection_name this retriever seraches through."""
+        return self._vector_store.collection_name
+
     def retrieve(self, query: str, **kwargs) -> list[dict]:
         """Retrieve relevant documents from vector store.
 

--- a/ai4rag/rag/retrieval/retriever.py
+++ b/ai4rag/rag/retrieval/retriever.py
@@ -54,7 +54,7 @@ class Retriever:
 
     @property
     def collection_name(self):
-        """Exposes the collection_name this retriever seraches through."""
+        """Exposes the collection_name this retriever searches through."""
         return self._vector_store.collection_name
 
     def retrieve(self, query: str, **kwargs) -> list[dict]:

--- a/ai4rag/rag/template/simple_rag_template.py
+++ b/ai4rag/rag/template/simple_rag_template.py
@@ -119,7 +119,7 @@ class SimpleRAG(BaseRAGTemplate):
 
         answer = self.foundation_model.create_response(
             user_message=user_message,
-            vector_store_id=self.vector_store.provider_id,
+            vector_store_id=self.retriever.collection_name,
         )
 
         return {

--- a/ai4rag/rag/template/simple_rag_template.py
+++ b/ai4rag/rag/template/simple_rag_template.py
@@ -71,7 +71,11 @@ class SimpleRAG(BaseRAGTemplate):
         documents : list[Document]
             List of LangChain Document objects to index.
         """
-        if self.chunker is None and self.embedding_model is None and self.vector_store is None:
+        if (
+            self.chunker is None
+            and self.embedding_model is None
+            and self.vector_store is None
+        ):
             raise RAGTemplateError()
         chunks = self.chunker.split_documents(documents)
 
@@ -101,7 +105,9 @@ class SimpleRAG(BaseRAGTemplate):
 
         context = "\n".join(
             [
-                self.foundation_model.context_template_text.format(document=getattr(doc, "page_content", ""))
+                self.foundation_model.context_template_text.format(
+                    document=getattr(doc, "page_content", "")
+                )
                 for doc in reference_documents
             ]
         )
@@ -111,15 +117,13 @@ class SimpleRAG(BaseRAGTemplate):
             question=question,
         )
 
-        messages = [
-            {"role": "system", "content": self.foundation_model.system_message_text},
-            {"role": "user", "content": user_message},
-        ]
-
-        chat_response = self.foundation_model.chat(messages=messages)
+        answer = self.foundation_model.create_response(
+            user_message=user_message,
+            vector_store_id=self.vector_store.provider_id,
+        )
 
         return {
-            "answer": chat_response[0].message.content,
+            "answer": answer,
             "reference_documents": reference_documents,
             "question": question,
         }

--- a/ai4rag/rag/template/simple_rag_template.py
+++ b/ai4rag/rag/template/simple_rag_template.py
@@ -71,11 +71,7 @@ class SimpleRAG(BaseRAGTemplate):
         documents : list[Document]
             List of LangChain Document objects to index.
         """
-        if (
-            self.chunker is None
-            and self.embedding_model is None
-            and self.vector_store is None
-        ):
+        if self.chunker is None and self.embedding_model is None and self.vector_store is None:
             raise RAGTemplateError()
         chunks = self.chunker.split_documents(documents)
 
@@ -105,9 +101,7 @@ class SimpleRAG(BaseRAGTemplate):
 
         context = "\n".join(
             [
-                self.foundation_model.context_template_text.format(
-                    document=getattr(doc, "page_content", "")
-                )
+                self.foundation_model.context_template_text.format(document=getattr(doc, "page_content", ""))
                 for doc in reference_documents
             ]
         )

--- a/ai4rag/rag/vector_store/chroma.py
+++ b/ai4rag/rag/vector_store/chroma.py
@@ -57,7 +57,7 @@ class ChromaVectorStore(BaseVectorStore):
         self._document_name_field = document_name_field
         self._chunk_sequence_number_field = chunk_sequence_number_field
         self._collection_name = reuse_collection_name or kwargs.pop(
-            "collection_name", f"ai4rag_{datetime.now().strftime("%Y%m%d%H%M%S")}"
+            "collection_name", f"ai4rag_{datetime.now().strftime('%Y%m%d%H%M%S')}"
         )
         self._vector_store = self._get_chroma_client(**kwargs)
 

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -36,7 +36,10 @@ class OGXVectorStore(BaseVectorStore):
 
     @staticmethod
     def _initialize_ogx_vector_store(
-        client: OgxClient, embedding_model: OGXEmbeddingModel, provider_id: str, reuse_collection_name: str | None
+        client: OgxClient,
+        embedding_model: OGXEmbeddingModel,
+        provider_id: str,
+        reuse_collection_name: str | None,
     ) -> VectorStore:
         """
         Create or retrieve vector store instance via OGX.
@@ -198,7 +201,13 @@ class OGXVectorStore(BaseVectorStore):
 
         if include_scores:
             return [
-                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
+                (
+                    Document(
+                        page_content=chunk.content,
+                        metadata=chunk.chunk_metadata.to_dict(),
+                    ),
+                    score,
+                )
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -36,10 +36,7 @@ class OGXVectorStore(BaseVectorStore):
 
     @staticmethod
     def _initialize_ogx_vector_store(
-        client: OgxClient,
-        embedding_model: OGXEmbeddingModel,
-        provider_id: str,
-        reuse_collection_name: str | None,
+        client: OgxClient, embedding_model: OGXEmbeddingModel, provider_id: str, reuse_collection_name: str | None
     ) -> VectorStore:
         """
         Create or retrieve vector store instance via OGX.
@@ -113,7 +110,7 @@ class OGXVectorStore(BaseVectorStore):
                 )
             if has_k:
                 raise ValueError(
-                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', " f"but search_mode='{search_mode}'."
+                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', but search_mode='{search_mode}'."
                 )
             if has_alpha:
                 raise ValueError(
@@ -201,13 +198,7 @@ class OGXVectorStore(BaseVectorStore):
 
         if include_scores:
             return [
-                (
-                    Document(
-                        page_content=chunk.content,
-                        metadata=chunk.chunk_metadata.to_dict(),
-                    ),
-                    score,
-                )
+                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -34,8 +34,7 @@ def _validate_foundation_model(model: OGXFoundationModel) -> bool:
     """
     try:
         # Test with minimal message and 1 token response
-        test_messages = [{"role": "user", "content": "Hi"}]
-        model.chat(messages=test_messages)
+        model.create_response(user_message="Hi")
         return True
     except Exception:  # pylint: disable=broad-exception-caught
         logger.warning(
@@ -78,19 +77,33 @@ def _get_default_ogx_models(client: OgxClient) -> _DefaultModelsResponseType:
     available_models = client.models.list().data
 
     registered_foundation_models = [
-        model for model in available_models if model.custom_metadata.get("model_type") == "llm"
+        model
+        for model in available_models
+        if model.custom_metadata.get("model_type") == "llm"
     ]
     registered_embedding_models = [
-        model for model in available_models if model.custom_metadata.get("model_type") == "embedding"
+        model
+        for model in available_models
+        if model.custom_metadata.get("model_type") == "embedding"
     ]
 
     if not registered_foundation_models:
-        raise SearchSpaceValueError("There are no registered models of type 'llm' in the OGX.")
+        raise SearchSpaceValueError(
+            "There are no registered models of type 'llm' in the OGX."
+        )
     if not registered_embedding_models:
-        raise SearchSpaceValueError("There are no registered models of type 'embedding' in the OGX.")
+        raise SearchSpaceValueError(
+            "There are no registered models of type 'embedding' in the OGX."
+        )
 
-    logger.info("Found registered foundation models: %s.", [model.id for model in registered_foundation_models])
-    logger.info("Found registered embedding models: %s.", [model.id for model in registered_embedding_models])
+    logger.info(
+        "Found registered foundation models: %s.",
+        [model.id for model in registered_foundation_models],
+    )
+    logger.info(
+        "Found registered embedding models: %s.",
+        [model.id for model in registered_embedding_models],
+    )
 
     return {
         "foundation_models": registered_foundation_models,
@@ -112,17 +125,30 @@ def _build_valid_and_invalid_models(
             try:
                 # If params is not provided model is trying to estimate parameters by sending some queries.
                 # If it fails it means that model is not available
-                embedding_dimension = custom_metadata.get("embedding_dimension", None) if custom_metadata else None
-                context_length = custom_metadata.get("context_length", None) if custom_metadata else None
+                embedding_dimension = (
+                    custom_metadata.get("embedding_dimension", None)
+                    if custom_metadata
+                    else None
+                )
+                context_length = (
+                    custom_metadata.get("context_length", None)
+                    if custom_metadata
+                    else None
+                )
                 _model = OGXEmbeddingModel(
                     model_id=model_id,
                     client=client,
-                    params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
+                    params=OGXEmbeddingParams(
+                        embedding_dimension=embedding_dimension,
+                        context_length=context_length,
+                    ),
                 )
                 is_valid = _validate_embedding_model(_model)
             except RuntimeError:
                 logger.warning(
-                    "Embedding model '%s' is registered in OGX, but does not respond.", model_id, exc_info=True
+                    "Embedding model '%s' is registered in OGX, but does not respond.",
+                    model_id,
+                    exc_info=True,
                 )
                 invalid_model_ids.append(model_id)
                 continue
@@ -180,14 +206,18 @@ def _validate_availability_and_create_models(
         candidate_ids = list(registered_models_as_dict)
     else:
         provided_not_registered_models_ids = [
-            pm_id for pm_id in provided_models_ids if pm_id not in registered_models_as_dict
+            pm_id
+            for pm_id in provided_models_ids
+            if pm_id not in registered_models_as_dict
         ]
         if provided_not_registered_models_ids:
             error_messages.append(
                 f"Provided models of type '{models_type}' are not registered in OGX: "
                 f"'{provided_not_registered_models_ids}'."
             )
-        candidate_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_as_dict]
+        candidate_ids = [
+            pm_id for pm_id in provided_models_ids if pm_id in registered_models_as_dict
+        ]
 
     valid_model_instances, invalid_model_ids = _build_valid_and_invalid_models(
         candidate_ids, registered_models_as_dict, models_type, client

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -88,14 +88,8 @@ def _get_default_ogx_models(client: OgxClient) -> _DefaultModelsResponseType:
     if not registered_embedding_models:
         raise SearchSpaceValueError("There are no registered models of type 'embedding' in the OGX.")
 
-    logger.info(
-        "Found registered foundation models: %s.",
-        [model.id for model in registered_foundation_models],
-    )
-    logger.info(
-        "Found registered embedding models: %s.",
-        [model.id for model in registered_embedding_models],
-    )
+    logger.info("Found registered foundation models: %s.", [model.id for model in registered_foundation_models])
+    logger.info("Found registered embedding models: %s.", [model.id for model in registered_embedding_models])
 
     return {
         "foundation_models": registered_foundation_models,
@@ -122,17 +116,12 @@ def _build_valid_and_invalid_models(
                 _model = OGXEmbeddingModel(
                     model_id=model_id,
                     client=client,
-                    params=OGXEmbeddingParams(
-                        embedding_dimension=embedding_dimension,
-                        context_length=context_length,
-                    ),
+                    params=OGXEmbeddingParams(embedding_dimension=embedding_dimension, context_length=context_length),
                 )
                 is_valid = _validate_embedding_model(_model)
             except RuntimeError:
                 logger.warning(
-                    "Embedding model '%s' is registered in OGX, but does not respond.",
-                    model_id,
-                    exc_info=True,
+                    "Embedding model '%s' is registered in OGX, but does not respond.", model_id, exc_info=True
                 )
                 invalid_model_ids.append(model_id)
                 continue

--- a/ai4rag/search_space/prepare/ogx_utils.py
+++ b/ai4rag/search_space/prepare/ogx_utils.py
@@ -77,24 +77,16 @@ def _get_default_ogx_models(client: OgxClient) -> _DefaultModelsResponseType:
     available_models = client.models.list().data
 
     registered_foundation_models = [
-        model
-        for model in available_models
-        if model.custom_metadata.get("model_type") == "llm"
+        model for model in available_models if model.custom_metadata.get("model_type") == "llm"
     ]
     registered_embedding_models = [
-        model
-        for model in available_models
-        if model.custom_metadata.get("model_type") == "embedding"
+        model for model in available_models if model.custom_metadata.get("model_type") == "embedding"
     ]
 
     if not registered_foundation_models:
-        raise SearchSpaceValueError(
-            "There are no registered models of type 'llm' in the OGX."
-        )
+        raise SearchSpaceValueError("There are no registered models of type 'llm' in the OGX.")
     if not registered_embedding_models:
-        raise SearchSpaceValueError(
-            "There are no registered models of type 'embedding' in the OGX."
-        )
+        raise SearchSpaceValueError("There are no registered models of type 'embedding' in the OGX.")
 
     logger.info(
         "Found registered foundation models: %s.",
@@ -125,16 +117,8 @@ def _build_valid_and_invalid_models(
             try:
                 # If params is not provided model is trying to estimate parameters by sending some queries.
                 # If it fails it means that model is not available
-                embedding_dimension = (
-                    custom_metadata.get("embedding_dimension", None)
-                    if custom_metadata
-                    else None
-                )
-                context_length = (
-                    custom_metadata.get("context_length", None)
-                    if custom_metadata
-                    else None
-                )
+                embedding_dimension = custom_metadata.get("embedding_dimension", None) if custom_metadata else None
+                context_length = custom_metadata.get("context_length", None) if custom_metadata else None
                 _model = OGXEmbeddingModel(
                     model_id=model_id,
                     client=client,
@@ -206,18 +190,14 @@ def _validate_availability_and_create_models(
         candidate_ids = list(registered_models_as_dict)
     else:
         provided_not_registered_models_ids = [
-            pm_id
-            for pm_id in provided_models_ids
-            if pm_id not in registered_models_as_dict
+            pm_id for pm_id in provided_models_ids if pm_id not in registered_models_as_dict
         ]
         if provided_not_registered_models_ids:
             error_messages.append(
                 f"Provided models of type '{models_type}' are not registered in OGX: "
                 f"'{provided_not_registered_models_ids}'."
             )
-        candidate_ids = [
-            pm_id for pm_id in provided_models_ids if pm_id in registered_models_as_dict
-        ]
+        candidate_ids = [pm_id for pm_id in provided_models_ids if pm_id in registered_models_as_dict]
 
     valid_model_instances, invalid_model_ids = _build_valid_and_invalid_models(
         candidate_ids, registered_models_as_dict, models_type, client

--- a/ai4rag/utils/constants.py
+++ b/ai4rag/utils/constants.py
@@ -112,7 +112,7 @@ class GenerationConstants(metaclass=ConstantMeta):
 class ChatGenerationConstants(metaclass=ConstantMeta):
     """Constants used for setting the generation (inference) parameters for chat models only."""
 
-    MAX_COMPLETION_TOKENS = 2048
+    MAX_TOKENS = 2048
     TEMPERATURE = 0.2
 
 

--- a/dev_utils/mocks.py
+++ b/dev_utils/mocks.py
@@ -6,7 +6,7 @@ from random import random, seed
 from typing import Any
 
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 
 seed(42)
 
@@ -30,15 +30,24 @@ class MockedFoundationModel(BaseFoundationModel[None, dict[str, Any] | None]):
             context_template_text=context_template_text,
         )
 
-    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
-        # Create a mock response that mimics the structure of real model responses
-        class MockMessage:
-            content = "I cannot answer this question, because I am just a mocked model."
+    def create_response(self, user_message: str, vector_store_id: str | None = None) -> str:
+        """
+        Utilise Responses API (agent loop) to interact with the model.
 
-        class MockChoice:
-            message = MockMessage()
+        Parameters
+        ----------
+        user_message : str
+            User message for the model to answer.
 
-        return [MockChoice()]
+        vector_store_id : str | None
+            If provided then references the vector store to search against.
+
+        Returns
+        -------
+        str
+            Response text from the model.
+        """
+        return "I cannot answer this question, because I am just a mocked model."
 
 
 class MockedEmbeddingModel(BaseEmbeddingModel[None, dict[str, Any]]):
@@ -54,3 +63,19 @@ class MockedEmbeddingModel(BaseEmbeddingModel[None, dict[str, Any]]):
 
     def embed_query(self, query: str) -> list[float]:
         return [random() for _ in range(self.params["embedding_dimension"])]
+
+
+class MockedOGXClient:
+    """Mock OGX client for testing without real OGX server."""
+
+    class MockedProviders:
+        """Mock providers interface."""
+
+        def retrieve(self, provider_id: str):
+            """Return mock provider with provider_type attribute."""
+            class MockProvider:
+                provider_type = "mock_provider"
+            return MockProvider()
+
+    def __init__(self):
+        self.providers = self.MockedProviders()

--- a/tests/functional/test_experiment_mocked_models.py
+++ b/tests/functional/test_experiment_mocked_models.py
@@ -232,3 +232,50 @@ class TestExperimentChromaWithMockedModels:
         assert isinstance(result, dict), f"Expected dict from generate(), got {type(result)}"
         answer = result.get("answer")
         assert isinstance(answer, str) and len(answer) > 0, f"Expected a non-empty answer string, got {answer!r}"
+
+    def test_pattern_params_include_generation_config(self, documents, benchmark_data, foundation_models, embedding_models, mock_client):
+        """
+        Verify that RAG patterns include complete generation configuration.
+        This ensures the API migration properly captures model parameters.
+        """
+        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models, mock_client)
+
+        experiment.search(
+            optimizer=RandomOptimizer,
+            skip_mps=True,  # Skip MPS to speed up test
+        )
+
+        # Get best pattern
+        best_evaluations = experiment.results.get_best_evaluations(k=1)
+        assert len(best_evaluations) > 0, f"No evaluations generated. Total results: {len(experiment.results)}"
+
+        # Verify rag_params contains both generation and retrieval configuration
+        rag_params = best_evaluations[0].rag_params
+        assert "generation" in rag_params, "RAG params should include generation config"
+        assert "retrieval" in rag_params, "RAG params should include retrieval config"
+
+        # Verify generation configuration fields
+        generation = rag_params["generation"]
+        assert "model_id" in generation, "Generation config should include model_id"
+        assert "context_template_text" in generation, "Generation config should include context_template_text"
+        assert "user_message_text" in generation, "Generation config should include user_message_text"
+        assert "system_message_text" in generation, "Generation config should include system_message_text"
+
+        # Verify field values are valid (not just present)
+        assert isinstance(generation["model_id"], str) and generation["model_id"], (
+            "model_id should be a non-empty string"
+        )
+        assert isinstance(generation["context_template_text"], str), (
+            "context_template_text should be a string"
+        )
+        assert isinstance(generation["user_message_text"], str), (
+            "user_message_text should be a string"
+        )
+        assert isinstance(generation["system_message_text"], str), (
+            "system_message_text should be a string"
+        )
+
+        # Verify the model_id matches one of our mocked models
+        assert generation["model_id"] in [fm.model_id for fm in foundation_models], (
+            f"Model ID {generation['model_id']} not in foundation models list"
+        )

--- a/tests/functional/test_experiment_mocked_models.py
+++ b/tests/functional/test_experiment_mocked_models.py
@@ -53,6 +53,13 @@ def embedding_models():
 
 
 @pytest.fixture(scope="module")
+def mock_client():
+    """Mock OGX client for experiments."""
+    from dev_utils.mocks import MockedOGXClient
+    return MockedOGXClient()
+
+
+@pytest.fixture(scope="module")
 def documents():
     """5 documents with enough content to be split into multiple chunks at chunk_size=512."""
     paragraph = (
@@ -108,12 +115,13 @@ def _build_search_space(foundation_models, embedding_models):
     )
 
 
-def _make_experiment(documents, benchmark_data, foundation_models, embedding_models, **kwargs):
+def _make_experiment(documents, benchmark_data, foundation_models, embedding_models, mock_client, **kwargs):
     return AI4RAGExperiment(
         documents=documents,
         benchmark_data=benchmark_data,
         search_space=_build_search_space(foundation_models, embedding_models),
         vector_store_type="chroma",
+        client=mock_client,
         optimizer_settings=RandomOptSettings(max_evals=3),
         event_handler=LocalEventHandler(),
         **kwargs,
@@ -124,7 +132,7 @@ class TestExperimentChromaWithMockedModels:
     """Full experiment runs with mocked models, real Chroma, and real UnitxtEvaluator."""
 
     def test_mps_is_triggered_and_reduces_model_pool(
-        self, documents, benchmark_data, foundation_models, embedding_models
+        self, documents, benchmark_data, foundation_models, embedding_models, mock_client
     ):
         """
         With 4 FMs (> DEFAULT_N_FOUNDATION_MODELS=3) and 3 EMs (> DEFAULT_N_EMBEDDING_MODELS=2),
@@ -132,7 +140,7 @@ class TestExperimentChromaWithMockedModels:
         at most DEFAULT_N_FOUNDATION_MODELS FMs and DEFAULT_N_EMBEDDING_MODELS EMs, and
         every selected model must belong to the original input pool.
         """
-        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models)
+        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models, mock_client)
 
         assert len(experiment.search_space[AI4RAGParamNames.FOUNDATION_MODEL].values) == _N_FOUNDATION_MODELS
         assert len(experiment.search_space[AI4RAGParamNames.EMBEDDING_MODEL].values) == _N_EMBEDDING_MODELS
@@ -157,12 +165,12 @@ class TestExperimentChromaWithMockedModels:
             em in embedding_models for em in em_selected
         ), "MPS selected an embedding model that was not in the original pool"
 
-    def test_skip_mps_preserves_full_model_pool(self, documents, benchmark_data, foundation_models, embedding_models):
+    def test_skip_mps_preserves_full_model_pool(self, documents, benchmark_data, foundation_models, embedding_models, mock_client):
         """
         When skip_mps=True, MPS is bypassed entirely. The search space must retain all
         originally provided models after search() completes.
         """
-        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models)
+        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models, mock_client)
 
         experiment.search(optimizer=RandomOptimizer, skip_mps=True)
 
@@ -176,7 +184,7 @@ class TestExperimentChromaWithMockedModels:
             f"With skip_mps=True, all {_N_EMBEDDING_MODELS} embedding models should remain, " f"got {len(em_after)}"
         )
 
-    def test_evaluation_scores_are_in_valid_range(self, documents, benchmark_data, foundation_models, embedding_models):
+    def test_evaluation_scores_are_in_valid_range(self, documents, benchmark_data, foundation_models, embedding_models, mock_client):
         """
         Every EvaluationResult produced by the experiment must have a final_score in [0, 1]
         and per-metric mean scores that are either None or in [0, 1].
@@ -187,6 +195,7 @@ class TestExperimentChromaWithMockedModels:
             benchmark_data,
             foundation_models,
             embedding_models,
+            mock_client,
             optimization_metric=MetricType.FAITHFULNESS,
             metrics=(MetricType.FAITHFULNESS, MetricType.ANSWER_CORRECTNESS, MetricType.CONTEXT_CORRECTNESS),
         )
@@ -207,12 +216,12 @@ class TestExperimentChromaWithMockedModels:
                     f"Mean score {mean!r} is outside [0, 1] for metric '{metric_name}' " f"in {evaluation.pattern_name}"
                 )
 
-    def test_best_pattern_can_generate_answer(self, documents, benchmark_data, foundation_models, embedding_models):
+    def test_best_pattern_can_generate_answer(self, documents, benchmark_data, foundation_models, embedding_models, mock_client):
         """
         The best RAG pattern returned by the experiment must produce a non-empty answer,
         confirming the full inference pipeline (retrieval + generation) is intact.
         """
-        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models)
+        experiment = _make_experiment(documents, benchmark_data, foundation_models, embedding_models, mock_client)
 
         experiment.search(optimizer=RandomOptimizer)
 

--- a/tests/unit/ai4rag/rag/foundation_models/test_base_model.py
+++ b/tests/unit/ai4rag/rag/foundation_models/test_base_model.py
@@ -7,27 +7,18 @@ from typing import Any
 
 import pytest
 
-from ai4rag.rag.foundation_models.base_model import BaseFoundationModel, MessageTyped
+from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 
 
 class ConcreteFoundationModel(BaseFoundationModel[Any, dict]):
     """Concrete implementation of BaseFoundationModel for testing purposes."""
 
-    def chat(self, messages: list[MessageTyped]) -> list[MessageTyped]:
-        """Simple chat implementation for testing."""
-
-        # Create a mock response that mimics the structure of real model responses
-        class MockMessage:
-            def __init__(self, content: str):
-                self.content = content
-
-        class MockChoice:
-            def __init__(self, content: str):
-                self.message = MockMessage(content)
-
-        # Simulate processing the messages
-        response_content = f"Response to {len(messages)} messages"
-        return [MockChoice(response_content)]
+    def create_response(self, user_message: str, vector_store_id: str | None = None) -> str:
+        """Simple create_response implementation for testing."""
+        # Simulate processing the message
+        if vector_store_id:
+            return f"Response to '{user_message}' using vector store '{vector_store_id}'"
+        return f"Response to '{user_message}'"
 
 
 class TestFoundationModel:
@@ -125,18 +116,21 @@ class TestFoundationModel:
         assert len(model_dict) == 1  # model2 overwrites model1
         assert model_dict[model1] == "value2"
 
-    def test_chat_implementation(self, foundation_model):
-        """Test that concrete implementation's chat method works."""
-        messages = [
-            {"role": "system", "content": "system prompt"},
-            {"role": "user", "content": "user query"},
-        ]
-        result = foundation_model.chat(messages)
-        assert len(result) == 1
-        assert result[0].message.content == "Response to 2 messages"
+    def test_create_response_implementation(self, foundation_model):
+        """Test that concrete implementation's create_response method works."""
+        user_message = "What is AI?"
+        result = foundation_model.create_response(user_message)
+        assert result == "Response to 'What is AI?'"
 
-    def test_chat_is_abstract(self):
-        """Test that BaseFoundationModel.chat is abstract and cannot be instantiated without implementation."""
+    def test_create_response_with_vector_store(self, foundation_model):
+        """Test create_response with vector_store_id parameter."""
+        user_message = "What is AI?"
+        vector_store_id = "test-vector-store"
+        result = foundation_model.create_response(user_message, vector_store_id)
+        assert result == "Response to 'What is AI?' using vector store 'test-vector-store'"
+
+    def test_create_response_is_abstract(self):
+        """Test that BaseFoundationModel.create_response is abstract and cannot be instantiated without implementation."""
         with pytest.raises(TypeError) as exc_info:
             BaseFoundationModel(client=None, model_id="test", params={})
         assert "Can't instantiate abstract class" in str(exc_info.value)

--- a/tests/unit/ai4rag/rag/foundation_models/test_ogx.py
+++ b/tests/unit/ai4rag/rag/foundation_models/test_ogx.py
@@ -105,9 +105,8 @@ class TestOGXFoundationModel:
         """Create a mock OgxClient."""
         mock_client = mocker.MagicMock()
         mock_response = mocker.MagicMock()
-        mock_response.choices = [mocker.MagicMock()]
-        mock_response.choices[0].message.content = "Test response from model"
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_response.output_text = "Test response from model"
+        mock_client.responses.create.return_value = mock_response
         return mock_client
 
     @pytest.fixture
@@ -271,59 +270,61 @@ class TestOGXFoundationModel:
         )
         assert model.system_message_text == system_msg
 
-    def test_chat_method(self, model_with_dict_params, mock_ogx_client):
-        """Test that chat method calls client correctly and returns response."""
-        messages = [
-            {"role": "system", "content": "You are helpful"},
-            {"role": "user", "content": "What is AI?"},
-        ]
+    def test_create_response_method(self, model_with_dict_params, mock_ogx_client):
+        """Test that create_response method calls client correctly and returns response."""
+        user_message = "What is AI?"
+        vector_store_id = "test-vector-store-id"
 
-        response = model_with_dict_params.chat(messages)
+        response = model_with_dict_params.create_response(user_message, vector_store_id)
 
         # Verify the client was called
-        mock_ogx_client.chat.completions.create.assert_called_once()
-        call_args = mock_ogx_client.chat.completions.create.call_args
+        mock_ogx_client.responses.create.assert_called_once()
+        call_args = mock_ogx_client.responses.create.call_args
 
-        # Verify model_id was passed
+        # Verify parameters
         assert call_args.kwargs["model"] == "test-model-id"
+        assert call_args.kwargs["input"] == user_message
+        assert call_args.kwargs["instructions"] == "You are a helpful assistant."
+        assert call_args.kwargs["tools"] == [{"type": "file_search", "vector_store_ids": vector_store_id}]
+        assert call_args.kwargs["max_completion_tokens"] == 1024
+        assert call_args.kwargs["temperature"] == 0.3
 
-        # Verify messages were passed correctly
-        passed_messages = call_args.kwargs["messages"]
-        assert len(passed_messages) == 2
-        assert passed_messages[0]["role"] == "system"
-        assert passed_messages[0]["content"] == "You are helpful"
-        assert passed_messages[1]["role"] == "user"
-        assert passed_messages[1]["content"] == "What is AI?"
+        # Verify response
+        assert response == "Test response from model"
+        assert isinstance(response, str)
 
-        # Verify response - should return choices list
-        assert len(response) == 1
-        assert response[0].message.content == "Test response from model"
+    def test_create_response_without_vector_store(self, model_with_dict_params, mock_ogx_client):
+        """Test create_response without vector_store_id (tools should be None)."""
+        response = model_with_dict_params.create_response("Hi")
 
-    def test_chat_method_extracts_content(self, model_with_dict_params, mock_ogx_client):
-        """Test that chat method correctly returns choices from response."""
-        messages = [
-            {"role": "system", "content": "system"},
-            {"role": "user", "content": "user"},
-        ]
-        response = model_with_dict_params.chat(messages)
-        assert len(response) == 1
-        assert response[0].message.content == "Test response from model"
+        call_args = mock_ogx_client.responses.create.call_args
+        assert call_args.kwargs["tools"] is None
+        assert response == "Test response from model"
 
-    def test_chat_with_different_messages(self, model_with_dict_params, mock_ogx_client):
-        """Test chat with different message combinations."""
+    def test_create_response_with_different_params(self, mock_ogx_client, valid_user_message_template, valid_context_template, valid_system_message):
+        """Test create_response with different model parameters."""
         test_cases = [
-            [{"role": "system", "content": "System prompt 1"}, {"role": "user", "content": "User query 1"}],
-            [{"role": "system", "content": ""}, {"role": "user", "content": "User query 2"}],
-            [{"role": "system", "content": "System prompt 3"}, {"role": "user", "content": ""}],
-            [{"role": "system", "content": "Multi\nline\nsystem"}, {"role": "user", "content": "Multi\nline\nuser"}],
+            (512, 0.7),
+            (2048, 0.0),
+            (100, 1.0),
         ]
 
-        for test_messages in test_cases:
-            model_with_dict_params.chat(test_messages)
-            call_args = mock_ogx_client.chat.completions.create.call_args
-            passed_messages = call_args.kwargs["messages"]
-            assert passed_messages[0]["content"] == test_messages[0]["content"]
-            assert passed_messages[1]["content"] == test_messages[1]["content"]
+        for max_tokens, temp in test_cases:
+            params = OGXModelParameters(max_completion_tokens=max_tokens, temperature=temp)
+            model = OGXFoundationModel(
+                model_id="test-model",
+                params=params,
+                client=mock_ogx_client,
+                user_message_text=valid_user_message_template,
+                context_template_text=valid_context_template,
+                system_message_text=valid_system_message,
+            )
+
+            model.create_response("test message")
+
+            call_args = mock_ogx_client.responses.create.call_args
+            assert call_args.kwargs["max_completion_tokens"] == max_tokens
+            assert call_args.kwargs["temperature"] == temp
 
     def test_invalid_user_message_template_missing_placeholder(
         self, mock_ogx_client, valid_context_template, valid_system_message

--- a/tests/unit/ai4rag/rag/foundation_models/test_ogx.py
+++ b/tests/unit/ai4rag/rag/foundation_models/test_ogx.py
@@ -20,30 +20,30 @@ class TestModelParameters:
     def test_default_values(self):
         """Test OGXModelParameters with default values."""
         params = OGXModelParameters()
-        assert params.max_completion_tokens == ChatGenerationConstants.MAX_COMPLETION_TOKENS
+        assert params.max_tokens == ChatGenerationConstants.MAX_TOKENS
         assert params.temperature == ChatGenerationConstants.TEMPERATURE
 
     def test_custom_values(self):
         """Test OGXModelParameters with custom valid values."""
-        params = OGXModelParameters(max_completion_tokens=1024, temperature=0.5)
-        assert params.max_completion_tokens == 1024
+        params = OGXModelParameters(max_tokens=1024, temperature=0.5)
+        assert params.max_tokens == 1024
         assert params.temperature == 0.5
 
-    def test_max_completion_tokens_positive(self):
-        """Test that max_completion_tokens must be positive."""
-        params = OGXModelParameters(max_completion_tokens=1)
-        assert params.max_completion_tokens == 1
+    def test_max_tokens_positive(self):
+        """Test that max_tokens must be positive."""
+        params = OGXModelParameters(max_tokens=1)
+        assert params.max_tokens == 1
 
-    def test_max_completion_tokens_zero_invalid(self):
-        """Test that max_completion_tokens cannot be zero."""
+    def test_max_tokens_zero_invalid(self):
+        """Test that max_tokens cannot be zero."""
         with pytest.raises(ValidationError) as exc_info:
-            OGXModelParameters(max_completion_tokens=0)
+            OGXModelParameters(max_tokens=0)
         assert "greater than 0" in str(exc_info.value).lower()
 
-    def test_max_completion_tokens_negative_invalid(self):
-        """Test that max_completion_tokens cannot be negative."""
+    def test_max_tokens_negative_invalid(self):
+        """Test that max_tokens cannot be negative."""
         with pytest.raises(ValidationError) as exc_info:
-            OGXModelParameters(max_completion_tokens=-100)
+            OGXModelParameters(max_tokens=-100)
         assert "greater than 0" in str(exc_info.value).lower()
 
     def test_temperature_minimum_boundary(self):
@@ -68,10 +68,10 @@ class TestModelParameters:
             OGXModelParameters(temperature=1.1)
         assert "less than or equal to 1" in str(exc_info.value).lower()
 
-    def test_max_completion_tokens_float_invalid(self):
-        """Test that max_completion_tokens must be an integer."""
+    def test_max_tokens_float_invalid(self):
+        """Test that max_tokens must be an integer."""
         with pytest.raises(ValidationError) as exc_info:
-            OGXModelParameters(max_completion_tokens=100.5)
+            OGXModelParameters(max_tokens=100.5)
         assert "int" in str(exc_info.value).lower()
 
     def test_temperature_int_coerced_to_float(self):
@@ -92,8 +92,8 @@ class TestModelParameters:
     )
     def test_valid_parameter_combinations(self, max_tokens, temp):
         """Parameterized test for valid parameter combinations."""
-        params = OGXModelParameters(max_completion_tokens=max_tokens, temperature=temp)
-        assert params.max_completion_tokens == max_tokens
+        params = OGXModelParameters(max_tokens=max_tokens, temperature=temp)
+        assert params.max_tokens == max_tokens
         assert params.temperature == temp
 
 
@@ -142,7 +142,7 @@ class TestOGXFoundationModel:
         """Create a OGXFoundationModel with dict parameters."""
         return OGXFoundationModel(
             model_id="test-model-id",
-            params={"max_completion_tokens": 1024, "temperature": 0.3},
+            params={"max_tokens": 1024, "temperature": 0.3},
             client=mock_ogx_client,
             user_message_text=valid_user_message_template,
             context_template_text=valid_context_template,
@@ -154,7 +154,7 @@ class TestOGXFoundationModel:
         self, mock_ogx_client, valid_user_message_template, valid_context_template, valid_system_message
     ):
         """Create a OGXFoundationModel with OGXModelParameters."""
-        params = OGXModelParameters(max_completion_tokens=512, temperature=0.7)
+        params = OGXModelParameters(max_tokens=512, temperature=0.7)
         return OGXFoundationModel(
             model_id="test-model-id",
             params=params,
@@ -182,7 +182,7 @@ class TestOGXFoundationModel:
         """Test initialization with dict parameters."""
         assert model_with_dict_params.model_id == "test-model-id"
         assert isinstance(model_with_dict_params.params, OGXModelParameters)
-        assert model_with_dict_params.params.max_completion_tokens == 1024
+        assert model_with_dict_params.params.max_tokens == 1024
         assert model_with_dict_params.params.temperature == 0.3
         assert model_with_dict_params.client == mock_ogx_client
         assert "question" in model_with_dict_params.user_message_text
@@ -192,7 +192,7 @@ class TestOGXFoundationModel:
         """Test initialization with OGXModelParameters object."""
         assert model_with_model_params.model_id == "test-model-id"
         assert isinstance(model_with_model_params.params, OGXModelParameters)
-        assert model_with_model_params.params.max_completion_tokens == 512
+        assert model_with_model_params.params.max_tokens == 512
         assert model_with_model_params.params.temperature == 0.7
         assert model_with_model_params.client == mock_ogx_client
 
@@ -200,7 +200,7 @@ class TestOGXFoundationModel:
         """Test initialization with None parameters uses defaults."""
         assert model_with_none_params.model_id == "test-model-id"
         assert isinstance(model_with_none_params.params, OGXModelParameters)
-        assert model_with_none_params.params.max_completion_tokens == ChatGenerationConstants.MAX_COMPLETION_TOKENS
+        assert model_with_none_params.params.max_tokens == ChatGenerationConstants.MAX_TOKENS
         assert model_with_none_params.params.temperature == ChatGenerationConstants.TEMPERATURE
         assert model_with_none_params.client == mock_ogx_client
 
@@ -297,7 +297,7 @@ class TestOGXFoundationModel:
         assert call_args.kwargs["input"] == user_message
         assert call_args.kwargs["instructions"] == "You are a helpful assistant."
         assert call_args.kwargs["tools"] == [{"type": "file_search", "vector_store_ids": vector_store_id}]
-        assert call_args.kwargs["max_completion_tokens"] == 1024
+        assert call_args.kwargs["max_output_tokens"] == 1024
         assert call_args.kwargs["temperature"] == 0.3
 
         # Verify response
@@ -312,7 +312,9 @@ class TestOGXFoundationModel:
         assert call_args.kwargs["tools"] is None
         assert response == "Response from Responses API"
 
-    def test_create_response_with_different_params(self, mock_ogx_client, valid_user_message_template, valid_context_template, valid_system_message):
+    def test_create_response_with_different_params(
+        self, mock_ogx_client, valid_user_message_template, valid_context_template, valid_system_message
+    ):
         """Test create_response with different model parameters."""
         test_cases = [
             (512, 0.7),
@@ -321,7 +323,7 @@ class TestOGXFoundationModel:
         ]
 
         for max_tokens, temp in test_cases:
-            params = OGXModelParameters(max_completion_tokens=max_tokens, temperature=temp)
+            params = OGXModelParameters(max_tokens=max_tokens, temperature=temp)
             model = OGXFoundationModel(
                 model_id="test-model",
                 params=params,
@@ -334,7 +336,7 @@ class TestOGXFoundationModel:
             model.create_response("test message")
 
             call_args = mock_ogx_client.responses.create.call_args
-            assert call_args.kwargs["max_completion_tokens"] == max_tokens
+            assert call_args.kwargs["max_output_tokens"] == max_tokens
             assert call_args.kwargs["temperature"] == temp
 
     def test_chat_method(self, model_with_dict_params, mock_ogx_client):
@@ -422,7 +424,7 @@ class TestOGXFoundationModel:
         ]
 
         for max_tokens, temp in test_params:
-            params = OGXModelParameters(max_completion_tokens=max_tokens, temperature=temp)
+            params = OGXModelParameters(max_tokens=max_tokens, temperature=temp)
             model = OGXFoundationModel(
                 model_id="test-model",
                 params=params,

--- a/tests/unit/ai4rag/rag/foundation_models/test_ogx.py
+++ b/tests/unit/ai4rag/rag/foundation_models/test_ogx.py
@@ -102,11 +102,22 @@ class TestOGXFoundationModel:
 
     @pytest.fixture
     def mock_ogx_client(self, mocker):
-        """Create a mock OgxClient."""
+        """Create a mock OgxClient supporting both chat/completions and Responses APIs."""
         mock_client = mocker.MagicMock()
-        mock_response = mocker.MagicMock()
-        mock_response.output_text = "Test response from model"
-        mock_client.responses.create.return_value = mock_response
+
+        # Setup for Responses API (create_response method)
+        mock_responses_response = mocker.MagicMock()
+        mock_responses_response.output_text = "Response from Responses API"
+        mock_client.responses.create.return_value = mock_responses_response
+
+        # Setup for chat/completions API (chat method)
+        mock_chat_response = mocker.MagicMock()
+        mock_choice = mocker.MagicMock()
+        mock_choice.message.content = "Response from chat/completions API"
+        mock_choice.message.role = "assistant"
+        mock_chat_response.choices = [mock_choice]
+        mock_client.chat.completions.create.return_value = mock_chat_response
+
         return mock_client
 
     @pytest.fixture
@@ -290,7 +301,7 @@ class TestOGXFoundationModel:
         assert call_args.kwargs["temperature"] == 0.3
 
         # Verify response
-        assert response == "Test response from model"
+        assert response == "Response from Responses API"
         assert isinstance(response, str)
 
     def test_create_response_without_vector_store(self, model_with_dict_params, mock_ogx_client):
@@ -299,7 +310,7 @@ class TestOGXFoundationModel:
 
         call_args = mock_ogx_client.responses.create.call_args
         assert call_args.kwargs["tools"] is None
-        assert response == "Test response from model"
+        assert response == "Response from Responses API"
 
     def test_create_response_with_different_params(self, mock_ogx_client, valid_user_message_template, valid_context_template, valid_system_message):
         """Test create_response with different model parameters."""
@@ -323,6 +334,108 @@ class TestOGXFoundationModel:
             model.create_response("test message")
 
             call_args = mock_ogx_client.responses.create.call_args
+            assert call_args.kwargs["max_completion_tokens"] == max_tokens
+            assert call_args.kwargs["temperature"] == temp
+
+    def test_chat_method(self, model_with_dict_params, mock_ogx_client):
+        """Test that chat method calls client correctly and returns response."""
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "What is AI?"},
+        ]
+
+        response = model_with_dict_params.chat(messages)
+
+        # Verify the client was called
+        mock_ogx_client.chat.completions.create.assert_called_once()
+        call_args = mock_ogx_client.chat.completions.create.call_args
+
+        # Verify model_id was passed
+        assert call_args.kwargs["model"] == "test-model-id"
+
+        # Verify messages were passed correctly
+        passed_messages = call_args.kwargs["messages"]
+        assert len(passed_messages) == 2
+        assert passed_messages[0]["role"] == "system"
+        assert passed_messages[0]["content"] == "You are helpful"
+        assert passed_messages[1]["role"] == "user"
+        assert passed_messages[1]["content"] == "What is AI?"
+
+        # Verify response - should return choices list
+        assert len(response) == 1
+        assert response[0].message.content == "Response from chat/completions API"
+
+    def test_chat_with_different_messages(self, model_with_dict_params, mock_ogx_client):
+        """Test chat with different message combinations."""
+        test_cases = [
+            [{"role": "system", "content": "System prompt 1"}, {"role": "user", "content": "User query 1"}],
+            [{"role": "system", "content": ""}, {"role": "user", "content": "User query 2"}],
+            [{"role": "system", "content": "System prompt 3"}, {"role": "user", "content": ""}],
+            [{"role": "system", "content": "Multi\nline\nsystem"}, {"role": "user", "content": "Multi\nline\nuser"}],
+        ]
+
+        for test_messages in test_cases:
+            model_with_dict_params.chat(test_messages)
+            call_args = mock_ogx_client.chat.completions.create.call_args
+            passed_messages = call_args.kwargs["messages"]
+            assert passed_messages[0]["role"] == test_messages[0]["role"]
+            assert passed_messages[0]["content"] == test_messages[0]["content"]
+            assert passed_messages[1]["role"] == test_messages[1]["role"]
+            assert passed_messages[1]["content"] == test_messages[1]["content"]
+
+    def test_chat_uses_model_params(self, model_with_dict_params, mock_ogx_client):
+        """Test that chat method passes model parameters correctly."""
+        messages = [{"role": "user", "content": "test"}]
+        model_with_dict_params.chat(messages)
+
+        call_args = mock_ogx_client.chat.completions.create.call_args
+        assert call_args.kwargs["max_completion_tokens"] == 1024
+        assert call_args.kwargs["temperature"] == 0.3
+
+    def test_chat_with_single_message(self, model_with_dict_params, mock_ogx_client):
+        """Test chat with a single user message (no system message)."""
+        messages = [{"role": "user", "content": "Single message test"}]
+        response = model_with_dict_params.chat(messages)
+
+        # Verify the client was called
+        mock_ogx_client.chat.completions.create.assert_called()
+        call_args = mock_ogx_client.chat.completions.create.call_args
+
+        # Verify single message was passed correctly
+        passed_messages = call_args.kwargs["messages"]
+        assert len(passed_messages) == 1
+        assert passed_messages[0]["role"] == "user"
+        assert passed_messages[0]["content"] == "Single message test"
+
+        # Verify response is returned correctly
+        assert len(response) == 1
+        assert response[0].message.content == "Response from chat/completions API"
+
+    def test_chat_with_different_params(
+        self, mock_ogx_client, valid_user_message_template, valid_context_template, valid_system_message
+    ):
+        """Test chat method with different model parameter combinations."""
+        test_params = [
+            (512, 0.7),
+            (2048, 0.0),
+            (100, 1.0),
+        ]
+
+        for max_tokens, temp in test_params:
+            params = OGXModelParameters(max_completion_tokens=max_tokens, temperature=temp)
+            model = OGXFoundationModel(
+                model_id="test-model",
+                params=params,
+                client=mock_ogx_client,
+                user_message_text=valid_user_message_template,
+                context_template_text=valid_context_template,
+                system_message_text=valid_system_message,
+            )
+
+            messages = [{"role": "user", "content": "test"}]
+            model.chat(messages)
+
+            call_args = mock_ogx_client.chat.completions.create.call_args
             assert call_args.kwargs["max_completion_tokens"] == max_tokens
             assert call_args.kwargs["temperature"] == temp
 

--- a/tests/unit/ai4rag/rag/template/test_simple_rag_template.py
+++ b/tests/unit/ai4rag/rag/template/test_simple_rag_template.py
@@ -339,18 +339,15 @@ class TestOGXRAGGenerate:
         mock.user_message_text = "Question: {question}\nReferences: {reference_documents}"
         mock.context_template_text = "Document: {document}"
 
-        # Mock the chat response to match new API (returns list of choices)
-        mock_message = mocker.MagicMock()
-        mock_message.content = "This is the generated answer."
-        mock_choice = mocker.MagicMock()
-        mock_choice.message = mock_message
-        mock.chat.return_value = [mock_choice]
+        # Mock the create_response method to return a string
+        mock.create_response.return_value = "This is the generated answer."
         return mock
 
     @pytest.fixture
     def mock_retriever(self, mocker):
         """Create a mock retriever."""
         mock = mocker.MagicMock()
+        mock.collection_name = "test-collection"
         mock.retrieve.return_value = [
             Document(page_content="Relevant document 1", metadata={"document_id": "doc1"}),
             Document(page_content="Relevant document 2", metadata={"document_id": "doc2"}),
@@ -422,28 +419,22 @@ class TestOGXRAGGenerate:
 
         rag.generate("What is AI?")
 
-        # Verify chat was called
-        mock_foundation_model.chat.assert_called_once()
-        call_args = mock_foundation_model.chat.call_args
+        # Verify create_response was called
+        mock_foundation_model.create_response.assert_called_once()
+        call_args = mock_foundation_model.create_response.call_args
 
-        # Verify messages list was passed correctly
-        messages = call_args.kwargs["messages"]
-        assert len(messages) == 2
-        assert messages[0]["role"] == "system"
-        assert messages[0]["content"] == "You are a helpful assistant."
-        assert messages[1]["role"] == "user"
-        # Verify user message contains formatted context
-        user_message = messages[1]["content"]
+        # Verify user_message was passed correctly with context
+        user_message = call_args.kwargs["user_message"]
+        assert "Question: What is AI?" in user_message
         assert "Document: Relevant document 1" in user_message
         assert "Document: Relevant document 2" in user_message
-        assert "What is AI?" in user_message
 
-    def test_generate_calls_foundation_model_chat(
+    def test_generate_calls_foundation_model_create_response(
         self,
         mock_foundation_model,
         mock_retriever,
     ):
-        """Test that generate calls foundation model's chat method."""
+        """Test that generate calls foundation model's create_response method."""
         rag = SimpleRAG(
             foundation_model=mock_foundation_model,
             retriever=mock_retriever,
@@ -451,16 +442,14 @@ class TestOGXRAGGenerate:
 
         rag.generate("What is AI?")
 
-        mock_foundation_model.chat.assert_called_once()
-        call_args = mock_foundation_model.chat.call_args
+        mock_foundation_model.create_response.assert_called_once()
+        call_args = mock_foundation_model.create_response.call_args
 
-        # Verify messages list was passed correctly
-        messages = call_args.kwargs["messages"]
-        assert len(messages) == 2
-        assert messages[0]["role"] == "system"
-        assert messages[0]["content"] == "You are a helpful assistant."
-        assert messages[1]["role"] == "user"
-        assert "What is AI?" in messages[1]["content"]
+        # Verify user_message and vector_store_id were passed correctly
+        user_message = call_args.kwargs["user_message"]
+        assert "What is AI?" in user_message
+        assert "Question:" in user_message
+        assert call_args.kwargs["vector_store_id"] == "test-collection"  # From retriever.collection_name
 
     def test_generate_returns_correct_answer(
         self,
@@ -528,11 +517,9 @@ class TestOGXRAGGenerate:
         assert result["answer"] == "This is the generated answer."
         assert result["question"] == "What is AI?"
 
-        # Verify chat was called with empty context
-        call_args = mock_foundation_model.chat.call_args
-        messages = call_args.kwargs["messages"]
-        assert len(messages) == 2
-        user_message = messages[1]["content"]
+        # Verify create_response was called with empty context
+        call_args = mock_foundation_model.create_response.call_args
+        user_message = call_args.kwargs["user_message"]
         assert "What is AI?" in user_message
 
     def test_generate_with_single_retrieved_document(
@@ -575,9 +562,8 @@ class TestOGXRAGGenerate:
         result = rag.generate("What is AI?")
 
         # Should use empty string when page_content is missing
-        call_args = mock_foundation_model.chat.call_args
-        messages = call_args.kwargs["messages"]
-        user_message = messages[1]["content"]
+        call_args = mock_foundation_model.create_response.call_args
+        user_message = call_args.kwargs["user_message"]
         assert "Document: " in user_message
         assert result["answer"] == "This is the generated answer."
 
@@ -641,12 +627,8 @@ class TestOGXRAGGenerateStream:
         mock.user_message_text = "Question: {question}\nReferences: {reference_documents}"
         mock.context_template_text = "Document: {document}"
 
-        # Mock the chat response to match new API (returns list of choices)
-        mock_message = mocker.MagicMock()
-        mock_message.content = "This is the generated answer."
-        mock_choice = mocker.MagicMock()
-        mock_choice.message = mock_message
-        mock.chat.return_value = [mock_choice]
+        # Mock the create_response method to return a string
+        mock.create_response.return_value = "This is the generated answer."
         return mock
 
     @pytest.fixture
@@ -736,8 +718,7 @@ class TestOGXRAGGenerateStream:
     ):
         """Test that generate_stream yields the complete answer in single chunk."""
         # Update the mock to return a longer answer
-        mock_message = mock_foundation_model.chat.return_value[0].message
-        mock_message.content = "This is a longer answer with multiple sentences."
+        mock_foundation_model.create_response.return_value = "This is a longer answer with multiple sentences."
 
         rag = SimpleRAG(
             foundation_model=mock_foundation_model,
@@ -780,12 +761,8 @@ class TestOGXRAGIntegration:
         foundation_model.user_message_text = "Question: {question}\nReferences: {reference_documents}"
         foundation_model.context_template_text = "Document: {document}"
 
-        # Mock the chat response to match new API (returns list of choices)
-        mock_message = mocker.MagicMock()
-        mock_message.content = "The answer is 42."
-        mock_choice = mocker.MagicMock()
-        mock_choice.message = mock_message
-        foundation_model.chat.return_value = [mock_choice]
+        # Mock the create_response method to return a string
+        foundation_model.create_response.return_value = "The answer is 42."
 
         # Retriever
         retriever = mocker.MagicMock()
@@ -845,7 +822,7 @@ class TestOGXRAGIntegration:
 
         # Verify generate worked
         complete_rag_system["retriever"].retrieve.assert_called_once_with("What is the answer?")
-        complete_rag_system["foundation_model"].chat.assert_called_once()
+        complete_rag_system["foundation_model"].create_response.assert_called_once()
 
         assert result["answer"] == "The answer is 42."
         assert result["question"] == "What is the answer?"
@@ -880,7 +857,7 @@ class TestOGXRAGIntegration:
 
         # Verify generate was called three times
         assert complete_rag_system["retriever"].retrieve.call_count == 3
-        assert complete_rag_system["foundation_model"].chat.call_count == 3
+        assert complete_rag_system["foundation_model"].create_response.call_count == 3
 
 
 class TestOGXRAGEdgeCases:
@@ -894,12 +871,8 @@ class TestOGXRAGEdgeCases:
         mock.user_message_text = "{question} {reference_documents}"
         mock.context_template_text = "{document}"
 
-        # Mock the chat response to match new API (returns list of choices)
-        mock_message = mocker.MagicMock()
-        mock_message.content = "Answer"
-        mock_choice = mocker.MagicMock()
-        mock_choice.message = mock_message
-        mock.chat.return_value = [mock_choice]
+        # Mock the create_response method to return a string
+        mock.create_response.return_value = "Answer"
         return mock
 
     @pytest.fixture

--- a/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
@@ -23,19 +23,21 @@ class TestValidateFoundationModel:
     def test_returns_true_when_model_responds(self):
         """Test that validation returns True when model responds successfully."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = Mock(choices=[])
+        mock_response = Mock()
+        mock_response.output_text = "Test response"
+        mock_client.responses.create.return_value = mock_response
 
         model = OGXFoundationModel(model_id="test-model", client=mock_client)
 
         result = _validate_foundation_model(model)
 
         assert result is True
-        mock_client.chat.completions.create.assert_called_once()
+        mock_client.responses.create.assert_called_once()
 
     def test_returns_false_when_model_fails(self):
         """Test that validation returns False when model raises exception."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.side_effect = Exception("Model error")
+        mock_client.responses.create.side_effect = Exception("Model error")
 
         model = OGXFoundationModel(model_id="test-model", client=mock_client)
 


### PR DESCRIPTION
## Description
- change API calls from `chat/completions` to `responses` (both OpenAI-compatible)
- modified streamed pattern according to the document: https://github.com/LukaszCmielowski/architecture-decision-records/blob/autox_docs_updates/documentation/components/autorag/features/rag_pattern_inference.md
- other small changes to different classes and functions not really affecting the overall behaviour


## Motivation
- Use the built-in agent loop working under the hood of Responses API, 
- stay on top of the industry standards

## Changes
- API calls change
- small refactoring of various names so that they better represent current behaviour
- 

## Testing
Commit with updated tests will be added once manual tests are completed.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
