### PR TITLE
fix: Ensure unique chunk ids

### DIFF
--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -6,9 +6,9 @@ from langchain_core.documents import Document
 from ogx_client import OgxClient
 from ogx_client.types.vector_store import VectorStore
 
+from ai4rag import logger
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
 from ai4rag.rag.vector_store.base_vector_store import BaseVectorStore
-from ai4rag import logger
 
 
 class OGXVectorStore(BaseVectorStore):
@@ -114,8 +114,7 @@ class OGXVectorStore(BaseVectorStore):
                 )
             if has_k:
                 raise ValueError(
-                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', "
-                    f"but search_mode='{search_mode}'."
+                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', " f"but search_mode='{search_mode}'."
                 )
             if has_alpha:
                 raise ValueError(
@@ -124,9 +123,7 @@ class OGXVectorStore(BaseVectorStore):
                 )
         else:
             if not has_strategy:
-                raise ValueError(
-                    "ranker_strategy must be set when search_mode='hybrid'."
-                )
+                raise ValueError("ranker_strategy must be set when search_mode='hybrid'.")
             if ranker_strategy not in OGXVectorStore._VALID_RANKER_STRATEGIES:
                 raise ValueError(
                     f"Invalid ranker_strategy='{ranker_strategy}'. "
@@ -186,9 +183,7 @@ class OGXVectorStore(BaseVectorStore):
         list[Document] | list[tuple[Document, float]]
             List of chunks as Document instances with or without scores, depending on the input.
         """
-        self._validate_search_params(
-            search_mode, ranker_strategy, ranker_k, ranker_alpha
-        )
+        self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
         params = {
             "max_chunks": k,
             "mode": search_mode,
@@ -199,17 +194,11 @@ class OGXVectorStore(BaseVectorStore):
             reranker_params = {}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
                 reranker_params["impact_factor"] = ranker_k
-            if (
-                ranker_strategy == "weighted"
-                and ranker_alpha is not None
-                and ranker_alpha != 1
-            ):
+            if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
                 reranker_params["alpha"] = ranker_alpha
             params["reranker_params"] = reranker_params
 
-        resp = self.client.vector_io.query(
-            query=query, vector_store_id=self._ogx_vs.id, params=params
-        )
+        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
 
         if include_scores:
             return [
@@ -223,12 +212,7 @@ class OGXVectorStore(BaseVectorStore):
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 
-        return [
-            Document(
-                page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()
-            )
-            for chunk in resp.chunks
-        ]
+        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """
@@ -255,9 +239,7 @@ class OGXVectorStore(BaseVectorStore):
                 },
                 "metadata": doc.metadata,
                 "chunk_id": str(
-                    hash(
-                        f"{doc.metadata.get('document_id')}_{doc.metadata.get('start_index')}_{doc.page_content}"
-                    )
+                    hash(f"{doc.metadata.get('document_id')}_{doc.metadata.get('start_index')}_{doc.page_content}")
                 ),
                 "embedding_model": self.embedding_model.model_id,
                 "embedding_dimension": embedding_dimension,
@@ -265,9 +247,7 @@ class OGXVectorStore(BaseVectorStore):
             for doc in documents
         ]
 
-        embeddings = self.embedding_model.embed_documents(
-            [doc.page_content for doc in documents]
-        )
+        embeddings = self.embedding_model.embed_documents([doc.page_content for doc in documents])
 
         seen_ids = set()
         unique_chunks = []
@@ -284,10 +264,7 @@ class OGXVectorStore(BaseVectorStore):
             unique_chunks.append(chunk)
             unique_embeddings.append(embedding)
 
-        full_chunks = [
-            chunk | {"embedding": embedding}
-            for chunk, embedding in zip(unique_chunks, unique_embeddings)
-        ]
+        full_chunks = [chunk | {"embedding": embedding} for chunk, embedding in zip(unique_chunks, unique_embeddings)]
 
         for idx in range(0, len(full_chunks), batch_size):
             self.client.vector_io.insert(

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -37,10 +37,7 @@ class OGXVectorStore(BaseVectorStore):
 
     @staticmethod
     def _initialize_ogx_vector_store(
-        client: OgxClient,
-        embedding_model: OGXEmbeddingModel,
-        provider_id: str,
-        reuse_collection_name: str | None,
+        client: OgxClient, embedding_model: OGXEmbeddingModel, provider_id: str, reuse_collection_name: str | None
     ) -> VectorStore:
         """
         Create or retrieve vector store instance via OGX.
@@ -202,13 +199,7 @@ class OGXVectorStore(BaseVectorStore):
 
         if include_scores:
             return [
-                (
-                    Document(
-                        page_content=chunk.content,
-                        metadata=chunk.chunk_metadata.to_dict(),
-                    ),
-                    score,
-                )
+                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -114,8 +114,7 @@ class OGXVectorStore(BaseVectorStore):
                 )
             if has_k:
                 raise ValueError(
-                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', "
-                    f"but search_mode='{search_mode}'."
+                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', but search_mode='{search_mode}'."
                 )
             if has_alpha:
                 raise ValueError(
@@ -124,9 +123,7 @@ class OGXVectorStore(BaseVectorStore):
                 )
         else:
             if not has_strategy:
-                raise ValueError(
-                    "ranker_strategy must be set when search_mode='hybrid'."
-                )
+                raise ValueError("ranker_strategy must be set when search_mode='hybrid'.")
             if ranker_strategy not in OGXVectorStore._VALID_RANKER_STRATEGIES:
                 raise ValueError(
                     f"Invalid ranker_strategy='{ranker_strategy}'. "
@@ -186,9 +183,7 @@ class OGXVectorStore(BaseVectorStore):
         list[Document] | list[tuple[Document, float]]
             List of chunks as Document instances with or without scores, depending on the input.
         """
-        self._validate_search_params(
-            search_mode, ranker_strategy, ranker_k, ranker_alpha
-        )
+        self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
         params = {
             "max_chunks": k,
             "mode": search_mode,
@@ -199,17 +194,11 @@ class OGXVectorStore(BaseVectorStore):
             reranker_params = {}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
                 reranker_params["impact_factor"] = ranker_k
-            if (
-                ranker_strategy == "weighted"
-                and ranker_alpha is not None
-                and ranker_alpha != 1
-            ):
+            if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
                 reranker_params["alpha"] = ranker_alpha
             params["reranker_params"] = reranker_params
 
-        resp = self.client.vector_io.query(
-            query=query, vector_store_id=self._ogx_vs.id, params=params
-        )
+        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
 
         if include_scores:
             return [
@@ -223,12 +212,7 @@ class OGXVectorStore(BaseVectorStore):
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 
-        return [
-            Document(
-                page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()
-            )
-            for chunk in resp.chunks
-        ]
+        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """
@@ -254,20 +238,14 @@ class OGXVectorStore(BaseVectorStore):
                     "document_id": doc.metadata["document_id"],
                 },
                 "metadata": doc.metadata,
-                "chunk_id": str(
-                    hash(
-                        f"{doc.metadata.get('document_id')}_{doc.metadata.get('start_index')}_{doc.page_content}"
-                    )
-                ),
+                "chunk_id": str(hash(doc.page_content)),
                 "embedding_model": self.embedding_model.model_id,
                 "embedding_dimension": embedding_dimension,
             }
             for doc in documents
         ]
 
-        embeddings = self.embedding_model.embed_documents(
-            [doc.page_content for doc in documents]
-        )
+        embeddings = self.embedding_model.embed_documents([doc.page_content for doc in documents])
 
         seen_ids = set()
         unique_chunks = []
@@ -286,10 +264,7 @@ class OGXVectorStore(BaseVectorStore):
             unique_chunks.append(chunk)
             unique_embeddings.append(embedding)
 
-        full_chunks = [
-            chunk | {"embedding": embedding}
-            for chunk, embedding in zip(unique_chunks, unique_embeddings)
-        ]
+        full_chunks = [chunk | {"embedding": embedding} for chunk, embedding in zip(unique_chunks, unique_embeddings)]
 
         for idx in range(0, len(full_chunks), batch_size):
             self.client.vector_io.insert(

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -8,6 +8,7 @@ from ogx_client.types.vector_store import VectorStore
 
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
 from ai4rag.rag.vector_store.base_vector_store import BaseVectorStore
+from ai4rag import logger
 
 
 class OGXVectorStore(BaseVectorStore):
@@ -36,7 +37,10 @@ class OGXVectorStore(BaseVectorStore):
 
     @staticmethod
     def _initialize_ogx_vector_store(
-        client: OgxClient, embedding_model: OGXEmbeddingModel, provider_id: str, reuse_collection_name: str | None
+        client: OgxClient,
+        embedding_model: OGXEmbeddingModel,
+        provider_id: str,
+        reuse_collection_name: str | None,
     ) -> VectorStore:
         """
         Create or retrieve vector store instance via OGX.
@@ -110,7 +114,8 @@ class OGXVectorStore(BaseVectorStore):
                 )
             if has_k:
                 raise ValueError(
-                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', " f"but search_mode='{search_mode}'."
+                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', "
+                    f"but search_mode='{search_mode}'."
                 )
             if has_alpha:
                 raise ValueError(
@@ -119,7 +124,9 @@ class OGXVectorStore(BaseVectorStore):
                 )
         else:
             if not has_strategy:
-                raise ValueError("ranker_strategy must be set when search_mode='hybrid'.")
+                raise ValueError(
+                    "ranker_strategy must be set when search_mode='hybrid'."
+                )
             if ranker_strategy not in OGXVectorStore._VALID_RANKER_STRATEGIES:
                 raise ValueError(
                     f"Invalid ranker_strategy='{ranker_strategy}'. "
@@ -179,7 +186,9 @@ class OGXVectorStore(BaseVectorStore):
         list[Document] | list[tuple[Document, float]]
             List of chunks as Document instances with or without scores, depending on the input.
         """
-        self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
+        self._validate_search_params(
+            search_mode, ranker_strategy, ranker_k, ranker_alpha
+        )
         params = {
             "max_chunks": k,
             "mode": search_mode,
@@ -190,19 +199,36 @@ class OGXVectorStore(BaseVectorStore):
             reranker_params = {}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
                 reranker_params["impact_factor"] = ranker_k
-            if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
+            if (
+                ranker_strategy == "weighted"
+                and ranker_alpha is not None
+                and ranker_alpha != 1
+            ):
                 reranker_params["alpha"] = ranker_alpha
             params["reranker_params"] = reranker_params
 
-        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
+        resp = self.client.vector_io.query(
+            query=query, vector_store_id=self._ogx_vs.id, params=params
+        )
 
         if include_scores:
             return [
-                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
+                (
+                    Document(
+                        page_content=chunk.content,
+                        metadata=chunk.chunk_metadata.to_dict(),
+                    ),
+                    score,
+                )
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 
-        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
+        return [
+            Document(
+                page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()
+            )
+            for chunk in resp.chunks
+        ]
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """
@@ -228,14 +254,40 @@ class OGXVectorStore(BaseVectorStore):
                     "document_id": doc.metadata["document_id"],
                 },
                 "metadata": doc.metadata,
-                "chunk_id": str(hash(doc.page_content)),
+                "chunk_id": str(
+                    hash(
+                        f"{doc.metadata.get('document_id')}_{doc.metadata.get('start_index')}_{doc.page_content}"
+                    )
+                ),
                 "embedding_model": self.embedding_model.model_id,
                 "embedding_dimension": embedding_dimension,
             }
             for doc in documents
         ]
-        embeddings = self.embedding_model.embed_documents([doc.page_content for doc in documents])
-        full_chunks = [chunk | {"embedding": embedding} for chunk, embedding in zip(chunks, embeddings)]
+
+        embeddings = self.embedding_model.embed_documents(
+            [doc.page_content for doc in documents]
+        )
+
+        seen_ids = set()
+        unique_chunks = []
+        unique_embeddings = []
+
+        for chunk, embedding in zip(chunks, embeddings):
+            chunk_id = chunk["chunk_id"]
+            if chunk_id in seen_ids:
+                logger.warning(
+                    f"Skipping duplicate chunk_id: {chunk_id} from document: {chunk['chunk_metadata']['document_id']}"
+                )
+                continue
+            seen_ids.add(chunk_id)
+            unique_chunks.append(chunk)
+            unique_embeddings.append(embedding)
+
+        full_chunks = [
+            chunk | {"embedding": embedding}
+            for chunk, embedding in zip(unique_chunks, unique_embeddings)
+        ]
 
         for idx in range(0, len(full_chunks), batch_size):
             self.client.vector_io.insert(

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -114,7 +114,8 @@ class OGXVectorStore(BaseVectorStore):
                 )
             if has_k:
                 raise ValueError(
-                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', " f"but search_mode='{search_mode}'."
+                    f"ranker_k={ranker_k} is only valid when search_mode='hybrid', "
+                    f"but search_mode='{search_mode}'."
                 )
             if has_alpha:
                 raise ValueError(
@@ -123,7 +124,9 @@ class OGXVectorStore(BaseVectorStore):
                 )
         else:
             if not has_strategy:
-                raise ValueError("ranker_strategy must be set when search_mode='hybrid'.")
+                raise ValueError(
+                    "ranker_strategy must be set when search_mode='hybrid'."
+                )
             if ranker_strategy not in OGXVectorStore._VALID_RANKER_STRATEGIES:
                 raise ValueError(
                     f"Invalid ranker_strategy='{ranker_strategy}'. "
@@ -183,7 +186,9 @@ class OGXVectorStore(BaseVectorStore):
         list[Document] | list[tuple[Document, float]]
             List of chunks as Document instances with or without scores, depending on the input.
         """
-        self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
+        self._validate_search_params(
+            search_mode, ranker_strategy, ranker_k, ranker_alpha
+        )
         params = {
             "max_chunks": k,
             "mode": search_mode,
@@ -194,11 +199,17 @@ class OGXVectorStore(BaseVectorStore):
             reranker_params = {}
             if ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
                 reranker_params["impact_factor"] = ranker_k
-            if ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
+            if (
+                ranker_strategy == "weighted"
+                and ranker_alpha is not None
+                and ranker_alpha != 1
+            ):
                 reranker_params["alpha"] = ranker_alpha
             params["reranker_params"] = reranker_params
 
-        resp = self.client.vector_io.query(query=query, vector_store_id=self._ogx_vs.id, params=params)
+        resp = self.client.vector_io.query(
+            query=query, vector_store_id=self._ogx_vs.id, params=params
+        )
 
         if include_scores:
             return [
@@ -212,7 +223,12 @@ class OGXVectorStore(BaseVectorStore):
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 
-        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
+        return [
+            Document(
+                page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()
+            )
+            for chunk in resp.chunks
+        ]
 
     def add_documents(self, documents: list[Document], **kwargs) -> None:
         """
@@ -239,7 +255,9 @@ class OGXVectorStore(BaseVectorStore):
                 },
                 "metadata": doc.metadata,
                 "chunk_id": str(
-                    hash(f"{doc.metadata.get('document_id')}_{doc.metadata.get('start_index')}_{doc.page_content}")
+                    hash(
+                        f"{doc.metadata.get('document_id')}_{doc.metadata.get('start_index')}_{doc.page_content}"
+                    )
                 ),
                 "embedding_model": self.embedding_model.model_id,
                 "embedding_dimension": embedding_dimension,
@@ -247,7 +265,9 @@ class OGXVectorStore(BaseVectorStore):
             for doc in documents
         ]
 
-        embeddings = self.embedding_model.embed_documents([doc.page_content for doc in documents])
+        embeddings = self.embedding_model.embed_documents(
+            [doc.page_content for doc in documents]
+        )
 
         seen_ids = set()
         unique_chunks = []
@@ -257,14 +277,19 @@ class OGXVectorStore(BaseVectorStore):
             chunk_id = chunk["chunk_id"]
             if chunk_id in seen_ids:
                 logger.warning(
-                    f"Skipping duplicate chunk_id: {chunk_id} from document: {chunk['chunk_metadata']['document_id']}"
+                    "Skipping duplicate chunk_id: %s from document: %s",
+                    chunk_id,
+                    chunk["chunk_metadata"]["document_id"],
                 )
                 continue
             seen_ids.add(chunk_id)
             unique_chunks.append(chunk)
             unique_embeddings.append(embedding)
 
-        full_chunks = [chunk | {"embedding": embedding} for chunk, embedding in zip(unique_chunks, unique_embeddings)]
+        full_chunks = [
+            chunk | {"embedding": embedding}
+            for chunk, embedding in zip(unique_chunks, unique_embeddings)
+        ]
 
         for idx in range(0, len(full_chunks), batch_size):
             self.client.vector_io.insert(

--- a/dev_utils/run_experiment.py
+++ b/dev_utils/run_experiment.py
@@ -28,9 +28,15 @@ if __name__ == "__main__":
     print()
 
     # client = OgxClient(base_url="http://localhost:8321")
+
+    # Disable SSL verification for self-signed certificates
+    import httpx
+    http_client = httpx.Client(verify=False)
+
     client = OgxClient(
         api_key=os.environ["OGX_CLIENT_API_KEY"],
         base_url=os.environ["OGX_CLIENT_BASE_URL"],
+        http_client=http_client,
     )
 
     # change to direct to your local documents path

--- a/dev_utils/run_experiment.py
+++ b/dev_utils/run_experiment.py
@@ -21,38 +21,25 @@ from dev_utils.utils import read_benchmark_from_json
 
 if __name__ == "__main__":
     _filepath = Path(__file__)
-    import os
     from dotenv import find_dotenv, load_dotenv
 
     load_dotenv(find_dotenv())
-    print()
 
-    # client = OgxClient(base_url="http://localhost:8321")
-
-    # Disable SSL verification for self-signed certificates
-    import httpx
-    http_client = httpx.Client(verify=False)
-
-    client = OgxClient(
-        api_key=os.environ["OGX_CLIENT_API_KEY"],
-        base_url=os.environ["OGX_CLIENT_BASE_URL"],
-        http_client=http_client,
-    )
+    client = OgxClient(base_url="http://localhost:8321")
+    # client = OgxClient()
 
     # change to direct to your local documents path
-    documents_path = _filepath.parents[1] / "local" / "data" / "documents"
+    documents_path = _filepath.parents[1] / "local" / "data" / "rh_summit_2026" / "documents"
 
     # change to direct to your benchmark_data.json
-    benchmark_data_path = (
-        _filepath.parents[1] / "local" / "data" / "benchmark_data_4q.json"
-    )
+    benchmark_data_path = _filepath.parents[1] / "local" / "data" / "rh_summit_2026" / "benchmark_data_4q.json"
 
     file_store = FileStore(documents_path)
     documents = file_store.load_as_documents()
     benchmark_data = read_benchmark_from_json(benchmark_data_path)
 
     # Configure optimizer
-    optimizer_settings = GAMOptSettings(max_evals=4, n_random_nodes=4)
+    optimizer_settings = GAMOptSettings(max_evals=1, n_random_nodes=4)
 
     # Edit configurations of search space
     search_space = AI4RAGSearchSpace(
@@ -61,21 +48,16 @@ if __name__ == "__main__":
             Parameter(
                 name="foundation_model",
                 param_type="C",
-                values=[
-                    OGXFoundationModel(
-                        model_id="vllm-inference-gpu-mistral/redhataimistral-small-24b-inst",
-                        client=client,
-                    )
-                ],
+                values=[OGXFoundationModel(model_id="ollama/llama3.2:3b", client=client)],
             ),
             Parameter(
                 name="embedding_model",
                 param_type="C",
                 values=[
                     OGXEmbeddingModel(
-                        model_id="vllm-embedding/bge-m3",
+                        model_id="ollama/nomic-embed-text:latest",
                         client=client,
-                        params={"embedding_dimension": 1024, "context_length": 8192},
+                        params={"embedding_dimension": 768, "context_length": 8192},
                     )
                 ],
             ),
@@ -112,7 +94,7 @@ if __name__ == "__main__":
         # event_handler=LocalEventHandler(output_path=_filepath.parent / "local" / "hybrid_test"),
         event_handler=LocalEventHandler(),
         vector_store_type="ogx",
-        ogx_vector_io_provider_id="pgvector",
+        ogx_vector_io_provider_id="milvus-lite",
     )
 
     experiment.search(skip_mps=True)

--- a/dev_utils/run_experiment.py
+++ b/dev_utils/run_experiment.py
@@ -21,25 +21,32 @@ from dev_utils.utils import read_benchmark_from_json
 
 if __name__ == "__main__":
     _filepath = Path(__file__)
+    import os
     from dotenv import find_dotenv, load_dotenv
 
     load_dotenv(find_dotenv())
+    print()
 
-    client = OgxClient(base_url="http://localhost:8321")
-    # client = OgxClient()
+    # client = OgxClient(base_url="http://localhost:8321")
+    client = OgxClient(
+        api_key=os.environ["OGX_CLIENT_API_KEY"],
+        base_url=os.environ["OGX_CLIENT_BASE_URL"],
+    )
 
     # change to direct to your local documents path
-    documents_path = _filepath.parents[1] / "local" / "data" / "rh_summit_2026" / "documents"
+    documents_path = _filepath.parents[1] / "local" / "data" / "documents"
 
     # change to direct to your benchmark_data.json
-    benchmark_data_path = _filepath.parents[1] / "local" / "data" / "rh_summit_2026" / "benchmark_data_4q.json"
+    benchmark_data_path = (
+        _filepath.parents[1] / "local" / "data" / "benchmark_data_4q.json"
+    )
 
     file_store = FileStore(documents_path)
     documents = file_store.load_as_documents()
     benchmark_data = read_benchmark_from_json(benchmark_data_path)
 
     # Configure optimizer
-    optimizer_settings = GAMOptSettings(max_evals=1, n_random_nodes=4)
+    optimizer_settings = GAMOptSettings(max_evals=4, n_random_nodes=4)
 
     # Edit configurations of search space
     search_space = AI4RAGSearchSpace(
@@ -48,16 +55,21 @@ if __name__ == "__main__":
             Parameter(
                 name="foundation_model",
                 param_type="C",
-                values=[OGXFoundationModel(model_id="ollama/llama3.2:3b", client=client)],
+                values=[
+                    OGXFoundationModel(
+                        model_id="vllm-inference-gpu-mistral/redhataimistral-small-24b-inst",
+                        client=client,
+                    )
+                ],
             ),
             Parameter(
                 name="embedding_model",
                 param_type="C",
                 values=[
                     OGXEmbeddingModel(
-                        model_id="ollama/nomic-embed-text:latest",
+                        model_id="vllm-embedding/bge-m3",
                         client=client,
-                        params={"embedding_dimension": 768, "context_length": 8192},
+                        params={"embedding_dimension": 1024, "context_length": 8192},
                     )
                 ],
             ),
@@ -94,7 +106,7 @@ if __name__ == "__main__":
         # event_handler=LocalEventHandler(output_path=_filepath.parent / "local" / "hybrid_test"),
         event_handler=LocalEventHandler(),
         vector_store_type="ogx",
-        ogx_vector_io_provider_id="milvus-lite",
+        ogx_vector_io_provider_id="pgvector",
     )
 
     experiment.search(skip_mps=True)

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -317,13 +317,7 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search(
-            "test query",
-            k=5,
-            search_mode="hybrid",
-            ranker_strategy="weighted",
-            ranker_alpha=0.7,
-        )
+        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_alpha=0.7)
 
         call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -366,10 +360,7 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        with pytest.raises(
-            ValueError,
-            match="ranker_alpha=0.5 is only valid when ranker_strategy='weighted'",
-        ):
+        with pytest.raises(ValueError, match="ranker_alpha=0.5 is only valid when ranker_strategy='weighted'"):
             vector_store.search(
                 "test query",
                 k=5,
@@ -388,12 +379,7 @@ class TestOGXVectorStoreHybridSearch:
         )
 
         result = vector_store.search(
-            "test query",
-            k=5,
-            include_scores=True,
-            search_mode="hybrid",
-            ranker_strategy="rrf",
-            ranker_k=60,
+            "test query", k=5, include_scores=True, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60
         )
 
         assert isinstance(result, list)
@@ -624,10 +610,7 @@ class TestOGXVectorStoreSearchValidation:
 
     def test_ranker_strategy_on_vector_mode_raises(self):
         """Test that a non-empty ranker_strategy with vector mode raises ValueError."""
-        with pytest.raises(
-            ValueError,
-            match="ranker_strategy='rrf' is only valid when search_mode='hybrid'",
-        ):
+        with pytest.raises(ValueError, match="ranker_strategy='rrf' is only valid when search_mode='hybrid'"):
             OGXVectorStore._validate_search_params("vector", "rrf", None, None)
 
     def test_ranker_k_on_vector_mode_raises(self):
@@ -675,18 +658,12 @@ class TestOGXVectorStoreSearchValidation:
 
     def test_alpha_with_rrf_strategy_raises(self):
         """Test that ranker_alpha > 0 with rrf strategy raises ValueError."""
-        with pytest.raises(
-            ValueError,
-            match="ranker_alpha=0.7 is only valid when ranker_strategy='weighted'",
-        ):
+        with pytest.raises(ValueError, match="ranker_alpha=0.7 is only valid when ranker_strategy='weighted'"):
             OGXVectorStore._validate_search_params("hybrid", "rrf", 60, 0.7)
 
     def test_alpha_with_normalized_strategy_raises(self):
         """Test that ranker_alpha > 0 with normalized strategy raises ValueError."""
-        with pytest.raises(
-            ValueError,
-            match="ranker_alpha=0.3 is only valid when ranker_strategy='weighted'",
-        ):
+        with pytest.raises(ValueError, match="ranker_alpha=0.3 is only valid when ranker_strategy='weighted'"):
             OGXVectorStore._validate_search_params("hybrid", "normalized", None, 0.3)
 
     # --- sentinel values must not trigger errors ---

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -2,7 +2,8 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
+import logging
 
 import pytest
 from langchain_core.documents import Document
@@ -59,7 +60,9 @@ class TestOGXVectorStoreInitialization:
         assert vector_store._ogx_vs is not None
         mock_ogx_client.vector_stores.create.assert_called_once()
 
-    def test_init_with_reuse_collection_name(self, mock_embedding_model, mock_ogx_client):
+    def test_init_with_reuse_collection_name(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test initialization with reuse_collection_name retrieves existing store."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -68,7 +71,9 @@ class TestOGXVectorStoreInitialization:
             reuse_collection_name="existing-collection",
         )
 
-        mock_ogx_client.vector_stores.retrieve.assert_called_once_with("existing-collection")
+        mock_ogx_client.vector_stores.retrieve.assert_called_once_with(
+            "existing-collection"
+        )
         mock_ogx_client.vector_stores.create.assert_not_called()
 
     def test_init_with_distance_metric(self, mock_embedding_model, mock_ogx_client):
@@ -94,7 +99,9 @@ class TestOGXVectorStoreInitialization:
         assert "extra_body" in call_kwargs
         assert call_kwargs["extra_body"]["provider_id"] == "test-provider"
 
-    def test_init_passes_embedding_model_params(self, mock_embedding_model, mock_ogx_client):
+    def test_init_passes_embedding_model_params(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that embedding model parameters are passed correctly."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -199,7 +206,9 @@ class TestOGXVectorStoreSearch:
         assert isinstance(result[0][1], float)
         assert result[0][1] == 0.95
 
-    def test_search_calls_client_with_correct_params(self, mock_embedding_model, mock_ogx_client):
+    def test_search_calls_client_with_correct_params(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that search calls client with correct parameters."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -300,7 +309,9 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60)
+        vector_store.search(
+            "test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60
+        )
 
         call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -308,7 +319,9 @@ class TestOGXVectorStoreHybridSearch:
         assert params["reranker_type"] == "rrf"
         assert params["reranker_params"]["impact_factor"] == 60
 
-    def test_search_with_hybrid_mode_weighted(self, mock_embedding_model, mock_ogx_client):
+    def test_search_with_hybrid_mode_weighted(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test search with hybrid mode and weighted ranker including alpha."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -316,7 +329,13 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="weighted", ranker_alpha=0.7)
+        vector_store.search(
+            "test query",
+            k=5,
+            search_mode="hybrid",
+            ranker_strategy="weighted",
+            ranker_alpha=0.7,
+        )
 
         call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -324,7 +343,9 @@ class TestOGXVectorStoreHybridSearch:
         assert params["reranker_type"] == "weighted"
         assert params["reranker_params"]["alpha"] == 0.7
 
-    def test_search_with_hybrid_mode_normalized(self, mock_embedding_model, mock_ogx_client):
+    def test_search_with_hybrid_mode_normalized(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test search with hybrid mode and normalized ranker."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -332,7 +353,9 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="normalized")
+        vector_store.search(
+            "test query", k=5, search_mode="hybrid", ranker_strategy="normalized"
+        )
 
         call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -340,7 +363,9 @@ class TestOGXVectorStoreHybridSearch:
         assert params["reranker_type"] == "normalized"
         assert params["reranker_params"] == {}
 
-    def test_search_hybrid_empty_strategy_raises(self, mock_embedding_model, mock_ogx_client):
+    def test_search_hybrid_empty_strategy_raises(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that empty ranker_strategy with hybrid mode raises ValueError."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -348,10 +373,16 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        with pytest.raises(ValueError, match="ranker_strategy must be set when search_mode='hybrid'"):
-            vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="")
+        with pytest.raises(
+            ValueError, match="ranker_strategy must be set when search_mode='hybrid'"
+        ):
+            vector_store.search(
+                "test query", k=5, search_mode="hybrid", ranker_strategy=""
+            )
 
-    def test_search_hybrid_alpha_with_rrf_raises(self, mock_embedding_model, mock_ogx_client):
+    def test_search_hybrid_alpha_with_rrf_raises(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that non-zero ranker_alpha with a non-weighted strategy raises ValueError."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -359,9 +390,17 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        with pytest.raises(ValueError, match="ranker_alpha=0.5 is only valid when ranker_strategy='weighted'"):
+        with pytest.raises(
+            ValueError,
+            match="ranker_alpha=0.5 is only valid when ranker_strategy='weighted'",
+        ):
             vector_store.search(
-                "test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60, ranker_alpha=0.5
+                "test query",
+                k=5,
+                search_mode="hybrid",
+                ranker_strategy="rrf",
+                ranker_k=60,
+                ranker_alpha=0.5,
             )
 
     def test_search_hybrid_with_scores(self, mock_embedding_model, mock_ogx_client):
@@ -373,7 +412,12 @@ class TestOGXVectorStoreHybridSearch:
         )
 
         result = vector_store.search(
-            "test query", k=5, include_scores=True, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60
+            "test query",
+            k=5,
+            include_scores=True,
+            search_mode="hybrid",
+            ranker_strategy="rrf",
+            ranker_k=60,
         )
 
         assert isinstance(result, list)
@@ -416,7 +460,9 @@ class TestOGXVectorStoreAddDocuments:
 
         mock_ogx_client.vector_io.insert.assert_called_once()
 
-    def test_add_documents_creates_chunks_with_embeddings(self, mock_embedding_model, mock_ogx_client):
+    def test_add_documents_creates_chunks_with_embeddings(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that add_documents creates chunks with embeddings."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -435,7 +481,11 @@ class TestOGXVectorStoreAddDocuments:
         assert "content" in chunks[0]
         assert "embedding" in chunks[0]
         assert "chunk_id" in chunks[0]
-        assert chunks[0]["chunk_id"] == str(hash("Test"))
+        assert chunks[0]["chunk_id"] == str(
+            hash(
+                f"{docs[0].metadata.get('document_id')}_{docs[0].metadata.get('start_index')}_{docs[0].page_content}"
+            )
+        )
         assert chunks[0]["chunk_metadata"] == {"document_id": "doc1"}
         assert chunks[0]["metadata"] == {"document_id": "doc1"}
 
@@ -447,7 +497,10 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
+        docs = [
+            Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"})
+            for i in range(5)
+        ]
 
         vector_store.add_documents(docs)
 
@@ -456,7 +509,9 @@ class TestOGXVectorStoreAddDocuments:
 
         assert len(chunks) == 5
 
-    def test_add_documents_preserves_metadata(self, mock_embedding_model, mock_ogx_client):
+    def test_add_documents_preserves_metadata(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that add_documents preserves metadata."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -497,7 +552,9 @@ class TestOGXVectorStoreAddDocuments:
 
         mock_embed_model.embed_documents.assert_called_once_with(["Test"])
 
-    def test_add_documents_batches_large_input(self, mock_embedding_model, mock_ogx_client):
+    def test_add_documents_batches_large_input(
+        self, mock_embedding_model, mock_ogx_client
+    ):
         """Test that add_documents batches inserts exceeding batch_size."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -505,7 +562,10 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
+        docs = [
+            Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"})
+            for i in range(5)
+        ]
 
         vector_store.add_documents(docs, batch_size=2)
 
@@ -581,7 +641,9 @@ class TestOGXVectorStoreInitializeVectorStore:
         )
 
         assert result == mock_vs
-        mock_client.vector_stores.retrieve.assert_called_once_with("existing-collection")
+        mock_client.vector_stores.retrieve.assert_called_once_with(
+            "existing-collection"
+        )
         mock_client.vector_stores.create.assert_not_called()
 
 
@@ -604,29 +666,40 @@ class TestOGXVectorStoreSearchValidation:
 
     def test_ranker_strategy_on_vector_mode_raises(self):
         """Test that a non-empty ranker_strategy with vector mode raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_strategy='rrf' is only valid when search_mode='hybrid'"):
+        with pytest.raises(
+            ValueError,
+            match="ranker_strategy='rrf' is only valid when search_mode='hybrid'",
+        ):
             OGXVectorStore._validate_search_params("vector", "rrf", None, None)
 
     def test_ranker_k_on_vector_mode_raises(self):
         """Test that a positive ranker_k with vector mode raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_k=60 is only valid when search_mode='hybrid'"):
+        with pytest.raises(
+            ValueError, match="ranker_k=60 is only valid when search_mode='hybrid'"
+        ):
             OGXVectorStore._validate_search_params("vector", None, 60, None)
 
     def test_ranker_alpha_on_vector_mode_raises(self):
         """Test that a positive ranker_alpha with vector mode raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_alpha=0.5 is only valid when search_mode='hybrid'"):
+        with pytest.raises(
+            ValueError, match="ranker_alpha=0.5 is only valid when search_mode='hybrid'"
+        ):
             OGXVectorStore._validate_search_params("vector", None, None, 0.5)
 
     # --- hybrid mode missing ranker_strategy ---
 
     def test_hybrid_mode_none_strategy_raises(self):
         """Test that hybrid mode with ranker_strategy=None raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_strategy must be set when search_mode='hybrid'"):
+        with pytest.raises(
+            ValueError, match="ranker_strategy must be set when search_mode='hybrid'"
+        ):
             OGXVectorStore._validate_search_params("hybrid", None, None, None)
 
     def test_hybrid_mode_empty_strategy_raises(self):
         """Test that hybrid mode with ranker_strategy='' raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_strategy must be set when search_mode='hybrid'"):
+        with pytest.raises(
+            ValueError, match="ranker_strategy must be set when search_mode='hybrid'"
+        ):
             OGXVectorStore._validate_search_params("hybrid", "", None, None)
 
     # --- invalid ranker_strategy value ---
@@ -640,24 +713,34 @@ class TestOGXVectorStoreSearchValidation:
 
     def test_ranker_k_with_weighted_strategy_raises(self):
         """Test that ranker_k > 0 with weighted strategy raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_k=60 is only valid when ranker_strategy='rrf'"):
+        with pytest.raises(
+            ValueError, match="ranker_k=60 is only valid when ranker_strategy='rrf'"
+        ):
             OGXVectorStore._validate_search_params("hybrid", "weighted", 60, 0.7)
 
     def test_ranker_k_with_normalized_strategy_raises(self):
         """Test that ranker_k > 0 with normalized strategy raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_k=20 is only valid when ranker_strategy='rrf'"):
+        with pytest.raises(
+            ValueError, match="ranker_k=20 is only valid when ranker_strategy='rrf'"
+        ):
             OGXVectorStore._validate_search_params("hybrid", "normalized", 20, None)
 
     # --- ranker_alpha used with non-weighted strategy ---
 
     def test_alpha_with_rrf_strategy_raises(self):
         """Test that ranker_alpha > 0 with rrf strategy raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_alpha=0.7 is only valid when ranker_strategy='weighted'"):
+        with pytest.raises(
+            ValueError,
+            match="ranker_alpha=0.7 is only valid when ranker_strategy='weighted'",
+        ):
             OGXVectorStore._validate_search_params("hybrid", "rrf", 60, 0.7)
 
     def test_alpha_with_normalized_strategy_raises(self):
         """Test that ranker_alpha > 0 with normalized strategy raises ValueError."""
-        with pytest.raises(ValueError, match="ranker_alpha=0.3 is only valid when ranker_strategy='weighted'"):
+        with pytest.raises(
+            ValueError,
+            match="ranker_alpha=0.3 is only valid when ranker_strategy='weighted'",
+        ):
             OGXVectorStore._validate_search_params("hybrid", "normalized", None, 0.3)
 
     # --- sentinel values must not trigger errors ---
@@ -723,3 +806,164 @@ class TestOGXVectorStoreInitializeVectorStore:
         assert extra_body["embedding_model"] == "custom-model-id"
         assert extra_body["embedding_dimension"] == 256
         assert extra_body["provider_id"] == "provider1"
+
+
+class TestOGXVectorStoreDuplicateChunks:
+    """Test suite for OGXVectorStore duplicate chunk detection."""
+
+    @pytest.fixture
+    def mock_embedding_model(self):
+        """Create a mock embedding model."""
+        return MockOGXEmbeddingModel()
+
+    @pytest.fixture
+    def mock_ogx_client(self):
+        """Create a mock OgxClient."""
+        mock_client = MagicMock()
+        mock_vs = MagicMock()
+        mock_vs.id = "test-vs-id"
+        mock_client.vector_stores.create.return_value = mock_vs
+        return mock_client
+
+    def test_add_documents_with_duplicate_content_skips_duplicates(
+        self, mock_embedding_model, mock_ogx_client, caplog
+    ):
+        """Test that adding documents with duplicate content skips duplicates and logs warning."""
+
+        vector_store = OGXVectorStore(
+            embedding_model=mock_embedding_model,
+            client=mock_ogx_client,
+            provider_id="pgvector",
+        )
+
+        # Create documents with identical content (will generate same hash)
+        docs = [
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc1"}
+            ),
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc1"}
+            ),
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc1"}
+            ),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="ai4rag"):
+            vector_store.add_documents(docs)
+
+        # Should have logged warnings for duplicates
+        assert "Skipping duplicate chunk_id" in caplog.text
+
+        # Should only insert 1 unique chunk (first occurrence)
+        call_kwargs = mock_ogx_client.vector_io.insert.call_args.kwargs
+        chunks = call_kwargs["chunks"]
+        assert len(chunks) == 1
+
+    def test_add_documents_with_unique_content_succeeds(
+        self, mock_embedding_model, mock_ogx_client
+    ):
+        """Test that adding documents with unique content succeeds."""
+        vector_store = OGXVectorStore(
+            embedding_model=mock_embedding_model,
+            client=mock_ogx_client,
+            provider_id="pgvector",
+        )
+
+        docs = [
+            Document(page_content="Unique content 1", metadata={"document_id": "doc1"}),
+            Document(page_content="Unique content 2", metadata={"document_id": "doc2"}),
+            Document(page_content="Unique content 3", metadata={"document_id": "doc3"}),
+        ]
+
+        # Should not raise an error
+        vector_store.add_documents(docs)
+        mock_ogx_client.vector_io.insert.assert_called_once()
+
+        # Should insert all 3 chunks
+        call_kwargs = mock_ogx_client.vector_io.insert.call_args.kwargs
+        chunks = call_kwargs["chunks"]
+        assert len(chunks) == 3
+
+    def test_add_documents_with_mixed_content(
+        self, mock_embedding_model, mock_ogx_client, caplog
+    ):
+        """Test that adding documents with some duplicates filters them out."""
+
+        vector_store = OGXVectorStore(
+            embedding_model=mock_embedding_model,
+            client=mock_ogx_client,
+            provider_id="pgvector",
+        )
+
+        docs = [
+            Document(page_content="Unique content", metadata={"document_id": "doc1"}),
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc2"}
+            ),
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc2"}
+            ),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="ai4rag"):
+            vector_store.add_documents(docs)
+
+        # Should have logged warning for 1 duplicate
+        assert "Skipping duplicate chunk_id" in caplog.text
+
+        # Should insert 2 unique chunks
+        call_kwargs = mock_ogx_client.vector_io.insert.call_args.kwargs
+        chunks = call_kwargs["chunks"]
+        assert len(chunks) == 2
+
+    def test_duplicate_chunks_keeps_first_occurrence(
+        self, mock_embedding_model, mock_ogx_client
+    ):
+        """Test that duplicates keep the first occurrence."""
+        vector_store = OGXVectorStore(
+            embedding_model=mock_embedding_model,
+            client=mock_ogx_client,
+            provider_id="pgvector",
+        )
+
+        docs = [
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc1"}
+            ),
+            Document(
+                page_content="Duplicate content", metadata={"document_id": "doc1"}
+            ),
+        ]
+
+        vector_store.add_documents(docs)
+
+        # Should insert only first occurrence (doc1)
+        call_kwargs = mock_ogx_client.vector_io.insert.call_args.kwargs
+        chunks = call_kwargs["chunks"]
+        assert len(chunks) == 1
+        assert chunks[0]["chunk_metadata"]["document_id"] == "doc1"
+
+    def test_no_warning_when_no_duplicates(
+        self, mock_embedding_model, mock_ogx_client, caplog
+    ):
+        """Test that no warning is logged when there are no duplicates."""
+
+        vector_store = OGXVectorStore(
+            embedding_model=mock_embedding_model,
+            client=mock_ogx_client,
+            provider_id="pgvector",
+        )
+
+        docs = [
+            Document(page_content="Not unique 1", metadata={"document_id": "doc1"}),
+            Document(page_content="Not unique 1", metadata={"document_id": "doc2"}),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="ai4rag"):
+            vector_store.add_documents(docs)
+
+        # Should not have any warnings
+        assert "Skipping duplicate chunk_id" not in [
+            record.message for record in caplog.records
+        ]

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -60,9 +60,7 @@ class TestOGXVectorStoreInitialization:
         assert vector_store._ogx_vs is not None
         mock_ogx_client.vector_stores.create.assert_called_once()
 
-    def test_init_with_reuse_collection_name(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_init_with_reuse_collection_name(self, mock_embedding_model, mock_ogx_client):
         """Test initialization with reuse_collection_name retrieves existing store."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -71,9 +69,7 @@ class TestOGXVectorStoreInitialization:
             reuse_collection_name="existing-collection",
         )
 
-        mock_ogx_client.vector_stores.retrieve.assert_called_once_with(
-            "existing-collection"
-        )
+        mock_ogx_client.vector_stores.retrieve.assert_called_once_with("existing-collection")
         mock_ogx_client.vector_stores.create.assert_not_called()
 
     def test_init_with_distance_metric(self, mock_embedding_model, mock_ogx_client):
@@ -99,9 +95,7 @@ class TestOGXVectorStoreInitialization:
         assert "extra_body" in call_kwargs
         assert call_kwargs["extra_body"]["provider_id"] == "test-provider"
 
-    def test_init_passes_embedding_model_params(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_init_passes_embedding_model_params(self, mock_embedding_model, mock_ogx_client):
         """Test that embedding model parameters are passed correctly."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -206,9 +200,7 @@ class TestOGXVectorStoreSearch:
         assert isinstance(result[0][1], float)
         assert result[0][1] == 0.95
 
-    def test_search_calls_client_with_correct_params(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_search_calls_client_with_correct_params(self, mock_embedding_model, mock_ogx_client):
         """Test that search calls client with correct parameters."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -309,9 +301,7 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search(
-            "test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60
-        )
+        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="rrf", ranker_k=60)
 
         call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -319,9 +309,7 @@ class TestOGXVectorStoreHybridSearch:
         assert params["reranker_type"] == "rrf"
         assert params["reranker_params"]["impact_factor"] == 60
 
-    def test_search_with_hybrid_mode_weighted(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_search_with_hybrid_mode_weighted(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and weighted ranker including alpha."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -343,9 +331,7 @@ class TestOGXVectorStoreHybridSearch:
         assert params["reranker_type"] == "weighted"
         assert params["reranker_params"]["alpha"] == 0.7
 
-    def test_search_with_hybrid_mode_normalized(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_search_with_hybrid_mode_normalized(self, mock_embedding_model, mock_ogx_client):
         """Test search with hybrid mode and normalized ranker."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -353,9 +339,7 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        vector_store.search(
-            "test query", k=5, search_mode="hybrid", ranker_strategy="normalized"
-        )
+        vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="normalized")
 
         call_kwargs = mock_ogx_client.vector_io.query.call_args.kwargs
         params = call_kwargs["params"]
@@ -363,9 +347,7 @@ class TestOGXVectorStoreHybridSearch:
         assert params["reranker_type"] == "normalized"
         assert params["reranker_params"] == {}
 
-    def test_search_hybrid_empty_strategy_raises(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_search_hybrid_empty_strategy_raises(self, mock_embedding_model, mock_ogx_client):
         """Test that empty ranker_strategy with hybrid mode raises ValueError."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -373,16 +355,10 @@ class TestOGXVectorStoreHybridSearch:
             provider_id="milvus",
         )
 
-        with pytest.raises(
-            ValueError, match="ranker_strategy must be set when search_mode='hybrid'"
-        ):
-            vector_store.search(
-                "test query", k=5, search_mode="hybrid", ranker_strategy=""
-            )
+        with pytest.raises(ValueError, match="ranker_strategy must be set when search_mode='hybrid'"):
+            vector_store.search("test query", k=5, search_mode="hybrid", ranker_strategy="")
 
-    def test_search_hybrid_alpha_with_rrf_raises(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_search_hybrid_alpha_with_rrf_raises(self, mock_embedding_model, mock_ogx_client):
         """Test that non-zero ranker_alpha with a non-weighted strategy raises ValueError."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -460,9 +436,7 @@ class TestOGXVectorStoreAddDocuments:
 
         mock_ogx_client.vector_io.insert.assert_called_once()
 
-    def test_add_documents_creates_chunks_with_embeddings(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_add_documents_creates_chunks_with_embeddings(self, mock_embedding_model, mock_ogx_client):
         """Test that add_documents creates chunks with embeddings."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -481,11 +455,7 @@ class TestOGXVectorStoreAddDocuments:
         assert "content" in chunks[0]
         assert "embedding" in chunks[0]
         assert "chunk_id" in chunks[0]
-        assert chunks[0]["chunk_id"] == str(
-            hash(
-                f"{docs[0].metadata.get('document_id')}_{docs[0].metadata.get('start_index')}_{docs[0].page_content}"
-            )
-        )
+        assert chunks[0]["chunk_id"] == str(hash(docs[0].page_content))
         assert chunks[0]["chunk_metadata"] == {"document_id": "doc1"}
         assert chunks[0]["metadata"] == {"document_id": "doc1"}
 
@@ -497,10 +467,7 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [
-            Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"})
-            for i in range(5)
-        ]
+        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
 
         vector_store.add_documents(docs)
 
@@ -509,9 +476,7 @@ class TestOGXVectorStoreAddDocuments:
 
         assert len(chunks) == 5
 
-    def test_add_documents_preserves_metadata(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_add_documents_preserves_metadata(self, mock_embedding_model, mock_ogx_client):
         """Test that add_documents preserves metadata."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -552,9 +517,7 @@ class TestOGXVectorStoreAddDocuments:
 
         mock_embed_model.embed_documents.assert_called_once_with(["Test"])
 
-    def test_add_documents_batches_large_input(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_add_documents_batches_large_input(self, mock_embedding_model, mock_ogx_client):
         """Test that add_documents batches inserts exceeding batch_size."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -562,10 +525,7 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [
-            Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"})
-            for i in range(5)
-        ]
+        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
 
         vector_store.add_documents(docs, batch_size=2)
 
@@ -641,9 +601,7 @@ class TestOGXVectorStoreInitializeVectorStore:
         )
 
         assert result == mock_vs
-        mock_client.vector_stores.retrieve.assert_called_once_with(
-            "existing-collection"
-        )
+        mock_client.vector_stores.retrieve.assert_called_once_with("existing-collection")
         mock_client.vector_stores.create.assert_not_called()
 
 
@@ -674,32 +632,24 @@ class TestOGXVectorStoreSearchValidation:
 
     def test_ranker_k_on_vector_mode_raises(self):
         """Test that a positive ranker_k with vector mode raises ValueError."""
-        with pytest.raises(
-            ValueError, match="ranker_k=60 is only valid when search_mode='hybrid'"
-        ):
+        with pytest.raises(ValueError, match="ranker_k=60 is only valid when search_mode='hybrid'"):
             OGXVectorStore._validate_search_params("vector", None, 60, None)
 
     def test_ranker_alpha_on_vector_mode_raises(self):
         """Test that a positive ranker_alpha with vector mode raises ValueError."""
-        with pytest.raises(
-            ValueError, match="ranker_alpha=0.5 is only valid when search_mode='hybrid'"
-        ):
+        with pytest.raises(ValueError, match="ranker_alpha=0.5 is only valid when search_mode='hybrid'"):
             OGXVectorStore._validate_search_params("vector", None, None, 0.5)
 
     # --- hybrid mode missing ranker_strategy ---
 
     def test_hybrid_mode_none_strategy_raises(self):
         """Test that hybrid mode with ranker_strategy=None raises ValueError."""
-        with pytest.raises(
-            ValueError, match="ranker_strategy must be set when search_mode='hybrid'"
-        ):
+        with pytest.raises(ValueError, match="ranker_strategy must be set when search_mode='hybrid'"):
             OGXVectorStore._validate_search_params("hybrid", None, None, None)
 
     def test_hybrid_mode_empty_strategy_raises(self):
         """Test that hybrid mode with ranker_strategy='' raises ValueError."""
-        with pytest.raises(
-            ValueError, match="ranker_strategy must be set when search_mode='hybrid'"
-        ):
+        with pytest.raises(ValueError, match="ranker_strategy must be set when search_mode='hybrid'"):
             OGXVectorStore._validate_search_params("hybrid", "", None, None)
 
     # --- invalid ranker_strategy value ---
@@ -713,16 +663,12 @@ class TestOGXVectorStoreSearchValidation:
 
     def test_ranker_k_with_weighted_strategy_raises(self):
         """Test that ranker_k > 0 with weighted strategy raises ValueError."""
-        with pytest.raises(
-            ValueError, match="ranker_k=60 is only valid when ranker_strategy='rrf'"
-        ):
+        with pytest.raises(ValueError, match="ranker_k=60 is only valid when ranker_strategy='rrf'"):
             OGXVectorStore._validate_search_params("hybrid", "weighted", 60, 0.7)
 
     def test_ranker_k_with_normalized_strategy_raises(self):
         """Test that ranker_k > 0 with normalized strategy raises ValueError."""
-        with pytest.raises(
-            ValueError, match="ranker_k=20 is only valid when ranker_strategy='rrf'"
-        ):
+        with pytest.raises(ValueError, match="ranker_k=20 is only valid when ranker_strategy='rrf'"):
             OGXVectorStore._validate_search_params("hybrid", "normalized", 20, None)
 
     # --- ranker_alpha used with non-weighted strategy ---
@@ -825,9 +771,7 @@ class TestOGXVectorStoreDuplicateChunks:
         mock_client.vector_stores.create.return_value = mock_vs
         return mock_client
 
-    def test_add_documents_with_duplicate_content_skips_duplicates(
-        self, mock_embedding_model, mock_ogx_client, caplog
-    ):
+    def test_add_documents_with_duplicate_content_skips_duplicates(self, mock_embedding_model, mock_ogx_client, caplog):
         """Test that adding documents with duplicate content skips duplicates and logs warning."""
 
         vector_store = OGXVectorStore(
@@ -838,15 +782,9 @@ class TestOGXVectorStoreDuplicateChunks:
 
         # Create documents with identical content (will generate same hash)
         docs = [
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc1"}
-            ),
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc1"}
-            ),
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc1"}
-            ),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
         ]
 
         with caplog.at_level(logging.WARNING, logger="ai4rag"):
@@ -860,9 +798,7 @@ class TestOGXVectorStoreDuplicateChunks:
         chunks = call_kwargs["chunks"]
         assert len(chunks) == 1
 
-    def test_add_documents_with_unique_content_succeeds(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_add_documents_with_unique_content_succeeds(self, mock_embedding_model, mock_ogx_client):
         """Test that adding documents with unique content succeeds."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -885,9 +821,7 @@ class TestOGXVectorStoreDuplicateChunks:
         chunks = call_kwargs["chunks"]
         assert len(chunks) == 3
 
-    def test_add_documents_with_mixed_content(
-        self, mock_embedding_model, mock_ogx_client, caplog
-    ):
+    def test_add_documents_with_mixed_content(self, mock_embedding_model, mock_ogx_client, caplog):
         """Test that adding documents with some duplicates filters them out."""
 
         vector_store = OGXVectorStore(
@@ -898,12 +832,8 @@ class TestOGXVectorStoreDuplicateChunks:
 
         docs = [
             Document(page_content="Unique content", metadata={"document_id": "doc1"}),
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc2"}
-            ),
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc2"}
-            ),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc2"}),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc2"}),
         ]
 
         with caplog.at_level(logging.WARNING, logger="ai4rag"):
@@ -917,9 +847,7 @@ class TestOGXVectorStoreDuplicateChunks:
         chunks = call_kwargs["chunks"]
         assert len(chunks) == 2
 
-    def test_duplicate_chunks_keeps_first_occurrence(
-        self, mock_embedding_model, mock_ogx_client
-    ):
+    def test_duplicate_chunks_keeps_first_occurrence(self, mock_embedding_model, mock_ogx_client):
         """Test that duplicates keep the first occurrence."""
         vector_store = OGXVectorStore(
             embedding_model=mock_embedding_model,
@@ -928,12 +856,8 @@ class TestOGXVectorStoreDuplicateChunks:
         )
 
         docs = [
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc1"}
-            ),
-            Document(
-                page_content="Duplicate content", metadata={"document_id": "doc1"}
-            ),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
+            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
         ]
 
         vector_store.add_documents(docs)
@@ -944,9 +868,7 @@ class TestOGXVectorStoreDuplicateChunks:
         assert len(chunks) == 1
         assert chunks[0]["chunk_metadata"]["document_id"] == "doc1"
 
-    def test_no_warning_when_no_duplicates(
-        self, mock_embedding_model, mock_ogx_client, caplog
-    ):
+    def test_no_warning_when_no_duplicates(self, mock_embedding_model, mock_ogx_client, caplog):
         """Test that no warning is logged when there are no duplicates."""
 
         vector_store = OGXVectorStore(
@@ -964,6 +886,4 @@ class TestOGXVectorStoreDuplicateChunks:
             vector_store.add_documents(docs)
 
         # Should not have any warnings
-        assert "Skipping duplicate chunk_id" not in [
-            record.message for record in caplog.records
-        ]
+        assert "Skipping duplicate chunk_id" not in [record.message for record in caplog.records]


### PR DESCRIPTION
## Description
We had to add additional portion of information during chunk index creation to prevent hash conflicts.

## Motivation
PG vector does not support the same chunk ID's within the batch and throws an error.

## Changes
- there is a probability near 0 that the chunk index will be the same within the batch
- unit test cases have been created

## Testing
Manual testing with remote OGX server and PG vector db.

## Checklist
- [x] Tests added/updated
- [x] Code follows style guide
- [ ] All checks passing
