### PR TITLE
Introduces DoclingChunker

### DIFF
--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, is_dataclass
 from typing import Any, Sequence
 
 import pandas as pd
-from langchain_core.documents import Document
+from docling_core.types.doc import DoclingDocument
 from ogx_client import OgxClient
 
 from ai4rag import logger
@@ -34,7 +34,7 @@ from ai4rag.core.hpo.gam_opt import GAMOptimizer
 from ai4rag.core.hpo.random_opt import FailedIterationError
 from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, MetricType
 from ai4rag.evaluator.unitxt_evaluator import UnitxtEvaluator
-from ai4rag.rag.chunking import LangChainChunker
+from ai4rag.rag.chunking import DoclingChunker, LangChainChunker
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
 from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 from ai4rag.rag.retrieval.retriever import Retriever
@@ -63,12 +63,8 @@ class AI4RAGExperiment:
 
     Parameters
     ----------
-    documents : list[Document | tuple[str, str]]
-        List of documents to embed in vector db and use as context in RAG.
-        When given as list of langchain's Document instances, both content and document
-        ids must be provided:
-        Document(page_content=..., metadata={document_id: 'some_id'})
-        When given as list of tuples it should be (content, document_id)
+    documents : list[DoclingDocument]
+        List of parsed docling documents to embed in vector db and use as context in RAG.
 
     benchmark_data : pd.DataFrame | BenchmarkData
         Structure with 3 columns: 'question', 'correct_answers' and - if applicable - 'correct_answer_document_ids'.
@@ -132,7 +128,7 @@ class AI4RAGExperiment:
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
-        documents: list[Document],
+        documents: list[DoclingDocument],
         benchmark_data: pd.DataFrame,
         search_space: AI4RAGSearchSpace,
         vector_store_type: str,
@@ -174,32 +170,25 @@ class AI4RAGExperiment:
             logger.warning("Unknown parameters: %s", kwargs)
 
     @property
-    def documents(self) -> list[Document]:
-        """Get list of documents"""
+    def documents(self) -> list[DoclingDocument]:
+        """Get list of documents."""
         return self._documents
 
     @documents.setter
-    def documents(self, docs: list[Document | tuple[str, str]] | None) -> None:
+    def documents(self, docs: list[DoclingDocument] | None) -> None:
         """
         Validate and set documents value.
-        We need to make sure if we have needed content and document_ids
-        provided and the documents. All documents need to be instances
-        of LangChain's Document class.
+        All documents must be ``DoclingDocument`` instances.
         """
         proper_docs = []
         if docs:
             for idx, doc in enumerate(docs):
-                if isinstance(doc, Document):
-                    if not doc.page_content:
-                        which_doc = doc.metadata.get("document_id") or idx
-                        logger.warning("Empty document: %s", which_doc)
-                    if not doc.metadata.get("document_id", None):
-                        logger.warning("document_id not provided for document at index: %s", idx)
-
+                if isinstance(doc, DoclingDocument):
+                    if not doc.name:
+                        logger.warning("Document at index %s has no name set.", idx)
                     proper_docs.append(doc)
-
                 else:
-                    raise ValueError(f"Incorrect type of document provided at index: {idx}.")
+                    raise ValueError(f"Incorrect type of document provided at index: {idx}. Expected DoclingDocument.")
 
         self._documents = proper_docs
 
@@ -389,7 +378,10 @@ class AI4RAGExperiment:
             chunk_size = chunking_params.get(AI4RAGParamNames.CHUNK_SIZE)
             chunk_overlap = chunking_params.get(AI4RAGParamNames.CHUNK_OVERLAP)
 
-            chunker = LangChainChunker(method=chunking_method, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+            if chunking_method == "hybrid":
+                chunker = DoclingChunker(max_tokens=chunk_size)
+            else:
+                chunker = LangChainChunker(method=chunking_method, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
             chunked_documents = chunker.split_documents(self.documents)
 
             if self.event_handler:

--- a/ai4rag/core/experiment/mps.py
+++ b/ai4rag/core/experiment/mps.py
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 from typing import Any, TypedDict
 
-from langchain_core.documents import Document
+from docling_core.types.doc import DoclingDocument
 
 from ai4rag import logger
 from ai4rag.core.experiment.benchmark_data import BenchmarkData
@@ -17,6 +17,7 @@ from ai4rag.core.experiment.exception_handler import (
 from ai4rag.core.experiment.utils import build_evaluation_data, query_rag
 from ai4rag.evaluator import UnitxtEvaluator
 from ai4rag.evaluator.base_evaluator import BaseEvaluator
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.chunking.langchain_chunker import LangChainChunker
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
 from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
@@ -66,7 +67,7 @@ class ModelsPreSelector:
     embedding_models : list[BaseEmbeddingModel]
         Embedding models to models pre-selection.
 
-    documents : list[Document]
+    documents : list[DoclingDocument]
         Grounding documents that will be sampled to perform pre-selection.
 
     benchmark_data : BenchmarkData
@@ -103,7 +104,7 @@ class ModelsPreSelector:
         metric: str,
         foundation_models: list[BaseFoundationModel],
         embedding_models: list[BaseEmbeddingModel],
-        documents: list[Document],
+        documents: list[DoclingDocument],
         benchmark_data: BenchmarkData,
         **kwargs,
     ):
@@ -147,7 +148,7 @@ class ModelsPreSelector:
         for element in self.benchmark_data.document_ids:
             document_ids.extend(element)
 
-        documents = [document for document in self.documents if document.metadata["document_id"] in document_ids]
+        documents = [document for document in self.documents if document.name in document_ids]
         chunked_documents = self._chunk_documents(documents)
 
         for i, embedding_model in enumerate(self.embedding_models):
@@ -219,7 +220,7 @@ class ModelsPreSelector:
     @staticmethod
     def _create_vector_store(
         embedding_model: BaseEmbeddingModel,
-        chunked_documents: list[Document],
+        chunked_documents: list[AI4RAGChunk],
         collection_name: str,
     ) -> BaseVectorStore:
         """
@@ -230,8 +231,8 @@ class ModelsPreSelector:
         embedding_model : BaseEmbeddingModel
             Embedding model used for collection creation.
 
-        chunked_documents : list[Document]
-            Chunked documents fot the embedding process.
+        chunked_documents : list[AI4RAGChunk]
+            Chunked documents for the embedding process.
 
         collection_name : str
             Name of the collection in the chroma vector database.
@@ -417,18 +418,18 @@ class ModelsPreSelector:
 
         return evaluation_result
 
-    def _chunk_documents(self, documents: list[Document]) -> list[Document]:
+    def _chunk_documents(self, documents: list[DoclingDocument]) -> list[AI4RAGChunk]:
         """
         Chunk provided documents.
 
         Parameters
         ----------
-        documents : list[Document]
-            List of LangChain.Document instance that will be chunked.
+        documents : list[DoclingDocument]
+            Docling documents to chunk.
 
         Returns
         -------
-        list[Document]
+        list[AI4RAGChunk]
             Chunked documents.
         """
         logger.debug("MPS: Chunking documents...")

--- a/ai4rag/core/experiment/utils.py
+++ b/ai4rag/core/experiment/utils.py
@@ -44,7 +44,7 @@ class RAGParamsType(TypedDict):
     foundation_model: BaseFoundationModel
     chunk_size: int
     chunk_overlap: int | float
-    chunking_method: Literal["recursive"]
+    chunking_method: Literal["recursive", "hybrid"]
     window_size: int
     number_of_chunks: int
     retrieval_method: Literal["simple", "window"]
@@ -59,7 +59,7 @@ class RAGChunkingParamsType(TypedDict):
 
     chunk_size: int
     chunk_overlap: int | float
-    chunking_method: Literal["recursive"]
+    chunking_method: Literal["recursive", "hybrid"]
 
 
 class RAGRetrievalParamsType(TypedDict):
@@ -173,8 +173,8 @@ def build_evaluation_data(
         contexts = []
         context_ids = []
         for el in inference_response[idx]["reference_documents"]:
-            contexts.append(getattr(el, "page_content", None))
-            context_ids.append(getattr(el, "metadata", {}).get("document_id"))
+            contexts.append(el.text)
+            context_ids.append(el.metadata.get("document_id"))
 
         evaluation_data.append(
             EvaluationData(

--- a/ai4rag/rag/chunking/__init__.py
+++ b/ai4rag/rag/chunking/__init__.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from .base_chunker import BaseChunker
+from .chunk import AI4RAGChunk
+from .docling_chunker import DoclingChunker
 from .langchain_chunker import LangChainChunker
 
-__all__ = ["BaseChunker", "LangChainChunker"]
+__all__ = ["AI4RAGChunk", "BaseChunker", "DoclingChunker", "LangChainChunker"]

--- a/ai4rag/rag/chunking/base_chunker.py
+++ b/ai4rag/rag/chunking/base_chunker.py
@@ -3,36 +3,41 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Sequence, TypeVar
+from typing import Any, Sequence
+
+from docling_core.types.doc import DoclingDocument
+
+from .chunk import AI4RAGChunk
 
 __all__ = [
     "BaseChunker",
 ]
 
-ChunkT = TypeVar("ChunkT")
 
-
-class BaseChunker(ABC, Generic[ChunkT]):
+class BaseChunker(ABC):
     """
     Responsible for handling splitting document operations
     in the RAG application.
+
+    All chunkers accept ``DoclingDocument`` as input and
+    produce ``AI4RAGChunk`` as output.
     """
 
     @abstractmethod
-    def split_documents(self, documents: Sequence[ChunkT]) -> list[ChunkT]:
+    def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
         """
         Split series of documents into smaller parts based on
         the provided chunker settings.
 
         Parameters
         ----------
-        documents : Sequence[ChunkType]
-            Sequence of elements that contain context in a text format.
+        documents : Sequence[DoclingDocument]
+            Parsed docling documents to chunk.
 
         Returns
         -------
-        list[ChunkType]
-            List of documents split into smaller ones, having less content.
+        list[AI4RAGChunk]
+            List of chunks produced from the input documents.
         """
 
     @abstractmethod

--- a/ai4rag/rag/chunking/chunk.py
+++ b/ai4rag/rag/chunking/chunk.py
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = ["AI4RAGChunk"]
+
+
+@dataclass(frozen=True)
+class AI4RAGChunk:
+    """
+    Framework-agnostic chunk representation used across the ai4rag pipeline.
+
+    Parameters
+    ----------
+    text : str
+        The textual content of the chunk.
+
+    metadata : dict[str, Any]
+        Chunk metadata. Expected keys include ``document_id`` and
+        ``sequence_number``; additional keys (headings, provenance)
+        are chunker-dependent.
+    """
+
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/ai4rag/rag/chunking/docling_chunker.py
+++ b/ai4rag/rag/chunking/docling_chunker.py
@@ -2,6 +2,7 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+import hashlib
 from typing import Any, Sequence
 
 import tiktoken
@@ -85,7 +86,7 @@ class DoclingChunker(BaseChunker):
         all_chunks: list[AI4RAGChunk] = []
 
         for doc in documents:
-            doc_id = doc.name or str(hash(str(doc)))
+            doc_id = doc.name or hashlib.sha256(str(doc).encode()).hexdigest()[:16]
             seq_num = 0
 
             for chunk in self._chunker.chunk(doc):

--- a/ai4rag/rag/chunking/docling_chunker.py
+++ b/ai4rag/rag/chunking/docling_chunker.py
@@ -91,11 +91,7 @@ class DoclingChunker(BaseChunker):
             for chunk in self._chunker.chunk(doc):
                 seq_num += 1
 
-                text = (
-                    self._chunker.contextualize(chunk)
-                    if self.contextualize
-                    else chunk.text
-                )
+                text = self._chunker.contextualize(chunk) if self.contextualize else chunk.text
 
                 metadata: dict[str, Any] = {
                     "document_id": doc_id,

--- a/ai4rag/rag/chunking/docling_chunker.py
+++ b/ai4rag/rag/chunking/docling_chunker.py
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+from typing import Any, Sequence
+
+import tiktoken
+from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
+from docling_core.transforms.chunker.tokenizer.base import BaseTokenizer
+from docling_core.transforms.chunker.tokenizer.openai import OpenAITokenizer
+from docling_core.types.doc import DoclingDocument
+
+from .base_chunker import BaseChunker
+from .chunk import AI4RAGChunk
+
+__all__ = ["DoclingChunker"]
+
+_DEFAULT_TIKTOKEN_MODEL = "text-embedding-3-small"
+
+
+class DoclingChunker(BaseChunker):
+    """
+    Structure-aware, token-aware chunker wrapping docling's ``HybridChunker``.
+
+    Operates directly on ``DoclingDocument`` objects, preserving document
+    hierarchy (headings, tables, figures) during chunking. Chunks are
+    bounded by a token limit aligned to the embedding model.
+
+    Parameters
+    ----------
+    max_tokens : int, default=8192
+        Maximum number of tokens per chunk.
+
+    contextualize : bool, default=True
+        When ``True``, each chunk's text is enriched with its heading
+        hierarchy via ``HybridChunker.contextualize``. This improves
+        embedding quality at the cost of increased token usage.
+
+    tokenizer : BaseTokenizer | None, default=None
+        Tokenizer for token counting and split-point decisions.
+        When ``None``, defaults to OpenAI tiktoken (``cl100k_base``,
+        zero model downloads).
+
+    merge_peers : bool, default=True
+        Merge adjacent undersized chunks that share the same heading
+        and caption context.
+    """
+
+    def __init__(
+        self,
+        max_tokens: int = 8192,
+        contextualize: bool = True,
+        tokenizer: BaseTokenizer | None = None,
+        merge_peers: bool = True,
+    ) -> None:
+        self.max_tokens = max_tokens
+        self.contextualize = contextualize
+        self.merge_peers = merge_peers
+
+        if tokenizer is None:
+            encoding = tiktoken.encoding_for_model(_DEFAULT_TIKTOKEN_MODEL)
+            tokenizer = OpenAITokenizer(tokenizer=encoding, max_tokens=max_tokens)
+
+        self._tokenizer = tokenizer
+        self._chunker = HybridChunker(
+            tokenizer=tokenizer,
+            merge_peers=merge_peers,
+        )
+
+    def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
+        """
+        Split docling documents into token-bounded chunks.
+
+        Parameters
+        ----------
+        documents : Sequence[DoclingDocument]
+            Parsed documents to chunk.
+
+        Returns
+        -------
+        list[AI4RAGChunk]
+            Chunks with ``document_id``, ``sequence_number``, and
+            optional heading/provenance metadata.
+        """
+        all_chunks: list[AI4RAGChunk] = []
+
+        for doc in documents:
+            doc_id = doc.name or str(hash(str(doc)))
+            seq_num = 0
+
+            for chunk in self._chunker.chunk(doc):
+                seq_num += 1
+
+                text = (
+                    self._chunker.contextualize(chunk)
+                    if self.contextualize
+                    else chunk.text
+                )
+
+                metadata: dict[str, Any] = {
+                    "document_id": doc_id,
+                    "sequence_number": seq_num,
+                }
+
+                if chunk.meta.headings:
+                    metadata["headings"] = chunk.meta.headings
+
+                all_chunks.append(AI4RAGChunk(text=text, metadata=metadata))
+
+        return all_chunks
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return dictionary that can be used to recreate an instance."""
+        return {
+            "max_tokens": self.max_tokens,
+            "contextualize": self.contextualize,
+            "merge_peers": self.merge_peers,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "DoclingChunker":
+        """Create an instance from the dictionary."""
+        return cls(**d)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, DoclingChunker):
+            return self.to_dict() == other.to_dict()
+        return NotImplemented

--- a/ai4rag/rag/chunking/langchain_chunker.py
+++ b/ai4rag/rag/chunking/langchain_chunker.py
@@ -2,6 +2,7 @@
 # Copyright IBM Corp. 2025-2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+import hashlib
 from typing import Any, Iterable, Literal, Sequence
 
 import tiktoken
@@ -167,7 +168,7 @@ class LangChainChunker(BaseChunker):
         return [
             Document(
                 page_content=doc.export_to_markdown(),
-                metadata={"document_id": doc.name or str(hash(str(doc)))},
+                metadata={"document_id": doc.name or hashlib.sha256(str(doc).encode()).hexdigest()[:16]},
             )
             for doc in documents
         ]

--- a/ai4rag/rag/chunking/langchain_chunker.py
+++ b/ai4rag/rag/chunking/langchain_chunker.py
@@ -4,19 +4,27 @@
 # -----------------------------------------------------------------------------
 from typing import Any, Iterable, Literal, Sequence
 
+import tiktoken
+from docling_core.types.doc import DoclingDocument
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter, TextSplitter
 
 from .base_chunker import BaseChunker
+from .chunk import AI4RAGChunk
 
 __all__ = [
     "LangChainChunker",
 ]
 
+_DEFAULT_TIKTOKEN_MODEL = "text-embedding-3-small"
 
-class LangChainChunker(BaseChunker[Document]):
+
+class LangChainChunker(BaseChunker):
     """
-    Wrapper for LangChain TextSplitter.
+    Wrapper for LangChain TextSplitter operating on ``DoclingDocument`` input.
+
+    Converts each ``DoclingDocument`` to markdown internally, applies
+    token-based splitting via tiktoken, and returns ``AI4RAGChunk`` objects.
 
     Parameters
     ----------
@@ -24,10 +32,10 @@ class LangChainChunker(BaseChunker[Document]):
         Describes the type of TextSplitter as the main instance performing the chunking.
 
     chunk_size : int, default=2048
-        Maximum size of a single chunk that is returned.
+        Maximum number of tokens per chunk.
 
     chunk_overlap : int, default=256
-        Overlap in characters between chunks.
+        Overlap in tokens between chunks.
 
     Other Parameters
     ----------------
@@ -48,6 +56,7 @@ class LangChainChunker(BaseChunker[Document]):
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
         self.separators = kwargs.pop("separators", ["\n\n", r"(?<=\. )", "\n", " ", ""])
+        self._encoding = tiktoken.encoding_for_model(_DEFAULT_TIKTOKEN_MODEL)
         self._text_splitter = self._get_text_splitter()
 
     def __eq__(self, other: object) -> bool:
@@ -65,7 +74,7 @@ class LangChainChunker(BaseChunker[Document]):
                     chunk_size=self.chunk_size,
                     chunk_overlap=self.chunk_overlap,
                     separators=self.separators,
-                    length_function=len,
+                    length_function=lambda text: len(self._encoding.encode(text)),
                     add_start_index=True,
                 )
 
@@ -139,23 +148,49 @@ class LangChainChunker(BaseChunker[Document]):
 
         return sorted_chunks
 
-    def split_documents(self, documents: Sequence[Document]) -> list[Document]:
+    @staticmethod
+    def _docling_to_langchain(documents: Sequence[DoclingDocument]) -> list[Document]:
         """
-        Split series of documents into smaller chunks based on the provided
-        chunker settings. Each chunk has metadata that includes the document_id,
-        sequence_number, and start_index.
+        Convert ``DoclingDocument`` objects to langchain ``Document`` objects
+        by exporting each to markdown.
 
         Parameters
         ----------
-        documents : Sequence[Document]
-            Sequence of elements that contain context in a text format.
+        documents : Sequence[DoclingDocument]
+            Parsed docling documents.
 
         Returns
         -------
         list[Document]
-            List of documents split into smaller chunks.
+            Langchain documents with markdown content and ``document_id`` metadata.
         """
-        self._set_document_id_in_metadata_if_missing(documents)
-        chunks = self._text_splitter.split_documents(documents)
+        return [
+            Document(
+                page_content=doc.export_to_markdown(),
+                metadata={"document_id": doc.name or str(hash(str(doc)))},
+            )
+            for doc in documents
+        ]
+
+    def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
+        """
+        Split docling documents into smaller chunks using token-based splitting.
+
+        Each ``DoclingDocument`` is first exported to markdown, then split using
+        the configured ``TextSplitter``. Results are returned as ``AI4RAGChunk``.
+
+        Parameters
+        ----------
+        documents : Sequence[DoclingDocument]
+            Parsed docling documents to chunk.
+
+        Returns
+        -------
+        list[AI4RAGChunk]
+            Chunks with ``document_id``, ``sequence_number``, and ``start_index`` metadata.
+        """
+        lc_docs = self._docling_to_langchain(documents)
+        self._set_document_id_in_metadata_if_missing(lc_docs)
+        chunks = self._text_splitter.split_documents(lc_docs)
         sorted_chunks = self._set_sequence_number_in_metadata(chunks)
-        return sorted_chunks
+        return [AI4RAGChunk(text=chunk.page_content, metadata=chunk.metadata) for chunk in sorted_chunks]

--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -141,8 +141,8 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
             Embeddings made from the list of texts.
         """
         resp = []
-        for idx in range(0, len(texts), 2048):
-            resp.extend(self._embed_text(text_input=texts[idx : idx + 2048]))
+        for idx in range(0, len(texts), 512):
+            resp.extend(self._embed_text(text_input=texts[idx : idx + 512]))
 
         return resp
 

--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -28,6 +28,8 @@ class OGXEmbeddingParams:
 class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
     """Creates embeddings for OGX client."""
 
+    _BATCH_SIZE = 1024
+
     def __init__(self, client: OgxClient, model_id: str, params: dict | OGXEmbeddingParams | None = None):
         super().__init__(client=client, model_id=model_id, params=params)
 
@@ -141,8 +143,8 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
             Embeddings made from the list of texts.
         """
         resp = []
-        for idx in range(0, len(texts), 512):
-            resp.extend(self._embed_text(text_input=texts[idx : idx + 512]))
+        for idx in range(0, len(texts), self._BATCH_SIZE):
+            resp.extend(self._embed_text(text_input=texts[idx : idx + self._BATCH_SIZE]))
 
         return resp
 

--- a/ai4rag/rag/retrieval/retriever.py
+++ b/ai4rag/rag/retrieval/retriever.py
@@ -4,6 +4,7 @@
 # -----------------------------------------------------------------------------
 from typing import Literal
 
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.vector_store.base_vector_store import BaseVectorStore
 
 
@@ -52,18 +53,18 @@ class Retriever:
         self.ranker_k = ranker_k
         self.ranker_alpha = ranker_alpha
 
-    def retrieve(self, query: str, **kwargs) -> list[dict]:
-        """Retrieve relevant documents from vector store.
+    def retrieve(self, query: str, **kwargs) -> list[AI4RAGChunk]:
+        """Retrieve relevant chunks from vector store.
 
         Parameters
         ----------
         query : str
-            question for which documents should be retrieved.
+            Question for which chunks should be retrieved.
 
         Returns
         -------
-        list[Document]
-            list of documents with their metadata corresponding to the query.
+        list[AI4RAGChunk]
+            Chunks with their metadata corresponding to the query.
         """
         _number_of_chunks = kwargs.get("number_of_chunks", self.number_of_chunks)
 

--- a/ai4rag/rag/template/simple_rag_template.py
+++ b/ai4rag/rag/template/simple_rag_template.py
@@ -5,11 +5,11 @@
 
 from typing import Any
 
-from langchain_core.documents import Document
+from docling_core.types.doc import DoclingDocument
 
-from ai4rag.rag.chunking.langchain_chunker import LangChainChunker
+from ai4rag.rag.chunking.base_chunker import BaseChunker
 from ai4rag.rag.retrieval.retriever import Retriever
-from ai4rag.rag.vector_store.ogx import OGXVectorStore
+from ai4rag.rag.vector_store.base_vector_store import BaseVectorStore
 
 from ..embedding.base_model import BaseEmbeddingModel
 from ..foundation_models.base_model import BaseFoundationModel
@@ -19,10 +19,7 @@ from .base_template import BaseRAGTemplate, RAGTemplateError
 class SimpleRAG(BaseRAGTemplate):
     """
     RAG template using OGX components for embedding, vector store,
-    retrieval, and foundation model, with LangChain for document chunking.
-
-    This template implements the BaseRAGTemplate using OGX services
-    for all major RAG components while utilizing LangChain's chunking capabilities.
+    retrieval, and foundation model.
 
     Parameters
     ----------
@@ -32,23 +29,23 @@ class SimpleRAG(BaseRAGTemplate):
     retriever : Retriever
         Initialized retriever for document retrieval.
 
-    chunker : LangChainChunker | None, default=None
-        Initialized LangChain chunker for document splitting.
+    chunker : BaseChunker | None, default=None
+        Initialized chunker for document splitting.
 
-    embedding_model : OGXEmbeddingModel | None, default=None
-        Initialized OGX embedding model.
+    embedding_model : BaseEmbeddingModel | None, default=None
+        Initialized embedding model.
 
-    vector_store : OGXVectorStore | None, default=None
-        Initialized OGX vector store.
+    vector_store : BaseVectorStore | None, default=None
+        Initialized vector store.
     """
 
     def __init__(
         self,
         foundation_model: BaseFoundationModel,
         retriever: Retriever,
-        chunker: LangChainChunker | None = None,
+        chunker: BaseChunker | None = None,
         embedding_model: BaseEmbeddingModel | None = None,
-        vector_store: OGXVectorStore | None = None,
+        vector_store: BaseVectorStore | None = None,
     ):
         super().__init__(
             foundation_model=foundation_model,
@@ -59,17 +56,16 @@ class SimpleRAG(BaseRAGTemplate):
 
         self.chunker = chunker
 
-    def build_index(self, documents: list[Document], **kwargs) -> None:
+    def build_index(self, documents: list[DoclingDocument], **kwargs) -> None:
         """
         Index documents into the vector store.
 
-        This method chunks the documents using the LangChain chunker and
-        adds them to the vector store.
+        This method chunks the documents and adds them to the vector store.
 
         Parameters
         ----------
-        documents : list[Document]
-            List of LangChain Document objects to index.
+        documents : list[DoclingDocument]
+            Parsed docling documents to index.
         """
         if self.chunker is None and self.embedding_model is None and self.vector_store is None:
             raise RAGTemplateError()
@@ -101,8 +97,8 @@ class SimpleRAG(BaseRAGTemplate):
 
         context = "\n".join(
             [
-                self.foundation_model.context_template_text.format(document=getattr(doc, "page_content", ""))
-                for doc in reference_documents
+                self.foundation_model.context_template_text.format(document=chunk.text)
+                for chunk in reference_documents
             ]
         )
 

--- a/ai4rag/rag/template/simple_rag_template.py
+++ b/ai4rag/rag/template/simple_rag_template.py
@@ -96,10 +96,7 @@ class SimpleRAG(BaseRAGTemplate):
         reference_documents = self.retriever.retrieve(question, **kwargs)
 
         context = "\n".join(
-            [
-                self.foundation_model.context_template_text.format(document=chunk.text)
-                for chunk in reference_documents
-            ]
+            [self.foundation_model.context_template_text.format(document=chunk.text) for chunk in reference_documents]
         )
 
         user_message = self.foundation_model.user_message_text.format(

--- a/ai4rag/rag/vector_store/base_vector_store.py
+++ b/ai4rag/rag/vector_store/base_vector_store.py
@@ -5,8 +5,7 @@
 from abc import ABC, abstractmethod
 from typing import Sequence
 
-from langchain_core.documents import Document
-
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
 
 __all__ = ["BaseVectorStore"]
@@ -26,7 +25,7 @@ class BaseVectorStore(ABC):
         self.reuse_collection_name = reuse_collection_name
 
     @abstractmethod
-    def search(self, query: str, k: int, **kwargs) -> list[dict]:
+    def search(self, query: str, k: int, **kwargs) -> list[AI4RAGChunk]:
         """
         Search for the chunks relevant to the query.
         The method used will be simple similarity search.
@@ -41,19 +40,19 @@ class BaseVectorStore(ABC):
 
         Returns
         -------
-        list[dict]
-            List of chunks as dicts with content and metadata.
+        list[AI4RAGChunk]
+            List of chunks with content and metadata.
         """
 
     @abstractmethod
-    def add_documents(self, documents: Sequence[Document]) -> None:
+    def add_documents(self, documents: Sequence[AI4RAGChunk]) -> None:
         """
         Add documents to the collection.
 
         Parameters
         ----------
-        documents : Sequence[Document]
-            Documents to add to the collection.
+        documents : Sequence[AI4RAGChunk]
+            Chunks to add to the collection.
         """
 
     @property

--- a/ai4rag/rag/vector_store/chroma.py
+++ b/ai4rag/rag/vector_store/chroma.py
@@ -10,6 +10,7 @@ from langchain_chroma import Chroma
 from langchain_core.documents import Document
 
 from ai4rag import logger
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 
 from ..embedding.base_model import BaseEmbeddingModel
 from .base_vector_store import BaseVectorStore
@@ -19,6 +20,9 @@ from .utils import merge_window_into_a_document
 class ChromaVectorStore(BaseVectorStore):
     """
     Class representing single index in the chroma vector database.
+
+    Internally converts between ``AI4RAGChunk`` (pipeline type) and
+    langchain ``Document`` (required by ``langchain_chroma.Chroma``).
 
     Parameters
     ----------
@@ -122,72 +126,42 @@ class ChromaVectorStore(BaseVectorStore):
         return len(self._vector_store.get()["ids"])
 
     @staticmethod
-    def _as_langchain_documents(content: list) -> list[Document]:
-        """Creates a LangChain ``Document`` list from a list of potentially unstructured data.
+    def _to_langchain_documents(chunks: list[AI4RAGChunk]) -> list[Document]:
+        """Convert ``AI4RAGChunk`` objects to langchain ``Document`` for Chroma storage.
 
         Parameters
         ----------
-        content : list
-            Unstructured data to be parsed.
+        chunks : list[AI4RAGChunk]
+            Pipeline chunks to convert.
 
         Returns
         -------
         list[Document]
-            List of `Document` instances.
+            Langchain documents suitable for ``langchain_chroma.Chroma``.
         """
-        result = []
-        for doc in content:
-            if isinstance(doc, str):
-                result.append(Document(page_content=doc))
-            elif isinstance(doc, dict):
-                content_str: str | None = doc.get("content", None)
-                metadata = doc.get("metadata", {})
+        return [Document(page_content=chunk.text, metadata=chunk.metadata) for chunk in chunks]
 
-                if content_str:
-                    if isinstance(metadata, dict):
-                        result.append(Document(page_content=content_str, metadata=metadata))
-                    else:
-                        logger.warning(
-                            "Document: %s is incorrect. Metadata needs to be given with 'metadata' "
-                            "attribute and it needs to be a serializable dict. Skipping.",
-                            doc,
-                        )
-                        continue
-                else:
-                    logger.warning("Document: %s is incorrect. Field 'content' is required.", doc)
-                    continue
-            else:
-                try:
-                    result.append(Document(page_content=doc.page_content, metadata=doc.metadata))
-                except AttributeError:
-                    logger.warning(
-                        "Document: %s is not a dict, nor string, nor LangChain Document-like object. Skipping.", doc
-                    )
+    @staticmethod
+    def _from_langchain_document(doc: Document) -> AI4RAGChunk:
+        """Convert a single langchain ``Document`` back to ``AI4RAGChunk``."""
+        return AI4RAGChunk(text=doc.page_content, metadata=doc.metadata)
 
-        return result
-
-    def _process_documents(self, content: list) -> tuple[list[str], list[Document]]:
+    def _process_documents(self, chunks: list[AI4RAGChunk]) -> tuple[list[str], list[Document]]:
         """
-        Processes arbitrary list of data to produce two lists:
-        one with unique IDs, and one with LangChain documents.
-
-        Handles duplicate documents.
+        Convert chunks to langchain documents and deduplicate by content hash.
 
         Parameters
         ----------
-        content : list
-            Arbitrary data.
+        chunks : list[AI4RAGChunk]
+            Pipeline chunks.
 
         Returns
         -------
         tuple[list[str], list[Document]]
-            Lists with IDs and docs
+            Lists with unique IDs and deduplicated langchain documents.
         """
-        docs = self._as_langchain_documents(content)
+        docs = self._to_langchain_documents(chunks)
         if docs:
-            # Take only unique ID document. Get two lists, one with ids, one with documents
-            # For some documents, not all chars can be encoded properly.
-            # In such cases, replace invalid chars by question marks, i.e. setting errors="replace"
             return tuple(
                 map(
                     list,
@@ -196,19 +170,19 @@ class ChromaVectorStore(BaseVectorStore):
             )
         return [], []
 
-    def add_documents(self, documents: list, **kwargs: Any) -> list[str]:
+    def add_documents(self, documents: list[AI4RAGChunk], **kwargs: Any) -> list[str]:
         """
-        Embed and add documents to the vector store.
+        Embed and add chunks to the vector store.
 
         Parameters
         ----------
-        documents : list
-            Documents to be embedded and added to the vector store.
+        documents : list[AI4RAGChunk]
+            Chunks to be embedded and added to the vector store.
 
         Returns
         -------
         list[str]
-            List of documents IDs.
+            List of document IDs.
         """
         max_batch_size = kwargs.get("max_batch_size", 2048)
 
@@ -272,7 +246,7 @@ class ChromaVectorStore(BaseVectorStore):
         k: int = 5,
         include_scores: bool = False,
         **kwargs: Any,
-    ) -> list[Document] | list[tuple[Document, float]]:
+    ) -> list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]:
         """Searches for documents most similar to the query.
 
         The method is designed as a wrapper for respective LangChain VectorStores' similarity search methods.
@@ -292,16 +266,16 @@ class ChromaVectorStore(BaseVectorStore):
 
         Returns
         -------
-        list[Document] | list[tuple[Document, float]]
-            Found documents with or without scores.
+        list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]
+            Found chunks with or without scores.
         """
         filtered_kwargs = {k_: v for k_, v in kwargs.items() if k_ not in self._HYBRID_KWARGS}
         if include_scores:
-            result = self._vector_store.similarity_search_with_score(query, k=k, **filtered_kwargs)
-        else:
-            result = self._vector_store.similarity_search(query, k=k, **filtered_kwargs)
+            lc_results = self._vector_store.similarity_search_with_score(query, k=k, **filtered_kwargs)
+            return [(self._from_langchain_document(doc), score) for doc, score in lc_results]
 
-        return result
+        lc_results = self._vector_store.similarity_search(query, k=k, **filtered_kwargs)
+        return [self._from_langchain_document(doc) for doc in lc_results]
 
     def window_search(
         self,
@@ -310,7 +284,7 @@ class ChromaVectorStore(BaseVectorStore):
         include_scores: bool = False,
         window_size: int = 2,
         **kwargs: Any,
-    ) -> list:
+    ) -> list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]:
         """
         Searches for documents most similar to the query and extend a document (a chunk)
         to its adjacent chunks (if they exist) from the same origin document.
@@ -335,58 +309,58 @@ class ChromaVectorStore(BaseVectorStore):
 
         Returns
         -------
-        list
-            Found documents with or without scores.
+        list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]
+            Found chunks with or without scores.
         """
-        documents = self.search(query, k, include_scores, **kwargs)
+        results = self.search(query, k, include_scores, **kwargs)
         if window_size <= 0:
-            return documents
+            return results
 
         if not include_scores:
-            documents = cast(list[Document], documents)
-            return [self._window_extend_and_merge(document, window_size) for document in documents]
+            chunks = cast(list[AI4RAGChunk], results)
+            return [self._window_extend_and_merge(chunk, window_size) for chunk in chunks]
 
-        documents_and_scores = cast(list[tuple[Document, float]], documents)
-        documents = [t[0] for t in documents_and_scores]
-        scores = [t[1] for t in documents_and_scores]
-        extended_documents = [self._window_extend_and_merge(document, window_size) for document in documents]
-        return list(zip(extended_documents, scores))
+        chunks_and_scores = cast(list[tuple[AI4RAGChunk, float]], results)
+        chunks = [t[0] for t in chunks_and_scores]
+        scores = [t[1] for t in chunks_and_scores]
+        extended = [self._window_extend_and_merge(chunk, window_size) for chunk in chunks]
+        return list(zip(extended, scores))
 
     def delete(self, ids: list[str], **kwargs: Any) -> None:
-        """Delete by vector ID or other criteria. Sor more details see LangChain documentation
+        """Delete by vector ID or other criteria. For more details see LangChain documentation
         https://python.langchain.com/api_reference/core/vectorstores/langchain_core.vectorstores.base.VectorStore.html#langchain_core.vectorstores.base.VectorStore
         """
         self._vector_store.delete(ids, **kwargs)
 
-    def _window_extend_and_merge(self, document: Document, window_size: int) -> Document:
+    def _window_extend_and_merge(self, chunk: AI4RAGChunk, window_size: int) -> AI4RAGChunk:
         """
-        Extends a document (a chunk) to its adjacent chunks (if they exist) from the same origin document.
-        Then merges the adjacent chunks into one chunk while keeping their order,
+        Extends a chunk to its adjacent chunks (if they exist) from the same origin document.
+        Then merges the adjacent chunks into one while keeping their order,
         and merges intersecting text between them (if it exists).
-        This requires chunks to have "document_id" and "sequence_number" in their metadata.
 
         Parameters
         ----------
-        document : Document
-            Chunk / document to be extended to its window and merged.
+        chunk : AI4RAGChunk
+            Chunk to be extended to its window and merged.
 
         window_size : int
-            Number of adjacent chunks to retrieve before and after the center, according to the sequence_number.
+            Number of adjacent chunks to retrieve before and after the center.
 
         Returns
         -------
-        Document
-            Chunk / document after extending and merging.
+        AI4RAGChunk
+            Chunk after extending and merging.
         """
-        if "document_id" not in document.metadata:
-            raise ValueError('document must have "document_id" in its metadata')
-        if "sequence_number" not in document.metadata:
-            raise ValueError('document must have "sequence_number" in its metadata')
-        doc_id = document.metadata["document_id"]
-        seq_num = document.metadata["sequence_number"]
+        if "document_id" not in chunk.metadata:
+            raise ValueError('chunk must have "document_id" in its metadata')
+        if "sequence_number" not in chunk.metadata:
+            raise ValueError('chunk must have "sequence_number" in its metadata')
+        doc_id = chunk.metadata["document_id"]
+        seq_num = chunk.metadata["sequence_number"]
         seq_nums_window = [seq_num + i for i in range(-window_size, window_size + 1, 1)]
 
         window_documents = self._get_window_documents(doc_id, seq_nums_window)
-
         window_documents.sort(key=lambda x: x.metadata["sequence_number"])
-        return merge_window_into_a_document(window_documents)
+
+        merged_lc_doc = merge_window_into_a_document(window_documents)
+        return self._from_langchain_document(merged_lc_doc)

--- a/ai4rag/rag/vector_store/chroma.py
+++ b/ai4rag/rag/vector_store/chroma.py
@@ -9,7 +9,6 @@ from typing import Any, cast
 from langchain_chroma import Chroma
 from langchain_core.documents import Document
 
-from ai4rag import logger
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
 
 from ..embedding.base_model import BaseEmbeddingModel

--- a/ai4rag/rag/vector_store/ogx.py
+++ b/ai4rag/rag/vector_store/ogx.py
@@ -2,11 +2,11 @@
 # Copyright IBM Corp. 2025-2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from langchain_core.documents import Document
 from ogx_client import OgxClient
 from ogx_client.types.vector_store import VectorStore
 
 from ai4rag import logger
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
 from ai4rag.rag.vector_store.base_vector_store import BaseVectorStore
 
@@ -147,7 +147,7 @@ class OGXVectorStore(BaseVectorStore):
         ranker_k: int | None = None,
         ranker_alpha: float | None = None,
         **kwargs,
-    ) -> list[Document] | list[tuple[Document, float]]:
+    ) -> list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]:
         """
         Search for the chunks relevant to the query.
 
@@ -177,8 +177,8 @@ class OGXVectorStore(BaseVectorStore):
 
         Returns
         -------
-        list[Document] | list[tuple[Document, float]]
-            List of chunks as Document instances with or without scores, depending on the input.
+        list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]
+            List of chunks with or without scores, depending on the input.
         """
         self._validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha)
         params = {
@@ -199,20 +199,20 @@ class OGXVectorStore(BaseVectorStore):
 
         if include_scores:
             return [
-                (Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
+                (AI4RAGChunk(text=chunk.content, metadata=chunk.chunk_metadata.to_dict()), score)
                 for chunk, score in zip(resp.chunks, resp.scores)
             ]
 
-        return [Document(page_content=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
+        return [AI4RAGChunk(text=chunk.content, metadata=chunk.chunk_metadata.to_dict()) for chunk in resp.chunks]
 
-    def add_documents(self, documents: list[Document], **kwargs) -> None:
+    def add_documents(self, documents: list[AI4RAGChunk], **kwargs) -> None:
         """
         Add documents to the collection.
 
         Parameters
         ----------
-        documents : Sequence[Document]
-            Documents to add to the collection.
+        documents : list[AI4RAGChunk]
+            Chunks to add to the collection.
         """
         batch_size = kwargs.get("batch_size", 2048)
 
@@ -224,19 +224,19 @@ class OGXVectorStore(BaseVectorStore):
 
         chunks = [
             {
-                "content": doc.page_content,
+                "content": doc.text,
                 "chunk_metadata": {
                     "document_id": doc.metadata["document_id"],
                 },
                 "metadata": doc.metadata,
-                "chunk_id": str(hash(doc.page_content)),
+                "chunk_id": str(hash(doc.text)),
                 "embedding_model": self.embedding_model.model_id,
                 "embedding_dimension": embedding_dimension,
             }
             for doc in documents
         ]
 
-        embeddings = self.embedding_model.embed_documents([doc.page_content for doc in documents])
+        embeddings = self.embedding_model.embed_documents([doc.text for doc in documents])
 
         seen_ids = set()
         unique_chunks = []

--- a/ai4rag/search_space/src/default_search_space.py
+++ b/ai4rag/search_space/src/default_search_space.py
@@ -10,9 +10,9 @@ __all__ = [
 ]
 
 # Note: "" and 0 are sentinels for unused params; ranker_alpha uses 1 as sentinel (0 means 100% sparse)
-_default_chunking_methods = ("recursive",)
-_default_chunk_sizes = (1024, 2048)
-_default_chunk_overlaps = (128, 256)
+_default_chunking_methods = ("recursive", "hybrid")
+_default_chunk_sizes = (512, 1024, 2048)
+_default_chunk_overlaps = (0, 128, 256)
 _default_retrieval_methods = ("simple",)
 _default_window_sizes = (0,)
 _default_chroma_retrieval_methods = ("simple", "window")

--- a/ai4rag/search_space/src/search_space.py
+++ b/ai4rag/search_space/src/search_space.py
@@ -57,17 +57,13 @@ def _rule_adjust_window_to_retrieval_method(combination: dict) -> bool:
     return True
 
 
-def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
-    """Check that estimated token count of a chunk fits the embedding model's context length.
+def _rule_chunk_overlap_for_chunking_method(combination: dict) -> bool:
+    """Enforce chunker-specific overlap constraints.
 
-    The chunk_size is in characters.  We convert to an estimated token count
-    using a conservative ratio of 4.5 characters per token (i.e. we
-    *overestimate* the number of tokens so that borderline cases are pruned
-    rather than silently failing at runtime).
-
-    Note: ``chunk_overlap`` is not included in the estimation because
-    ``RecursiveCharacterTextSplitter`` already keeps chunks within the
-    ``chunk_size`` budget — overlap is not added on top.
+    - ``hybrid`` (DoclingChunker): overlap must be ``0`` — the chunker
+      does not support overlap.
+    - ``recursive`` (LangChainChunker): overlap must be ``> 0`` — splitting
+      without overlap loses context between chunks.
 
     Parameters
     ----------
@@ -77,7 +73,37 @@ def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
     Returns
     -------
     bool
-        Whether the estimated token count fits within the embedding model's context length.
+        Whether the overlap value is valid for the given chunking method.
+    """
+    chunking_method = combination.get(AI4RAGParamNames.CHUNKING_METHOD)
+    chunk_overlap = combination.get(AI4RAGParamNames.CHUNK_OVERLAP)
+
+    if chunking_method is None or chunk_overlap is None:
+        return True
+
+    if chunking_method == "hybrid":
+        return chunk_overlap == 0
+
+    return chunk_overlap > 0
+
+
+def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
+    """Check that chunk token count fits the embedding model's context length.
+
+    Both chunkers (``LangChainChunker`` and ``DoclingChunker``) express
+    ``chunk_size`` in tokens, so the comparison is direct.  A 10 % safety
+    margin is applied to account for tokenizer divergence between the
+    chunker's tiktoken encoder and the embedding model's native tokenizer.
+
+    Parameters
+    ----------
+    combination : dict
+        Single node in the solutions space represented as a dict.
+
+    Returns
+    -------
+    bool
+        Whether the chunk size fits within the embedding model's context length.
     """
     chunk_size = combination.get(AI4RAGParamNames.CHUNK_SIZE)
     embedding_model = combination.get(AI4RAGParamNames.EMBEDDING_MODEL)
@@ -94,10 +120,7 @@ def _rule_chunk_size_within_embedding_context_length(combination: dict) -> bool:
     if context_length is None:
         return True
 
-    chars_per_token = 3.6
-    estimated_tokens = chunk_size / chars_per_token
-
-    return estimated_tokens <= context_length
+    return chunk_size <= context_length * 0.9
 
 
 def _rule_search_mode_ranker_consistency(combination: dict) -> bool:
@@ -330,6 +353,7 @@ class AI4RAGSearchSpace(SearchSpace):
     """
 
     _base_rules = (
+        _rule_chunk_overlap_for_chunking_method,
         _rule_chunk_size_bigger_than_chunk_overlap,
         _rule_adjust_window_to_retrieval_method,
         _rule_chunk_size_within_embedding_context_length,

--- a/ai4rag/utils/constants.py
+++ b/ai4rag/utils/constants.py
@@ -121,9 +121,9 @@ class ChunkingConstraints(metaclass=ConstantMeta):
 
     MIN_CHUNK_SIZE = 128
     MAX_CHUNK_SIZE = 2048
-    MIN_CHUNK_OVERLAP = 64
+    MIN_CHUNK_OVERLAP = 0
     MAX_CHUNK_OVERLAP = 512
-    METHODS = ["recursive", "semantic"]
+    METHODS = ["recursive", "hybrid"]
 
 
 class RetrievalConstraints(metaclass=ConstantMeta):

--- a/dev_utils/file_store.py
+++ b/dev_utils/file_store.py
@@ -179,7 +179,8 @@ class FileStore:
         except Exception as exc:
             raise FileStoreException("Failed to convert files") from exc
 
-        ordered = [cached.get(str(fp)) or next(r for r in results if r.name == fp.name) for fp in filepaths]
+        converted_by_name = {r.name: r for r in results}
+        ordered = [cached.get(str(fp)) or converted_by_name[fp.name] for fp in filepaths]
         return ordered
 
     def _save_markdown(self, filepath: Path, content: str) -> None:

--- a/dev_utils/file_store.py
+++ b/dev_utils/file_store.py
@@ -12,11 +12,14 @@ from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption, settings
-from langchain_core.documents import Document
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.labels import DocItemLabel
 
 logger = logging.getLogger(__name__)
 
 SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".pptx", ".md", ".html", ".txt"}
+
+_DEFAULT_CACHE_DIR = Path(__file__).parent / "local" / "docling_cache"
 
 
 class FileStoreException(Exception):
@@ -26,10 +29,15 @@ class FileStoreException(Exception):
 class FileStore:
     """
     Class used to load locally saved input files.
-    Uses docling library to extract content from documents as markdown.
+    Uses docling library to extract content from documents.
     """
 
-    def __init__(self, path: str | Path | Sequence[str] | Sequence[Path], save_dir: str | Path | None = None):
+    def __init__(
+        self,
+        path: str | Path | Sequence[str] | Sequence[Path],
+        save_dir: str | Path | None = None,
+        cache_dir: str | Path | None = _DEFAULT_CACHE_DIR,
+    ):
         """
         Parameters
         ----------
@@ -37,10 +45,14 @@ class FileStore:
             Path to a single file or a directory of files.
         save_dir : str | Path | None
             Optional directory to save extracted markdown files. If None, no files are saved.
+        cache_dir : str | Path | None
+            Directory for caching DoclingDocument JSON files. Set to None to disable caching.
+            Defaults to ``dev_utils/local/docling_cache``.
         """
         self.path = Path(path)
         self.is_dir = self.path.is_dir()
         self.save_dir = Path(save_dir) if save_dir is not None else None
+        self.cache_dir = Path(cache_dir) if cache_dir is not None else None
         self.files = {}
 
         pipeline_options = PdfPipelineOptions()
@@ -59,58 +71,116 @@ class FileStore:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(path={self.path})"
 
-    def load_as_documents(self) -> list[Document]:
-        """Read files as langchain documents"""
-        contents = self._load_content()
-        return [Document(page_content=content[0], metadata={"document_id": content[1]}) for content in contents]
+    def load_as_documents(self) -> list[DoclingDocument]:
+        """Load files as ``DoclingDocument`` objects preserving document structure.
+
+        Returns
+        -------
+        list[DoclingDocument]
+            Parsed documents with full structural representation.
+        """
+        return self._load_docling_documents()
 
     @lru_cache(maxsize=2)
-    def _load_content(self) -> list[tuple[str, str]]:
-        """Load file(s) from given path"""
+    def _load_docling_documents(self) -> list[DoclingDocument]:
+        """Load files as ``DoclingDocument`` objects."""
         if self.is_dir:
             all_files = [f for f in self.path.iterdir() if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS]
             txt_files = [f for f in all_files if f.suffix.lower() == ".txt"]
             docling_files = [f for f in all_files if f.suffix.lower() != ".txt"]
 
-            contents = [(self._read_txt(f), f.name) for f in txt_files]
-            contents.extend(self._convert_batch(docling_files))
-            return contents
+            docs = [self._txt_to_docling_document(f) for f in txt_files]
+            docs.extend(self._convert_batch_as_docling(docling_files))
+            return docs
 
         if self.path.suffix.lower() == ".txt":
-            return [(self._read_txt(self.path), self.path.name)]
+            return [self._txt_to_docling_document(self.path)]
 
-        return self._convert_batch([self.path])
+        return self._convert_batch_as_docling([self.path])
 
-    def _read_txt(self, filepath: Path) -> str:
-        """Read a plain text file directly."""
+    def _cache_path_for(self, filepath: Path) -> Path | None:
+        """Return the JSON cache path for a source file, or None if caching is disabled."""
+        if self.cache_dir is None:
+            return None
+        return self.cache_dir / f"{filepath.name}.json"
+
+    def _load_from_cache(self, filepath: Path) -> DoclingDocument | None:
+        """Load a ``DoclingDocument`` from the JSON cache if it exists."""
+        cache_path = self._cache_path_for(filepath)
+        if cache_path is None or not cache_path.exists():
+            return None
+
+        try:
+            doc = DoclingDocument.model_validate_json(cache_path.read_bytes())
+            logger.info("Loaded from cache: %s", cache_path.name)
+            return doc
+        except Exception:
+            logger.warning("Corrupted cache file %s — will re-convert", cache_path.name)
+            return None
+
+    def _save_to_cache(self, filepath: Path, doc: DoclingDocument) -> None:
+        """Persist a ``DoclingDocument`` as JSON to the cache directory."""
+        cache_path = self._cache_path_for(filepath)
+        if cache_path is None:
+            return
+
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(doc.model_dump_json(), encoding="utf-8")
+        logger.info("Cached DoclingDocument: %s", cache_path.name)
+
+    @staticmethod
+    def _txt_to_docling_document(filepath: Path) -> DoclingDocument:
+        """Wrap a plain text file into a ``DoclingDocument``."""
         content = filepath.read_text(encoding="utf-8", errors="ignore")
-        self.files[str(filepath)] = content
-        self._save_markdown(filepath, content)
-        return content
+        doc = DoclingDocument(name=filepath.name)
+        doc.add_text(label=DocItemLabel.PARAGRAPH, text=content)
+        return doc
 
-    def _convert_batch(self, filepaths: list[Path]) -> list[tuple[str, str]]:
-        """Convert multiple files to markdown using docling's batch processing."""
+    def _convert_batch_as_docling(self, filepaths: list[Path]) -> list[DoclingDocument]:
+        """Convert multiple files to ``DoclingDocument`` objects.
+
+        Checks the JSON cache first; only files without a cached representation
+        are sent through the docling converter.
+        """
         if not filepaths:
             return []
 
-        results = []
+        cached: dict[str, DoclingDocument] = {}
+        to_convert: list[Path] = []
+
+        for fp in filepaths:
+            doc = self._load_from_cache(fp)
+            if doc is not None:
+                cached[str(fp)] = doc
+            else:
+                to_convert.append(fp)
+
+        if to_convert:
+            logger.info("Converting %d file(s) (cache hit for %d)", len(to_convert), len(cached))
+        elif cached:
+            logger.info("All %d file(s) loaded from cache", len(cached))
+
+        results: list[DoclingDocument] = []
         try:
-            for conv_result in self._converter.convert_all(filepaths, raises_on_error=False):
+            for conv_result in self._converter.convert_all(to_convert, raises_on_error=False):
                 filepath = Path(conv_result.input.file)
                 if conv_result.errors:
                     error_msgs = "; ".join(e.error_message for e in conv_result.errors)
                     raise FileStoreException(f"Failed to convert file: {filepath.name}: {error_msgs}")
 
-                markdown_content = conv_result.document.export_to_markdown()
-                self.files[str(filepath)] = markdown_content
-                self._save_markdown(filepath, markdown_content)
-                results.append((markdown_content, filepath.name))
+                doc = conv_result.document
+                doc.name = filepath.name
+
+                self._save_markdown(filepath, doc.export_to_markdown())
+                self._save_to_cache(filepath, doc)
+                results.append(doc)
         except FileStoreException:
             raise
         except Exception as exc:
-            raise FileStoreException(f"Failed to convert files") from exc
+            raise FileStoreException("Failed to convert files") from exc
 
-        return results
+        ordered = [cached.get(str(fp)) or next(r for r in results if r.name == fp.name) for fp in filepaths]
+        return ordered
 
     def _save_markdown(self, filepath: Path, content: str) -> None:
         """Save extracted content as a markdown file if save_dir is set."""

--- a/dev_utils/run_experiment.py
+++ b/dev_utils/run_experiment.py
@@ -16,7 +16,6 @@ from ai4rag.search_space.src.parameter import Parameter
 from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
 from ai4rag.utils.event_handler import LocalEventHandler
 from dev_utils.file_store import FileStore
-from dev_utils.mocks import MockedEmbeddingModel, MockedFoundationModel
 from dev_utils.utils import read_benchmark_from_json
 
 if __name__ == "__main__":
@@ -25,8 +24,7 @@ if __name__ == "__main__":
 
     load_dotenv(find_dotenv())
 
-    client = OgxClient(base_url="http://localhost:8321")
-    # client = OgxClient()
+    client = OgxClient()
 
     # change to direct to your local documents path
     documents_path = _filepath.parents[1] / "local" / "data" / "rh_summit_2026" / "documents"
@@ -39,7 +37,7 @@ if __name__ == "__main__":
     benchmark_data = read_benchmark_from_json(benchmark_data_path)
 
     # Configure optimizer
-    optimizer_settings = GAMOptSettings(max_evals=1, n_random_nodes=4)
+    optimizer_settings = GAMOptSettings(max_evals=8, n_random_nodes=4)
 
     # Edit configurations of search space
     search_space = AI4RAGSearchSpace(
@@ -48,42 +46,21 @@ if __name__ == "__main__":
             Parameter(
                 name="foundation_model",
                 param_type="C",
-                values=[OGXFoundationModel(model_id="ollama/llama3.2:3b", client=client)],
+                values=[OGXFoundationModel(model_id="vllm-inference-gpu-llama/llama-31-8b-instruct", client=client)],
             ),
             Parameter(
                 name="embedding_model",
                 param_type="C",
                 values=[
                     OGXEmbeddingModel(
-                        model_id="ollama/nomic-embed-text:latest",
+                        model_id="vllm-embedding/bge-m3",
                         client=client,
-                        params={"embedding_dimension": 768, "context_length": 8192},
+                        params={"embedding_dimension": 1024, "context_length": 8192},
                     )
                 ],
             ),
-            Parameter(name="search_mode", values=["hybrid"]),
         ],
     )
-
-    # search_space = AI4RAGSearchSpace(
-    #     vector_store_type="chroma",
-    #     params=[
-    #         Parameter(
-    #             name="foundation_model",
-    #             param_type="C",
-    #             values=[MockedFoundationModel(model_id="mocked_fm_1"), MockedFoundationModel(model_id="mocked_fm_2")],
-    #         ),
-    #         Parameter(
-    #             name="embedding_model",
-    #             param_type="C",
-    #             values=[
-    #                 MockedEmbeddingModel(
-    #                     model_id="ollama/nomic-embed-text:latest", params={"embedding_dimension": 768}
-    #                 ),
-    #             ],
-    #         ),
-    #     ]
-    # )
 
     experiment = AI4RAGExperiment(
         client=client,
@@ -91,10 +68,10 @@ if __name__ == "__main__":
         benchmark_data=benchmark_data,
         search_space=search_space,
         optimizer_settings=optimizer_settings,
-        # event_handler=LocalEventHandler(output_path=_filepath.parent / "local" / "hybrid_test"),
-        event_handler=LocalEventHandler(),
+        event_handler=LocalEventHandler(output_path=_filepath.parent / "local" / "chunkers"),
+        # event_handler=LocalEventHandler(),
         vector_store_type="ogx",
-        ogx_vector_io_provider_id="milvus-lite",
+        ogx_vector_io_provider_id="milvus-remote",
     )
 
     experiment.search(skip_mps=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ keywords = [
 dynamic = ["version"]
 
 dependencies = [
+    "docling-core[chunking-openai]~=2.74.1",
     "langchain~=1.1.3",
     "langchain_chroma~=1.1.0",
     "langchain-text-splitters~=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ keywords = [
 dynamic = ["version"]
 
 dependencies = [
-    "docling-core[chunking-openai]~=2.74.1",
+    "docling-core[chunking,chunking-openai]~=2.74.1",
     "langchain~=1.1.3",
     "langchain_chroma~=1.1.0",
     "langchain-text-splitters~=1.1.0",

--- a/tests/unit/ai4rag/core/experiment/test_mps.py
+++ b/tests/unit/ai4rag/core/experiment/test_mps.py
@@ -4,13 +4,15 @@
 # -----------------------------------------------------------------------------
 import pandas as pd
 import pytest
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.labels import DocItemLabel
 
 from ai4rag.core.experiment.mps import (
+    AI4RAGChunk,
     BaseEmbeddingModel,
     BaseFoundationModel,
     BenchmarkData,
     ChromaVectorStore,
-    Document,
     GenerationError,
     ModelsPreSelector,
     PreSelectorError,
@@ -32,19 +34,18 @@ def benchmark_data() -> BenchmarkData:
     return benchmark_data
 
 
+def _make_docling_doc(name: str, text: str) -> DoclingDocument:
+    doc = DoclingDocument(name=name)
+    doc.add_text(label=DocItemLabel.PARAGRAPH, text=text)
+    return doc
+
+
 @pytest.fixture
-def documents() -> list[Document]:
-    docs = [
-        Document(
-            page_content="Page content 1",
-            metadata={"document_id": "id_1_1"},
-        ),
-        Document(
-            page_content="Page content 2",
-            metadata={"document_id": "id_2_1"},
-        ),
+def documents() -> list[DoclingDocument]:
+    return [
+        _make_docling_doc("id_1_1", "Page content 1"),
+        _make_docling_doc("id_2_1", "Page content 2"),
     ]
-    return docs
 
 
 @pytest.fixture
@@ -221,7 +222,7 @@ class TestModelsPreSelector:
 
     def test_create_vector_store(self, mocker, fully_mocked_selector, caplog):
         vs = mocker.MagicMock(ChromaVectorStore)
-        document = mocker.MagicMock(Document)
+        document = mocker.MagicMock(AI4RAGChunk)
         val_err = ValueError("Fake embeddings error")
         vs.add_documents.side_effect = val_err
         mocker.patch("ai4rag.core.experiment.mps.ChromaVectorStore", return_value=vs)

--- a/tests/unit/ai4rag/core/experiment/test_utils.py
+++ b/tests/unit/ai4rag/core/experiment/test_utils.py
@@ -8,7 +8,6 @@ import pytest
 
 from ai4rag.core.experiment.benchmark_data import BenchmarkData
 from ai4rag.core.experiment.exception_handler import GenerationError
-from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.core.experiment.utils import (
     RAGExperimentError,
     build_evaluation_data,
@@ -17,6 +16,7 @@ from ai4rag.core.experiment.utils import (
     query_rag,
 )
 from ai4rag.evaluator.base_evaluator import EvaluationData
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 
 
 class TestQueryRag:

--- a/tests/unit/ai4rag/core/experiment/test_utils.py
+++ b/tests/unit/ai4rag/core/experiment/test_utils.py
@@ -5,10 +5,10 @@
 
 import pandas as pd
 import pytest
-from langchain_core.documents import Document
 
 from ai4rag.core.experiment.benchmark_data import BenchmarkData
 from ai4rag.core.experiment.exception_handler import GenerationError
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.core.experiment.utils import (
     RAGExperimentError,
     build_evaluation_data,
@@ -31,7 +31,7 @@ class TestQueryRag:
             "question": q,
             "answer": f"Answer to {q}",
             "reference_documents": [
-                Document(page_content="Doc content", metadata={"document_id": "doc1"}),
+                AI4RAGChunk(text="Doc content", metadata={"document_id": "doc1"}),
             ],
         }
         return mock
@@ -120,15 +120,15 @@ class TestBuildEvaluationData:
                 "question": "What is AI?",
                 "answer": "AI is artificial intelligence.",
                 "reference_documents": [
-                    Document(page_content="AI context", metadata={"document_id": "doc1"}),
-                    Document(page_content="More AI context", metadata={"document_id": "doc2"}),
+                    AI4RAGChunk(text="AI context", metadata={"document_id": "doc1"}),
+                    AI4RAGChunk(text="More AI context", metadata={"document_id": "doc2"}),
                 ],
             },
             {
                 "question": "What is ML?",
                 "answer": "ML is machine learning.",
                 "reference_documents": [
-                    Document(page_content="ML context", metadata={"document_id": "doc3"}),
+                    AI4RAGChunk(text="ML context", metadata={"document_id": "doc3"}),
                 ],
             },
         ]
@@ -193,14 +193,14 @@ class TestBuildEvaluationData:
         assert result[0].ground_truths_context_ids == []
         assert result[1].ground_truths_context_ids == []
 
-    def test_build_evaluation_data_with_missing_page_content(self, benchmark_data):
-        """Test handling of documents without page_content attribute."""
+    def test_build_evaluation_data_with_empty_text(self, benchmark_data):
+        """Test handling of chunks with empty text."""
         inference_response = [
             {
                 "question": "What is AI?",
                 "answer": "AI is artificial intelligence.",
                 "reference_documents": [
-                    type("Doc", (), {"metadata": {"document_id": "doc1"}})(),
+                    AI4RAGChunk(text="", metadata={"document_id": "doc1"}),
                 ],
             },
             {
@@ -212,17 +212,17 @@ class TestBuildEvaluationData:
 
         result = build_evaluation_data(benchmark_data, inference_response)
 
-        assert result[0].contexts[0] is None
+        assert result[0].contexts[0] == ""
         assert result[0].context_ids[0] == "doc1"
 
-    def test_build_evaluation_data_with_missing_metadata(self, benchmark_data):
-        """Test handling of documents without metadata."""
+    def test_build_evaluation_data_with_missing_document_id(self, benchmark_data):
+        """Test handling of chunks without document_id in metadata."""
         inference_response = [
             {
                 "question": "What is AI?",
                 "answer": "AI is artificial intelligence.",
                 "reference_documents": [
-                    type("Doc", (), {"page_content": "Content"})(),
+                    AI4RAGChunk(text="Content", metadata={}),
                 ],
             },
             {

--- a/tests/unit/ai4rag/rag/chunking/test_base_chunker.py
+++ b/tests/unit/ai4rag/rag/chunking/test_base_chunker.py
@@ -2,27 +2,26 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from typing import Any
+from typing import Any, Sequence
 
 import pytest
+from docling_core.types.doc import DoclingDocument
 
 from ai4rag.rag.chunking.base_chunker import BaseChunker
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 
 
-class ConcreteChunker(BaseChunker[str]):
+class ConcreteChunker(BaseChunker):
     """Concrete implementation of BaseChunker for testing purposes."""
 
-    def split_documents(self, documents: list[str]) -> list[str]:
-        """Simple split implementation for testing."""
-        return [doc[:5] for doc in documents if doc]
+    def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
+        return [AI4RAGChunk(text=doc.name[:5], metadata={}) for doc in documents]
 
     def to_dict(self) -> dict[str, Any]:
-        """Return dictionary representation."""
         return {"type": "concrete", "param": "value"}
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "ConcreteChunker":
-        """Create instance from dictionary."""
         return cls()
 
 
@@ -30,21 +29,17 @@ class TestBaseChunker:
     """Test suite for BaseChunker abstract base class."""
 
     def test_base_chunker_cannot_be_instantiated(self):
-        """Test that BaseChunker cannot be instantiated directly."""
         with pytest.raises(TypeError) as exc_info:
             BaseChunker()
         assert "Can't instantiate abstract class" in str(exc_info.value)
 
     def test_base_chunker_initialization_via_subclass(self):
-        """Test that BaseChunker can be instantiated via a concrete subclass."""
         chunker = ConcreteChunker()
         assert isinstance(chunker, BaseChunker)
 
     def test_split_documents_is_abstract(self):
-        """Test that split_documents is abstract and must be implemented."""
 
-        # Create a subclass without implementing split_documents
-        class IncompleteChunker(BaseChunker[str]):
+        class IncompleteChunker(BaseChunker):
             def to_dict(self) -> dict[str, Any]:
                 return {}
 
@@ -57,12 +52,10 @@ class TestBaseChunker:
         assert "Can't instantiate abstract class" in str(exc_info.value)
 
     def test_to_dict_is_abstract(self):
-        """Test that to_dict is abstract and must be implemented."""
 
-        # Create a subclass without implementing to_dict
-        class IncompleteChunker(BaseChunker[str]):
-            def split_documents(self, documents: list[str]) -> list[str]:
-                return documents
+        class IncompleteChunker(BaseChunker):
+            def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
+                return []
 
             @classmethod
             def from_dict(cls, d: dict[str, Any]) -> "IncompleteChunker":
@@ -73,12 +66,10 @@ class TestBaseChunker:
         assert "Can't instantiate abstract class" in str(exc_info.value)
 
     def test_from_dict_is_abstract(self):
-        """Test that from_dict is abstract and must be implemented."""
 
-        # Create a subclass without implementing from_dict
-        class IncompleteChunker(BaseChunker[str]):
-            def split_documents(self, documents: list[str]) -> list[str]:
-                return documents
+        class IncompleteChunker(BaseChunker):
+            def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
+                return []
 
             def to_dict(self) -> dict[str, Any]:
                 return {}
@@ -88,44 +79,21 @@ class TestBaseChunker:
         assert "Can't instantiate abstract class" in str(exc_info.value)
 
     def test_concrete_chunker_split_documents(self):
-        """Test that concrete implementation's split_documents works."""
         chunker = ConcreteChunker()
-        documents = ["hello world", "test document", "another one"]
-        result = chunker.split_documents(documents)
-        assert result == ["hello", "test ", "anoth"]
+        docs = [DoclingDocument(name="hello_world"), DoclingDocument(name="test_document")]
+        result = chunker.split_documents(docs)
+        assert len(result) == 2
+        assert all(isinstance(c, AI4RAGChunk) for c in result)
+        assert result[0].text == "hello"
+        assert result[1].text == "test_"
 
     def test_concrete_chunker_to_dict(self):
-        """Test that concrete implementation's to_dict works."""
         chunker = ConcreteChunker()
         result = chunker.to_dict()
         assert isinstance(result, dict)
         assert result["type"] == "concrete"
 
     def test_concrete_chunker_from_dict(self):
-        """Test that concrete implementation's from_dict works."""
         chunker = ConcreteChunker.from_dict({"type": "concrete", "param": "value"})
         assert isinstance(chunker, ConcreteChunker)
         assert isinstance(chunker, BaseChunker)
-
-    def test_base_chunker_is_generic(self):
-        """Test that BaseChunker supports generic types."""
-        # Test with string type
-        chunker_str = ConcreteChunker()
-        assert isinstance(chunker_str, BaseChunker)
-
-        # Test that we can create different type-specific chunkers
-        class IntChunker(BaseChunker[int]):
-            def split_documents(self, documents: list[int]) -> list[int]:
-                return [x // 2 for x in documents]
-
-            def to_dict(self) -> dict[str, Any]:
-                return {}
-
-            @classmethod
-            def from_dict(cls, d: dict[str, Any]) -> "IntChunker":
-                return cls()
-
-        chunker_int = IntChunker()
-        assert isinstance(chunker_int, BaseChunker)
-        result = chunker_int.split_documents([10, 20, 30])
-        assert result == [5, 10, 15]

--- a/tests/unit/ai4rag/rag/chunking/test_docling_chunker.py
+++ b/tests/unit/ai4rag/rag/chunking/test_docling_chunker.py
@@ -1,0 +1,156 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+import pytest
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.labels import DocItemLabel
+
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
+from ai4rag.rag.chunking.docling_chunker import DoclingChunker
+
+
+def _make_doc(name: str, sections: list[tuple[str, str]] | None = None) -> DoclingDocument:
+    """Helper: create a DoclingDocument with optional heading-paragraph pairs."""
+    doc = DoclingDocument(name=name)
+    if sections:
+        for heading, paragraph in sections:
+            doc.add_heading(text=heading, level=1)
+            doc.add_text(label=DocItemLabel.PARAGRAPH, text=paragraph)
+    return doc
+
+
+class TestDoclingChunkerInitialization:
+
+    def test_init_with_defaults(self):
+        chunker = DoclingChunker()
+        assert chunker.max_tokens == 8192
+        assert chunker.contextualize is True
+        assert chunker.merge_peers is True
+
+    def test_init_with_custom_parameters(self):
+        chunker = DoclingChunker(max_tokens=512, contextualize=False, merge_peers=False)
+        assert chunker.max_tokens == 512
+        assert chunker.contextualize is False
+        assert chunker.merge_peers is False
+
+    def test_init_creates_hybrid_chunker(self):
+        chunker = DoclingChunker()
+        assert chunker._chunker is not None
+
+
+class TestDoclingChunkerSplitDocuments:
+
+    @pytest.fixture
+    def doc_with_sections(self):
+        return _make_doc(
+            "report.pdf",
+            [
+                ("Introduction", "Machine learning is a branch of AI."),
+                ("Methods", "We used gradient descent for optimization."),
+                ("Results", "The model achieved 95% accuracy."),
+            ],
+        )
+
+    @pytest.fixture
+    def chunker(self):
+        return DoclingChunker(max_tokens=8192)
+
+    def test_returns_ai4rag_chunks(self, chunker, doc_with_sections):
+        chunks = chunker.split_documents([doc_with_sections])
+        assert isinstance(chunks, list)
+        assert all(isinstance(c, AI4RAGChunk) for c in chunks)
+
+    def test_document_id_from_doc_name(self, chunker, doc_with_sections):
+        chunks = chunker.split_documents([doc_with_sections])
+        for chunk in chunks:
+            assert chunk.metadata["document_id"] == "report.pdf"
+
+    def test_sequence_numbers_start_at_one(self, chunker, doc_with_sections):
+        chunks = chunker.split_documents([doc_with_sections])
+        seq_nums = [c.metadata["sequence_number"] for c in chunks]
+        assert seq_nums[0] == 1
+        assert seq_nums == list(range(1, len(chunks) + 1))
+
+    def test_contextualize_true_includes_headings(self, doc_with_sections):
+        chunker = DoclingChunker(contextualize=True)
+        chunks = chunker.split_documents([doc_with_sections])
+        heading_chunks = [c for c in chunks if c.metadata.get("headings")]
+        assert len(heading_chunks) > 0
+        for chunk in heading_chunks:
+            assert chunk.metadata["headings"][0] in chunk.text
+
+    def test_contextualize_false_excludes_headings(self, doc_with_sections):
+        chunker = DoclingChunker(contextualize=False)
+        chunks = chunker.split_documents([doc_with_sections])
+        heading_chunks = [c for c in chunks if c.metadata.get("headings")]
+        for chunk in heading_chunks:
+            heading = chunk.metadata["headings"][0]
+            assert not chunk.text.startswith(heading)
+
+    def test_headings_in_metadata(self, chunker, doc_with_sections):
+        chunks = chunker.split_documents([doc_with_sections])
+        heading_chunks = [c for c in chunks if c.metadata.get("headings")]
+        heading_values = [c.metadata["headings"][0] for c in heading_chunks]
+        assert "Introduction" in heading_values
+        assert "Methods" in heading_values
+        assert "Results" in heading_values
+
+    def test_multiple_documents(self, chunker):
+        doc1 = _make_doc("doc1.pdf", [("Intro", "Content one.")])
+        doc2 = _make_doc("doc2.pdf", [("Intro", "Content two.")])
+        chunks = chunker.split_documents([doc1, doc2])
+        doc_ids = {c.metadata["document_id"] for c in chunks}
+        assert doc_ids == {"doc1.pdf", "doc2.pdf"}
+
+    def test_sequence_numbers_reset_per_document(self, chunker):
+        doc1 = _make_doc("doc1.pdf", [("A", "Text A."), ("B", "Text B.")])
+        doc2 = _make_doc("doc2.pdf", [("C", "Text C.")])
+        chunks = chunker.split_documents([doc1, doc2])
+        doc2_chunks = [c for c in chunks if c.metadata["document_id"] == "doc2.pdf"]
+        assert doc2_chunks[0].metadata["sequence_number"] == 1
+
+    def test_empty_input(self, chunker):
+        chunks = chunker.split_documents([])
+        assert chunks == []
+
+
+class TestDoclingChunkerSerialization:
+
+    def test_to_dict(self):
+        chunker = DoclingChunker(max_tokens=512, contextualize=False, merge_peers=True)
+        d = chunker.to_dict()
+        assert d == {"max_tokens": 512, "contextualize": False, "merge_peers": True}
+
+    def test_from_dict(self):
+        d = {"max_tokens": 1024, "contextualize": True, "merge_peers": False}
+        chunker = DoclingChunker.from_dict(d)
+        assert chunker.max_tokens == 1024
+        assert chunker.contextualize is True
+        assert chunker.merge_peers is False
+
+    def test_round_trip(self):
+        original = DoclingChunker(max_tokens=2048, contextualize=False)
+        recreated = DoclingChunker.from_dict(original.to_dict())
+        assert original == recreated
+
+
+class TestDoclingChunkerEquality:
+
+    def test_equal_instances(self):
+        c1 = DoclingChunker(max_tokens=512)
+        c2 = DoclingChunker(max_tokens=512)
+        assert c1 == c2
+
+    def test_different_max_tokens(self):
+        c1 = DoclingChunker(max_tokens=512)
+        c2 = DoclingChunker(max_tokens=1024)
+        assert c1 != c2
+
+    def test_different_contextualize(self):
+        c1 = DoclingChunker(contextualize=True)
+        c2 = DoclingChunker(contextualize=False)
+        assert c1 != c2
+
+    def test_non_chunker_comparison(self):
+        assert DoclingChunker().__eq__("not a chunker") is NotImplemented

--- a/tests/unit/ai4rag/rag/chunking/test_langchain_chunker.py
+++ b/tests/unit/ai4rag/rag/chunking/test_langchain_chunker.py
@@ -2,14 +2,14 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-import tiktoken
 import pytest
+import tiktoken
 from docling_core.types.doc import DoclingDocument
 from docling_core.types.doc.labels import DocItemLabel
 from langchain_core.documents import Document
 
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
-from ai4rag.rag.chunking.langchain_chunker import LangChainChunker, _DEFAULT_TIKTOKEN_MODEL
+from ai4rag.rag.chunking.langchain_chunker import _DEFAULT_TIKTOKEN_MODEL, LangChainChunker
 
 
 def _make_docling_doc(name: str, text: str) -> DoclingDocument:

--- a/tests/unit/ai4rag/rag/chunking/test_langchain_chunker.py
+++ b/tests/unit/ai4rag/rag/chunking/test_langchain_chunker.py
@@ -2,17 +2,27 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+import tiktoken
 import pytest
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.labels import DocItemLabel
 from langchain_core.documents import Document
 
-from ai4rag.rag.chunking.langchain_chunker import LangChainChunker
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
+from ai4rag.rag.chunking.langchain_chunker import LangChainChunker, _DEFAULT_TIKTOKEN_MODEL
+
+
+def _make_docling_doc(name: str, text: str) -> DoclingDocument:
+    """Helper to create a DoclingDocument with a single paragraph."""
+    doc = DoclingDocument(name=name)
+    doc.add_text(label=DocItemLabel.PARAGRAPH, text=text)
+    return doc
 
 
 class TestLangChainChunkerInitialization:
     """Test suite for LangChainChunker initialization."""
 
     def test_init_with_defaults(self):
-        """Test initialization with default parameters."""
         chunker = LangChainChunker()
         assert chunker.method == "recursive"
         assert chunker.chunk_size == 2048
@@ -20,7 +30,6 @@ class TestLangChainChunkerInitialization:
         assert chunker.separators == ["\n\n", "(?<=\. )", "\n", " ", ""]
 
     def test_init_with_custom_parameters(self):
-        """Test initialization with custom parameters."""
         chunker = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128, separators=["\n", " "])
         assert chunker.method == "recursive"
         assert chunker.chunk_size == 1024
@@ -28,216 +37,121 @@ class TestLangChainChunkerInitialization:
         assert chunker.separators == ["\n", " "]
 
     def test_init_with_unsupported_method(self):
-        """Test initialization with unsupported method raises ValueError."""
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="not supported"):
             LangChainChunker(method="character")
-        assert "not supported" in str(exc_info.value).lower()
-        assert "character" in str(exc_info.value)
 
     def test_init_with_token_method(self):
-        """Test initialization with token method raises ValueError."""
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="not supported"):
             LangChainChunker(method="token")
-        assert "not supported" in str(exc_info.value).lower()
 
     def test_text_splitter_is_created(self):
-        """Test that text_splitter is created during initialization."""
         chunker = LangChainChunker()
         assert chunker._text_splitter is not None
         assert hasattr(chunker._text_splitter, "split_documents")
 
 
 class TestLangChainChunkerSplitDocuments:
-    """Test suite for LangChainChunker.split_documents method."""
+    """Test suite for LangChainChunker.split_documents with DoclingDocument input."""
 
     @pytest.fixture
     def sample_documents(self):
-        """Create sample documents for testing."""
         return [
-            Document(page_content="This is a test document. It has multiple sentences.", metadata={}),
-            Document(page_content="Another document with some content.", metadata={}),
+            _make_docling_doc("doc1.pdf", "This is a test document. It has multiple sentences."),
+            _make_docling_doc("doc2.pdf", "Another document with some content."),
         ]
 
     @pytest.fixture
     def chunker_small(self):
-        """Create a chunker with small chunk size for testing."""
         return LangChainChunker(chunk_size=20, chunk_overlap=5)
 
-    def test_split_documents_basic(self, chunker_small, sample_documents):
-        """Test basic document splitting."""
+    def test_split_returns_ai4rag_chunks(self, chunker_small, sample_documents):
         chunks = chunker_small.split_documents(sample_documents)
         assert isinstance(chunks, list)
         assert len(chunks) > 0
-        assert all(isinstance(chunk, Document) for chunk in chunks)
+        assert all(isinstance(chunk, AI4RAGChunk) for chunk in chunks)
 
-    def test_split_documents_adds_document_id(self, chunker_small, sample_documents):
-        """Test that split_documents adds document_id to metadata if missing."""
+    def test_chunks_have_text_attribute(self, chunker_small, sample_documents):
         chunks = chunker_small.split_documents(sample_documents)
         for chunk in chunks:
-            assert "document_id" in chunk.metadata
-            assert isinstance(chunk.metadata["document_id"], str)
+            assert isinstance(chunk.text, str)
+            assert len(chunk.text) > 0
 
-    def test_split_documents_preserves_existing_document_id(self, chunker_small):
-        """Test that split_documents preserves existing document_id."""
-        documents = [
-            Document(
-                page_content="Test content.",
-                metadata={"document_id": "custom-id-123"},
-            )
-        ]
-        chunks = chunker_small.split_documents(documents)
-        for chunk in chunks:
-            assert chunk.metadata["document_id"] == "custom-id-123"
+    def test_split_adds_document_id_from_doc_name(self, chunker_small, sample_documents):
+        chunks = chunker_small.split_documents(sample_documents)
+        doc_ids = {chunk.metadata["document_id"] for chunk in chunks}
+        assert "doc1.pdf" in doc_ids
+        assert "doc2.pdf" in doc_ids
 
-    def test_split_documents_adds_sequence_number(self, chunker_small, sample_documents):
-        """Test that split_documents adds sequence_number to metadata."""
+    def test_split_adds_sequence_number(self, chunker_small, sample_documents):
         chunks = chunker_small.split_documents(sample_documents)
         for chunk in chunks:
             assert "sequence_number" in chunk.metadata
             assert isinstance(chunk.metadata["sequence_number"], int)
             assert chunk.metadata["sequence_number"] > 0
 
-    def test_split_documents_sequence_numbers_are_sequential(self, chunker_small):
-        """Test that sequence numbers are sequential per document."""
-        documents = [
-            Document(page_content="A" * 100, metadata={"document_id": "doc1"}),
-        ]
-        chunks = chunker_small.split_documents(documents)
+    def test_sequence_numbers_are_sequential(self, chunker_small):
+        doc = _make_docling_doc("doc1.pdf", "A" * 100)
+        chunks = chunker_small.split_documents([doc])
         sequence_numbers = [chunk.metadata["sequence_number"] for chunk in chunks]
-        assert sequence_numbers == sorted(sequence_numbers)
         assert sequence_numbers == list(range(1, len(chunks) + 1))
 
-    def test_split_documents_sorts_by_start_index(self, chunker_small):
-        """Test that chunks are sorted by document_id and start_index."""
-        documents = [
-            Document(page_content="A" * 100, metadata={"document_id": "doc1"}),
-        ]
-        chunks = chunker_small.split_documents(documents)
-        start_indices = [chunk.metadata.get("start_index", 0) for chunk in chunks]
-        assert start_indices == sorted(start_indices)
-
-    def test_split_documents_with_empty_documents(self, chunker_small):
-        """Test split_documents with empty document list."""
+    def test_split_with_empty_list(self, chunker_small):
         chunks = chunker_small.split_documents([])
         assert chunks == []
 
-    def test_split_documents_with_empty_content(self, chunker_small):
-        """Test split_documents with documents having empty content."""
-        documents = [Document(page_content="", metadata={})]
-        chunks = chunker_small.split_documents(documents)
-        # Empty content might result in empty chunks or be filtered out
-        assert isinstance(chunks, list)
-
-    def test_split_documents_respects_chunk_size(self, sample_documents):
-        """Test that split_documents respects chunk_size parameter."""
+    def test_split_respects_chunk_size(self, sample_documents):
+        encoding = tiktoken.encoding_for_model(_DEFAULT_TIKTOKEN_MODEL)
         chunker = LangChainChunker(chunk_size=10, chunk_overlap=2)
         chunks = chunker.split_documents(sample_documents)
         for chunk in chunks:
-            # Chunk size is approximate due to splitting logic, but should be close
-            assert len(chunk.page_content) <= 15  # Allow some margin
+            assert len(encoding.encode(chunk.text)) <= 10
 
-    def test_split_documents_respects_chunk_overlap(self, sample_documents):
-        """Test that split_documents respects chunk_overlap parameter."""
-        chunker = LangChainChunker(chunk_size=20, chunk_overlap=5)
-        chunks = chunker.split_documents(sample_documents)
-        # With overlap, we should have more chunks than without
-        chunker_no_overlap = LangChainChunker(chunk_size=20, chunk_overlap=0)
-        chunks_no_overlap = chunker_no_overlap.split_documents(sample_documents)
-        # Overlap typically creates more chunks
-        assert len(chunks) >= len(chunks_no_overlap)
-
-    def test_split_documents_multiple_documents(self, chunker_small):
-        """Test split_documents with multiple documents."""
-        documents = [
-            Document(page_content="First document with some content.", metadata={"document_id": "doc1"}),
-            Document(page_content="Second document with different content.", metadata={"document_id": "doc2"}),
-            Document(page_content="Third document.", metadata={"document_id": "doc3"}),
+    def test_split_multiple_documents(self, chunker_small):
+        docs = [
+            _make_docling_doc("doc1.pdf", "First document with some content."),
+            _make_docling_doc("doc2.pdf", "Second document with different content."),
+            _make_docling_doc("doc3.pdf", "Third document."),
         ]
-        chunks = chunker_small.split_documents(documents)
+        chunks = chunker_small.split_documents(docs)
         assert len(chunks) > 0
-        # Verify document_ids are preserved
         doc_ids = {chunk.metadata["document_id"] for chunk in chunks}
-        assert "doc1" in doc_ids
-        assert "doc2" in doc_ids
-        assert "doc3" in doc_ids
+        assert "doc1.pdf" in doc_ids
+        assert "doc2.pdf" in doc_ids
+        assert "doc3.pdf" in doc_ids
 
 
 class TestLangChainChunkerToDict:
     """Test suite for LangChainChunker.to_dict method."""
 
     def test_to_dict_returns_dict(self):
-        """Test that to_dict returns a dictionary."""
-        chunker = LangChainChunker()
-        result = chunker.to_dict()
+        result = LangChainChunker().to_dict()
         assert isinstance(result, dict)
 
-    def test_to_dict_contains_method(self):
-        """Test that to_dict contains method parameter."""
-        chunker = LangChainChunker(method="recursive")
-        result = chunker.to_dict()
-        assert "method" in result
-        assert result["method"] == "recursive"
-
-    def test_to_dict_contains_chunk_size(self):
-        """Test that to_dict contains chunk_size parameter."""
-        chunker = LangChainChunker(chunk_size=1024)
-        result = chunker.to_dict()
-        assert "chunk_size" in result
-        assert result["chunk_size"] == 1024
-
-    def test_to_dict_contains_chunk_overlap(self):
-        """Test that to_dict contains chunk_overlap parameter."""
-        chunker = LangChainChunker(chunk_overlap=128)
-        result = chunker.to_dict()
-        assert "chunk_overlap" in result
-        assert result["chunk_overlap"] == 128
-
-    def test_to_dict_excludes_internal_attributes(self):
-        """Test that to_dict excludes internal attributes like _text_splitter."""
-        chunker = LangChainChunker()
-        result = chunker.to_dict()
-        assert "_text_splitter" not in result
-        assert "separators" not in result
-
-    def test_to_dict_all_required_params(self):
-        """Test that to_dict contains all required parameters."""
+    def test_to_dict_contains_all_params(self):
         chunker = LangChainChunker(method="recursive", chunk_size=512, chunk_overlap=64)
         result = chunker.to_dict()
         assert set(result.keys()) == {"method", "chunk_size", "chunk_overlap"}
+        assert result["method"] == "recursive"
+        assert result["chunk_size"] == 512
+        assert result["chunk_overlap"] == 64
+
+    def test_to_dict_excludes_internal_attributes(self):
+        result = LangChainChunker().to_dict()
+        assert "_text_splitter" not in result
+        assert "separators" not in result
 
 
 class TestLangChainChunkerFromDict:
     """Test suite for LangChainChunker.from_dict method."""
 
     def test_from_dict_creates_instance(self):
-        """Test that from_dict creates a LangChainChunker instance."""
         d = {"method": "recursive", "chunk_size": 1024, "chunk_overlap": 128}
         chunker = LangChainChunker.from_dict(d)
         assert isinstance(chunker, LangChainChunker)
 
-    def test_from_dict_sets_method(self):
-        """Test that from_dict sets method correctly."""
-        d = {"method": "recursive", "chunk_size": 2048, "chunk_overlap": 256}
-        chunker = LangChainChunker.from_dict(d)
-        assert chunker.method == "recursive"
-
-    def test_from_dict_sets_chunk_size(self):
-        """Test that from_dict sets chunk_size correctly."""
-        d = {"method": "recursive", "chunk_size": 512, "chunk_overlap": 64}
-        chunker = LangChainChunker.from_dict(d)
-        assert chunker.chunk_size == 512
-
-    def test_from_dict_sets_chunk_overlap(self):
-        """Test that from_dict sets chunk_overlap correctly."""
-        d = {"method": "recursive", "chunk_size": 1024, "chunk_overlap": 200}
-        chunker = LangChainChunker.from_dict(d)
-        assert chunker.chunk_overlap == 200
-
     def test_from_dict_round_trip(self):
-        """Test that to_dict and from_dict are inverse operations."""
         original = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        d = original.to_dict()
-        recreated = LangChainChunker.from_dict(d)
+        recreated = LangChainChunker.from_dict(original.to_dict())
         assert recreated.method == original.method
         assert recreated.chunk_size == original.chunk_size
         assert recreated.chunk_overlap == original.chunk_overlap
@@ -247,49 +161,26 @@ class TestLangChainChunkerEquality:
     """Test suite for LangChainChunker.__eq__ method."""
 
     def test_eq_same_parameters(self):
-        """Test equality when parameters are the same."""
-        chunker1 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        chunker2 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        assert chunker1 == chunker2
+        c1 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
+        c2 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
+        assert c1 == c2
 
-    def test_eq_different_chunk_size(self):
-        """Test inequality when chunk_size differs."""
-        chunker1 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        chunker2 = LangChainChunker(method="recursive", chunk_size=2048, chunk_overlap=128)
-        assert chunker1 != chunker2
-
-    def test_eq_different_chunk_overlap(self):
-        """Test inequality when chunk_overlap differs."""
-        chunker1 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        chunker2 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=256)
-        assert chunker1 != chunker2
-
-    def test_eq_different_method(self):
-        """Test inequality when method differs."""
-        chunker1 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        # Note: "character" method is not supported, but equality check happens before validation
-        # This test verifies the equality logic itself
-        chunker2 = LangChainChunker(method="recursive", chunk_size=1024, chunk_overlap=128)
-        assert chunker1 == chunker2
+    def test_neq_different_chunk_size(self):
+        c1 = LangChainChunker(chunk_size=1024)
+        c2 = LangChainChunker(chunk_size=2048)
+        assert c1 != c2
 
     def test_eq_with_non_chunker(self):
-        """Test equality with non-LangChainChunker object returns NotImplemented."""
-        chunker = LangChainChunker()
-        result = chunker.__eq__("not a chunker")
-        assert result is NotImplemented
+        assert LangChainChunker().__eq__("not a chunker") is NotImplemented
 
     def test_eq_with_none(self):
-        """Test equality with None returns NotImplemented."""
-        chunker = LangChainChunker()
-        result = chunker.__eq__(None)
-        assert result is NotImplemented
+        assert LangChainChunker().__eq__(None) is NotImplemented
 
 
 class TestLangChainChunkerStaticMethods:
-    """Test suite for LangChainChunker static methods."""
+    """Test suite for LangChainChunker static methods (internal langchain operations)."""
 
     def test_set_document_id_in_metadata_if_missing(self):
-        """Test _set_document_id_in_metadata_if_missing adds document_id when missing."""
         documents = [
             Document(page_content="Test content 1", metadata={}),
             Document(page_content="Test content 2", metadata={}),
@@ -300,24 +191,11 @@ class TestLangChainChunkerStaticMethods:
             assert isinstance(doc.metadata["document_id"], str)
 
     def test_set_document_id_preserves_existing(self):
-        """Test _set_document_id_in_metadata_if_missing preserves existing document_id."""
-        documents = [
-            Document(page_content="Test content", metadata={"document_id": "existing-id"}),
-        ]
+        documents = [Document(page_content="Test content", metadata={"document_id": "existing-id"})]
         LangChainChunker._set_document_id_in_metadata_if_missing(documents)
         assert documents[0].metadata["document_id"] == "existing-id"
 
-    def test_set_document_id_different_for_different_content(self):
-        """Test that different content gets different document_ids."""
-        documents = [
-            Document(page_content="Content 1", metadata={}),
-            Document(page_content="Content 2", metadata={}),
-        ]
-        LangChainChunker._set_document_id_in_metadata_if_missing(documents)
-        assert documents[0].metadata["document_id"] != documents[1].metadata["document_id"]
-
     def test_set_sequence_number_in_metadata(self):
-        """Test _set_sequence_number_in_metadata sets sequence numbers correctly."""
         chunks = [
             Document(page_content="Chunk 1", metadata={"document_id": "doc1", "start_index": 0}),
             Document(page_content="Chunk 2", metadata={"document_id": "doc1", "start_index": 10}),
@@ -328,103 +206,60 @@ class TestLangChainChunkerStaticMethods:
         assert result[1].metadata["sequence_number"] == 2
         assert result[2].metadata["sequence_number"] == 3
 
-    def test_set_sequence_number_sorts_by_start_index(self):
-        """Test _set_sequence_number_in_metadata sorts by start_index."""
-        chunks = [
-            Document(page_content="Chunk 3", metadata={"document_id": "doc1", "start_index": 20}),
-            Document(page_content="Chunk 1", metadata={"document_id": "doc1", "start_index": 0}),
-            Document(page_content="Chunk 2", metadata={"document_id": "doc1", "start_index": 10}),
-        ]
-        result = LangChainChunker._set_sequence_number_in_metadata(chunks)
-        assert result[0].metadata["start_index"] == 0
-        assert result[1].metadata["start_index"] == 10
-        assert result[2].metadata["start_index"] == 20
-
     def test_set_sequence_number_multiple_documents(self):
-        """Test _set_sequence_number_in_metadata handles multiple documents correctly."""
         chunks = [
-            Document(page_content="Chunk 1", metadata={"document_id": "doc1", "start_index": 0}),
-            Document(page_content="Chunk 2", metadata={"document_id": "doc1", "start_index": 10}),
-            Document(page_content="Chunk A", metadata={"document_id": "doc2", "start_index": 0}),
-            Document(page_content="Chunk B", metadata={"document_id": "doc2", "start_index": 10}),
+            Document(page_content="C1", metadata={"document_id": "doc1", "start_index": 0}),
+            Document(page_content="C2", metadata={"document_id": "doc1", "start_index": 10}),
+            Document(page_content="CA", metadata={"document_id": "doc2", "start_index": 0}),
+            Document(page_content="CB", metadata={"document_id": "doc2", "start_index": 10}),
         ]
         result = LangChainChunker._set_sequence_number_in_metadata(chunks)
-        # Check doc1 sequence numbers
         doc1_chunks = [c for c in result if c.metadata["document_id"] == "doc1"]
+        doc2_chunks = [c for c in result if c.metadata["document_id"] == "doc2"]
         assert doc1_chunks[0].metadata["sequence_number"] == 1
         assert doc1_chunks[1].metadata["sequence_number"] == 2
-        # Check doc2 sequence numbers
-        doc2_chunks = [c for c in result if c.metadata["document_id"] == "doc2"]
         assert doc2_chunks[0].metadata["sequence_number"] == 1
         assert doc2_chunks[1].metadata["sequence_number"] == 2
 
-    def test_set_sequence_number_sorts_by_document_id_then_start_index(self):
-        """Test _set_sequence_number_in_metadata sorts by document_id first, then start_index."""
-        chunks = [
-            Document(page_content="Chunk", metadata={"document_id": "doc2", "start_index": 0}),
-            Document(page_content="Chunk", metadata={"document_id": "doc1", "start_index": 10}),
-            Document(page_content="Chunk", metadata={"document_id": "doc1", "start_index": 0}),
-            Document(page_content="Chunk", metadata={"document_id": "doc2", "start_index": 10}),
+    def test_docling_to_langchain(self):
+        docs = [
+            _make_docling_doc("file1.pdf", "Content of file 1"),
+            _make_docling_doc("file2.pdf", "Content of file 2"),
         ]
-        result = LangChainChunker._set_sequence_number_in_metadata(chunks)
-        # Should be sorted: doc1 (start 0), doc1 (start 10), doc2 (start 0), doc2 (start 10)
-        assert result[0].metadata["document_id"] == "doc1"
-        assert result[0].metadata["start_index"] == 0
-        assert result[1].metadata["document_id"] == "doc1"
-        assert result[1].metadata["start_index"] == 10
-        assert result[2].metadata["document_id"] == "doc2"
-        assert result[2].metadata["start_index"] == 0
-        assert result[3].metadata["document_id"] == "doc2"
-        assert result[3].metadata["start_index"] == 10
+        lc_docs = LangChainChunker._docling_to_langchain(docs)
+        assert len(lc_docs) == 2
+        assert all(isinstance(d, Document) for d in lc_docs)
+        assert lc_docs[0].metadata["document_id"] == "file1.pdf"
+        assert lc_docs[1].metadata["document_id"] == "file2.pdf"
 
 
 class TestLangChainChunkerEdgeCases:
-    """Test suite for edge cases and error handling."""
+    """Test suite for edge cases."""
 
     def test_chunker_with_very_small_chunk_size(self):
-        """Test chunker with very small chunk size."""
         chunker = LangChainChunker(chunk_size=5, chunk_overlap=1)
-        documents = [Document(page_content="This is a longer document.", metadata={})]
-        chunks = chunker.split_documents(documents)
-        assert len(chunks) > 1  # Should create multiple chunks
+        docs = [_make_docling_doc("test.pdf", "This is a longer document.")]
+        chunks = chunker.split_documents(docs)
+        assert len(chunks) > 1
 
     def test_chunker_with_large_chunk_size(self):
-        """Test chunker with large chunk size."""
         chunker = LangChainChunker(chunk_size=10000, chunk_overlap=100)
-        documents = [Document(page_content="Short document.", metadata={})]
-        chunks = chunker.split_documents(documents)
+        docs = [_make_docling_doc("test.pdf", "Short document.")]
+        chunks = chunker.split_documents(docs)
         assert len(chunks) >= 1
 
     def test_chunker_with_zero_overlap(self):
-        """Test chunker with zero overlap."""
         chunker = LangChainChunker(chunk_size=20, chunk_overlap=0)
-        documents = [Document(page_content="A" * 100, metadata={})]
-        chunks = chunker.split_documents(documents)
+        docs = [_make_docling_doc("test.pdf", "A" * 100)]
+        chunks = chunker.split_documents(docs)
         assert len(chunks) > 0
 
-    def test_chunker_with_overlap_equal_to_chunk_size(self):
-        """Test chunker with overlap equal to chunk size (edge case)."""
-        # This is an unusual but valid configuration
-        chunker = LangChainChunker(chunk_size=10, chunk_overlap=10)
-        documents = [Document(page_content="Test content here.", metadata={})]
-        chunks = chunker.split_documents(documents)
-        assert isinstance(chunks, list)
-
-    def test_chunker_with_single_character_document(self):
-        """Test chunker with single character document."""
-        chunker = LangChainChunker()
-        documents = [Document(page_content="A", metadata={})]
-        chunks = chunker.split_documents(documents)
-        assert len(chunks) >= 1
-
     def test_chunker_with_very_long_document(self):
-        """Test chunker with very long document."""
         chunker = LangChainChunker(chunk_size=100, chunk_overlap=10)
         long_content = "This is a sentence. " * 1000
-        documents = [Document(page_content=long_content, metadata={})]
-        chunks = chunker.split_documents(documents)
+        docs = [_make_docling_doc("big.pdf", long_content)]
+        chunks = chunker.split_documents(docs)
         assert len(chunks) > 1
-        # Verify all chunks have metadata
         for chunk in chunks:
             assert "document_id" in chunk.metadata
             assert "sequence_number" in chunk.metadata

--- a/tests/unit/ai4rag/rag/embedding/test_ogx.py
+++ b/tests/unit/ai4rag/rag/embedding/test_ogx.py
@@ -170,22 +170,27 @@ class TestOGXEmbeddingModel:
         assert embeddings[1] == [0.4, 0.5, 0.6]
 
     def test_embed_documents_batches_large_input(self, mock_ogx_client, mocker):
-        """Test embed_documents batches inputs exceeding 2048 texts."""
+        """Test embed_documents batches inputs exceeding _BATCH_SIZE texts."""
         model = OGXEmbeddingModel(
             client=mock_ogx_client,
             model_id="all-MiniLM-L6-v2",
             params=OGXEmbeddingParams(embedding_dimension=3, context_length=512),
         )
 
-        batch1_response = _make_mock_ogx_embedding_response(mocker, [[0.1] for _ in range(2048)])
-        batch2_response = _make_mock_ogx_embedding_response(mocker, [[0.2] for _ in range(100)])
-        mock_ogx_client.embeddings.create.side_effect = [batch1_response, batch2_response]
+        batch_size = OGXEmbeddingModel._BATCH_SIZE
+        remainder = 100
+        total = 2 * batch_size + remainder
 
-        texts = [f"text{i}" for i in range(2148)]
+        batch1_response = _make_mock_ogx_embedding_response(mocker, [[0.1] for _ in range(batch_size)])
+        batch2_response = _make_mock_ogx_embedding_response(mocker, [[0.2] for _ in range(batch_size)])
+        batch3_response = _make_mock_ogx_embedding_response(mocker, [[0.3] for _ in range(remainder)])
+        mock_ogx_client.embeddings.create.side_effect = [batch1_response, batch2_response, batch3_response]
+
+        texts = [f"text{i}" for i in range(total)]
         embeddings = model.embed_documents(texts)
 
-        assert len(embeddings) == 2148
-        assert mock_ogx_client.embeddings.create.call_count == 2
+        assert len(embeddings) == total
+        assert mock_ogx_client.embeddings.create.call_count == 3
 
     def test_embed_query(self, mock_ogx_client, mocker):
         """Test embed_query method."""

--- a/tests/unit/ai4rag/rag/template/test_simple_rag_template.py
+++ b/tests/unit/ai4rag/rag/template/test_simple_rag_template.py
@@ -4,10 +4,19 @@
 # -----------------------------------------------------------------------------
 
 import pytest
-from langchain_core.documents import Document
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.labels import DocItemLabel
 
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.template.base_template import RAGTemplateError
 from ai4rag.rag.template.simple_rag_template import SimpleRAG
+
+
+def _make_docling_doc(name: str, text: str) -> DoclingDocument:
+    """Create a minimal DoclingDocument for testing."""
+    doc = DoclingDocument(name=name)
+    doc.add_text(label=DocItemLabel.PARAGRAPH, text=text)
+    return doc
 
 
 class TestOGXRAGInitialization:
@@ -155,8 +164,8 @@ class TestOGXRAGBuildIndex:
         """Create a mock chunker."""
         mock = mocker.MagicMock()
         mock.split_documents.return_value = [
-            Document(page_content="chunk1", metadata={"document_id": "doc1", "sequence_number": 1}),
-            Document(page_content="chunk2", metadata={"document_id": "doc1", "sequence_number": 2}),
+            AI4RAGChunk(text="chunk1", metadata={"document_id": "doc1", "sequence_number": 1}),
+            AI4RAGChunk(text="chunk2", metadata={"document_id": "doc1", "sequence_number": 2}),
         ]
         return mock
 
@@ -169,10 +178,10 @@ class TestOGXRAGBuildIndex:
 
     @pytest.fixture
     def sample_documents(self):
-        """Create sample documents for testing."""
+        """Create sample DoclingDocuments for testing."""
         return [
-            Document(page_content="This is test document 1.", metadata={"document_id": "doc1"}),
-            Document(page_content="This is test document 2.", metadata={"document_id": "doc2"}),
+            _make_docling_doc("doc1", "This is test document 1."),
+            _make_docling_doc("doc2", "This is test document 2."),
         ]
 
     def test_build_index_chunks_and_adds_to_vector_store(
@@ -200,8 +209,8 @@ class TestOGXRAGBuildIndex:
         mock_vector_store.add_documents.assert_called_once()
         added_chunks = mock_vector_store.add_documents.call_args[0][0]
         assert len(added_chunks) == 2
-        assert added_chunks[0].page_content == "chunk1"
-        assert added_chunks[1].page_content == "chunk2"
+        assert added_chunks[0].text == "chunk1"
+        assert added_chunks[1].text == "chunk2"
 
     def test_build_index_raises_error_when_chunker_is_none(
         self,
@@ -216,7 +225,7 @@ class TestOGXRAGBuildIndex:
         )
 
         with pytest.raises(RAGTemplateError):
-            rag.build_index([Document(page_content="test", metadata={})])
+            rag.build_index([_make_docling_doc("test", "test")])
 
     def test_build_index_fails_when_vector_store_is_none(
         self,
@@ -235,7 +244,7 @@ class TestOGXRAGBuildIndex:
         )
 
         with pytest.raises(AttributeError):
-            rag.build_index([Document(page_content="test", metadata={})])
+            rag.build_index([_make_docling_doc("test", "test")])
 
     def test_build_index_works_with_embedding_model_none(
         self,
@@ -254,7 +263,7 @@ class TestOGXRAGBuildIndex:
         )
 
         # Should not raise RAGTemplateError - embedding_model is not used in build_index
-        rag.build_index([Document(page_content="test", metadata={})])
+        rag.build_index([_make_docling_doc("test", "test")])
         mock_chunker.split_documents.assert_called_once()
         mock_vector_store.add_documents.assert_called_once()
 
@@ -273,7 +282,7 @@ class TestOGXRAGBuildIndex:
         )
 
         with pytest.raises(RAGTemplateError):
-            rag.build_index([Document(page_content="test", metadata={})])
+            rag.build_index([_make_docling_doc("test", "test")])
 
     def test_build_index_with_empty_document_list(
         self,
@@ -304,11 +313,9 @@ class TestOGXRAGBuildIndex:
         mock_vector_store,
     ):
         """Test build_index with large document list."""
-        large_doc_list = [
-            Document(page_content=f"Document {i}", metadata={"document_id": f"doc{i}"}) for i in range(100)
-        ]
+        large_doc_list = [_make_docling_doc(f"doc{i}", f"Document {i}") for i in range(100)]
         large_chunk_list = [
-            Document(page_content=f"Chunk {i}", metadata={"document_id": f"doc{i % 100}", "sequence_number": i})
+            AI4RAGChunk(text=f"Chunk {i}", metadata={"document_id": f"doc{i % 100}", "sequence_number": i})
             for i in range(500)
         ]
         mock_chunker.split_documents.return_value = large_chunk_list
@@ -352,8 +359,8 @@ class TestOGXRAGGenerate:
         """Create a mock retriever."""
         mock = mocker.MagicMock()
         mock.retrieve.return_value = [
-            Document(page_content="Relevant document 1", metadata={"document_id": "doc1"}),
-            Document(page_content="Relevant document 2", metadata={"document_id": "doc2"}),
+            AI4RAGChunk(text="Relevant document 1", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Relevant document 2", metadata={"document_id": "doc2"}),
         ]
         return mock
 
@@ -491,8 +498,8 @@ class TestOGXRAGGenerate:
         result = rag.generate("What is AI?")
 
         assert len(result["reference_documents"]) == 2
-        assert result["reference_documents"][0].page_content == "Relevant document 1"
-        assert result["reference_documents"][1].page_content == "Relevant document 2"
+        assert result["reference_documents"][0].text == "Relevant document 1"
+        assert result["reference_documents"][1].text == "Relevant document 2"
 
     def test_generate_returns_original_question(
         self,
@@ -542,7 +549,7 @@ class TestOGXRAGGenerate:
     ):
         """Test generate with single retrieved document."""
         mock_retriever.retrieve.return_value = [
-            Document(page_content="Single document", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Single document", metadata={"document_id": "doc1"}),
         ]
 
         rag = SimpleRAG(
@@ -553,33 +560,28 @@ class TestOGXRAGGenerate:
         result = rag.generate("What is AI?")
 
         assert len(result["reference_documents"]) == 1
-        assert result["reference_documents"][0].page_content == "Single document"
+        assert result["reference_documents"][0].text == "Single document"
 
-    def test_generate_handles_document_without_page_content_attribute(
+    def test_generate_handles_chunk_without_text_attribute(
         self,
         mock_foundation_model,
         mock_retriever,
         mocker,
     ):
-        """Test that generate handles documents without page_content attribute gracefully."""
-        # Create a mock document-like object without page_content
-        mock_doc = mocker.MagicMock(spec=[])
-        del mock_doc.page_content  # Ensure page_content doesn't exist
-        mock_retriever.retrieve.return_value = [mock_doc]
+        """Test that generate raises AttributeError for chunks without text attribute."""
+        # Create a mock chunk-like object without text
+        mock_chunk = mocker.MagicMock(spec=[])
+        del mock_chunk.text  # Ensure text doesn't exist
+        mock_retriever.retrieve.return_value = [mock_chunk]
 
         rag = SimpleRAG(
             foundation_model=mock_foundation_model,
             retriever=mock_retriever,
         )
 
-        result = rag.generate("What is AI?")
-
-        # Should use empty string when page_content is missing
-        call_args = mock_foundation_model.chat.call_args
-        messages = call_args.kwargs["messages"]
-        user_message = messages[1]["content"]
-        assert "Document: " in user_message
-        assert result["answer"] == "This is the generated answer."
+        # Source code accesses chunk.text directly, so missing attribute raises
+        with pytest.raises(AttributeError):
+            rag.generate("What is AI?")
 
     def test_generate_with_different_questions(
         self,
@@ -654,7 +656,7 @@ class TestOGXRAGGenerateStream:
         """Create a mock retriever."""
         mock = mocker.MagicMock()
         mock.retrieve.return_value = [
-            Document(page_content="Relevant document", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Relevant document", metadata={"document_id": "doc1"}),
         ]
         return mock
 
@@ -790,8 +792,8 @@ class TestOGXRAGIntegration:
         # Retriever
         retriever = mocker.MagicMock()
         retriever.retrieve.return_value = [
-            Document(
-                page_content="The answer to everything is 42.",
+            AI4RAGChunk(
+                text="The answer to everything is 42.",
                 metadata={"document_id": "doc1", "sequence_number": 1},
             ),
         ]
@@ -799,8 +801,8 @@ class TestOGXRAGIntegration:
         # Chunker
         chunker = mocker.MagicMock()
         chunker.split_documents.return_value = [
-            Document(
-                page_content="The answer to everything is 42.",
+            AI4RAGChunk(
+                text="The answer to everything is 42.",
                 metadata={"document_id": "doc1", "sequence_number": 1},
             ),
         ]
@@ -832,7 +834,7 @@ class TestOGXRAGIntegration:
 
         # Step 1: Build index
         documents = [
-            Document(page_content="The answer to everything is 42.", metadata={"document_id": "doc1"}),
+            _make_docling_doc("doc1", "The answer to everything is 42."),
         ]
         rag.build_index(documents)
 
@@ -863,7 +865,7 @@ class TestOGXRAGIntegration:
 
         # Build index once
         documents = [
-            Document(page_content="Test content", metadata={"document_id": "doc1"}),
+            _make_docling_doc("doc1", "Test content"),
         ]
         rag.build_index(documents)
 

--- a/tests/unit/ai4rag/rag/vector_store/test_chroma.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_chroma.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from langchain_core.documents import Document
 
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
 from ai4rag.rag.vector_store.chroma import ChromaVectorStore
 
@@ -116,80 +117,51 @@ class TestChromaVectorStoreDistanceMetric:
         assert "cosine" in str(exc_info.value) or "l2" in str(exc_info.value)
 
 
-class TestChromaVectorStoreAsLangchainDocuments:
-    """Test suite for ChromaVectorStore._as_langchain_documents method."""
+class TestChromaVectorStoreToLangchainDocuments:
+    """Test suite for ChromaVectorStore._to_langchain_documents method."""
 
     @pytest.fixture
     def mock_embedding_model(self):
         """Create a mock embedding model."""
         return MockEmbeddingModel(client=MagicMock(), model_id="test-embedding-model")
 
-    def test_as_langchain_documents_with_strings(self, mocker, mock_embedding_model):
-        """Test _as_langchain_documents with list of strings."""
+    def test_to_langchain_documents_basic(self, mocker, mock_embedding_model):
+        """Test _to_langchain_documents converts AI4RAGChunks to Documents."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["First document", "Second document", "Third document"]
-        result = vector_store._as_langchain_documents(content)
+        chunks = [
+            AI4RAGChunk(text="First document"),
+            AI4RAGChunk(text="Second document"),
+            AI4RAGChunk(text="Third document"),
+        ]
+        result = vector_store._to_langchain_documents(chunks)
         assert len(result) == 3
         assert all(isinstance(doc, Document) for doc in result)
         assert result[0].page_content == "First document"
         assert result[1].page_content == "Second document"
         assert result[2].page_content == "Third document"
 
-    def test_as_langchain_documents_with_dicts(self, mocker, mock_embedding_model):
-        """Test _as_langchain_documents with list of dicts."""
+    def test_to_langchain_documents_with_metadata(self, mocker, mock_embedding_model):
+        """Test _to_langchain_documents preserves metadata."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = [
-            {"content": "First doc", "metadata": {"id": 1}},
-            {"content": "Second doc", "metadata": {"id": 2}},
+        chunks = [
+            AI4RAGChunk(text="First doc", metadata={"id": 1}),
+            AI4RAGChunk(text="Second doc", metadata={"id": 2}),
         ]
-        result = vector_store._as_langchain_documents(content)
+        result = vector_store._to_langchain_documents(chunks)
         assert len(result) == 2
         assert result[0].page_content == "First doc"
         assert result[0].metadata == {"id": 1}
         assert result[1].page_content == "Second doc"
         assert result[1].metadata == {"id": 2}
 
-    def test_as_langchain_documents_with_documents(self, mocker, mock_embedding_model):
-        """Test _as_langchain_documents with list of Document objects."""
+    def test_to_langchain_documents_empty_list(self, mocker, mock_embedding_model):
+        """Test _to_langchain_documents with empty list."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = [
-            Document(page_content="Doc 1", metadata={"id": 1}),
-            Document(page_content="Doc 2", metadata={"id": 2}),
-        ]
-        result = vector_store._as_langchain_documents(content)
-        assert len(result) == 2
-        assert result[0].page_content == "Doc 1"
-        assert result[1].page_content == "Doc 2"
-
-    def test_as_langchain_documents_with_dict_missing_content(self, mocker, mock_embedding_model, caplog):
-        """Test _as_langchain_documents with dict missing content field."""
-        mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
-        vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = [{"metadata": {"id": 1}}]  # Missing "content" field
-        result = vector_store._as_langchain_documents(content)
+        result = vector_store._to_langchain_documents([])
         assert len(result) == 0
-        assert "Field 'content' is required" in caplog.text
-
-    def test_as_langchain_documents_with_dict_invalid_metadata(self, mocker, mock_embedding_model, caplog):
-        """Test _as_langchain_documents with dict having invalid metadata."""
-        mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
-        vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = [{"content": "Test", "metadata": "not a dict"}]  # Invalid metadata type
-        result = vector_store._as_langchain_documents(content)
-        assert len(result) == 0
-        assert "Metadata needs to be" in caplog.text
-
-    def test_as_langchain_documents_with_invalid_type(self, mocker, mock_embedding_model, caplog):
-        """Test _as_langchain_documents with invalid type."""
-        mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
-        vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = [123]  # Invalid type
-        result = vector_store._as_langchain_documents(content)
-        assert len(result) == 0
-        assert "not a dict, nor string, nor LangChain Document" in caplog.text
 
 
 class TestChromaVectorStoreProcessDocuments:
@@ -201,22 +173,22 @@ class TestChromaVectorStoreProcessDocuments:
         return MockEmbeddingModel(client=MagicMock(), model_id="test-embedding-model")
 
     def test_process_documents_basic(self, mocker, mock_embedding_model):
-        """Test _process_documents with basic documents."""
+        """Test _process_documents with basic AI4RAGChunks."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Doc 1", "Doc 2"]
-        ids, docs = vector_store._process_documents(content)
+        chunks = [AI4RAGChunk(text="Doc 1"), AI4RAGChunk(text="Doc 2")]
+        ids, docs = vector_store._process_documents(chunks)
         assert len(ids) == len(docs)
         assert len(ids) == 2
         assert all(isinstance(doc, Document) for doc in docs)
         assert all(isinstance(doc_id, str) for doc_id in ids)
 
     def test_process_documents_removes_duplicates(self, mocker, mock_embedding_model):
-        """Test _process_documents removes duplicate documents."""
+        """Test _process_documents removes duplicate chunks."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Same doc", "Same doc", "Different doc"]
-        ids, docs = vector_store._process_documents(content)
+        chunks = [AI4RAGChunk(text="Same doc"), AI4RAGChunk(text="Same doc"), AI4RAGChunk(text="Different doc")]
+        ids, docs = vector_store._process_documents(chunks)
         # Should have 2 unique documents
         assert len(ids) == 2
         assert len(docs) == 2
@@ -229,17 +201,6 @@ class TestChromaVectorStoreProcessDocuments:
         ids, docs = vector_store._process_documents([])
         assert ids == []
         assert docs == []
-
-    def test_process_documents_with_invalid_content(self, mocker, mock_embedding_model):
-        """Test _process_documents filters out invalid content."""
-        mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
-        vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Valid doc", {"invalid": "dict"}, 123]
-        ids, docs = vector_store._process_documents(content)
-        # Should only have the valid document
-        assert len(ids) == 1
-        assert len(docs) == 1
-        assert docs[0].page_content == "Valid doc"
 
 
 class TestChromaVectorStoreAddDocuments:
@@ -259,21 +220,24 @@ class TestChromaVectorStoreAddDocuments:
         return mock_client
 
     def test_add_documents_basic(self, mocker, mock_embedding_model, mock_chroma_client):
-        """Test add_documents with basic documents."""
+        """Test add_documents with AI4RAGChunks."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = [Document(page_content="Doc 1"), Document(page_content="Doc 2")]
-        result = vector_store.add_documents(content)
+        chunks = [AI4RAGChunk(text="Doc 1"), AI4RAGChunk(text="Doc 2")]
+        result = vector_store.add_documents(chunks)
         assert isinstance(result, list)
         assert len(result) == 2
         mock_chroma_client.add_documents.assert_called_once()
 
-    def test_add_documents_with_strings(self, mocker, mock_embedding_model, mock_chroma_client):
-        """Test add_documents with string content."""
+    def test_add_documents_with_metadata(self, mocker, mock_embedding_model, mock_chroma_client):
+        """Test add_documents with AI4RAGChunks carrying metadata."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Doc 1", "Doc 2"]
-        result = vector_store.add_documents(content)
+        chunks = [
+            AI4RAGChunk(text="Doc 1", metadata={"source": "a"}),
+            AI4RAGChunk(text="Doc 2", metadata={"source": "b"}),
+        ]
+        result = vector_store.add_documents(chunks)
         assert isinstance(result, list)
         mock_chroma_client.add_documents.assert_called_once()
 
@@ -284,8 +248,8 @@ class TestChromaVectorStoreAddDocuments:
         mock_client.add_documents.return_value = ["id1", "id2"]
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Doc 1", "Doc 2", "Doc 3", "Doc 4", "Doc 5"]
-        result = vector_store.add_documents(content, max_batch_size=2)
+        chunks = [AI4RAGChunk(text=f"Doc {i}") for i in range(5)]
+        result = vector_store.add_documents(chunks, max_batch_size=2)
         # Should be called multiple times due to batching
         assert mock_client.add_documents.call_count >= 2
         assert isinstance(result, list)
@@ -294,8 +258,8 @@ class TestChromaVectorStoreAddDocuments:
         """Test add_documents with custom max_batch_size."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Doc 1", "Doc 2", "Doc 3"]
-        result = vector_store.add_documents(content, max_batch_size=2)
+        chunks = [AI4RAGChunk(text=f"Doc {i}") for i in range(3)]
+        result = vector_store.add_documents(chunks, max_batch_size=2)
         # Should be called multiple times due to custom batch size
         assert mock_chroma_client.add_documents.call_count >= 2
         assert isinstance(result, list)
@@ -307,8 +271,8 @@ class TestChromaVectorStoreAddDocuments:
         mock_client.add_documents.return_value = ["id1"]
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        content = ["Doc 1"]
-        result = vector_store.add_documents(content)
+        chunks = [AI4RAGChunk(text="Doc 1")]
+        result = vector_store.add_documents(chunks)
         # Should use default max_batch_size of 2048
         assert isinstance(result, list)
         mock_client.add_documents.assert_called_once()
@@ -332,17 +296,18 @@ class TestChromaVectorStoreSearch:
         return mock_client
 
     def test_search_basic(self, mocker, mock_embedding_model, mock_chroma_client):
-        """Test basic search without scores."""
+        """Test basic search without scores returns AI4RAGChunks."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
         result = vector_store.search("test query", k=5)
         assert isinstance(result, list)
         assert len(result) > 0
-        assert isinstance(result[0], Document)
+        assert isinstance(result[0], AI4RAGChunk)
+        assert result[0].text == "Test document"
         mock_chroma_client.similarity_search.assert_called_once_with("test query", k=5)
 
     def test_search_with_scores(self, mocker, mock_embedding_model, mock_chroma_client):
-        """Test search with scores."""
+        """Test search with scores returns AI4RAGChunk tuples."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_chroma_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
         result = vector_store.search("test query", k=5, include_scores=True)
@@ -350,7 +315,8 @@ class TestChromaVectorStoreSearch:
         assert len(result) > 0
         assert isinstance(result[0], tuple)
         assert len(result[0]) == 2
-        assert isinstance(result[0][0], Document)
+        assert isinstance(result[0][0], AI4RAGChunk)
+        assert result[0][0].text == "Test document"
         assert isinstance(result[0][1], float)
         mock_chroma_client.similarity_search_with_score.assert_called_once_with("test query", k=5)
 
@@ -402,7 +368,7 @@ class TestChromaVectorStoreWindowSearch:
         mock_chroma_client.similarity_search.assert_called_once()
 
     def test_window_search_without_scores(self, mocker, mock_embedding_model):
-        """Test window_search without scores."""
+        """Test window_search without scores returns AI4RAGChunks."""
         mock_client = MagicMock()
         mock_doc = Document(
             page_content="Test document",
@@ -422,10 +388,10 @@ class TestChromaVectorStoreWindowSearch:
         result = vector_store.window_search("test query", k=5, window_size=1, include_scores=False)
         assert isinstance(result, list)
         assert len(result) > 0
-        assert isinstance(result[0], Document)
+        assert isinstance(result[0], AI4RAGChunk)
 
     def test_window_search_with_scores(self, mocker, mock_embedding_model):
-        """Test window_search with scores."""
+        """Test window_search with scores returns AI4RAGChunk tuples."""
         mock_client = MagicMock()
         mock_doc = Document(
             page_content="Test document",
@@ -446,6 +412,7 @@ class TestChromaVectorStoreWindowSearch:
         assert isinstance(result, list)
         assert len(result) > 0
         assert isinstance(result[0], tuple)
+        assert isinstance(result[0][0], AI4RAGChunk)
         assert isinstance(result[0][1], float)
 
 
@@ -461,22 +428,22 @@ class TestChromaVectorStoreWindowExtendAndMerge:
         """Test _window_extend_and_merge raises ValueError when document_id is missing."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        document = Document(page_content="Test", metadata={"sequence_number": 1})
+        chunk = AI4RAGChunk(text="Test", metadata={"sequence_number": 1})
         with pytest.raises(ValueError) as exc_info:
-            vector_store._window_extend_and_merge(document, window_size=2)
+            vector_store._window_extend_and_merge(chunk, window_size=2)
         assert "document_id" in str(exc_info.value)
 
     def test_window_extend_and_merge_missing_sequence_number(self, mocker, mock_embedding_model):
         """Test _window_extend_and_merge raises ValueError when sequence_number is missing."""
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=MagicMock())
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        document = Document(page_content="Test", metadata={"document_id": "doc1"})
+        chunk = AI4RAGChunk(text="Test", metadata={"document_id": "doc1"})
         with pytest.raises(ValueError) as exc_info:
-            vector_store._window_extend_and_merge(document, window_size=2)
+            vector_store._window_extend_and_merge(chunk, window_size=2)
         assert "sequence_number" in str(exc_info.value)
 
     def test_window_extend_and_merge_basic(self, mocker, mock_embedding_model):
-        """Test _window_extend_and_merge with basic document."""
+        """Test _window_extend_and_merge with basic chunk."""
         mock_client = MagicMock()
         mock_client.get.return_value = {
             "documents": ["Chunk 1", "Chunk 2", "Chunk 3"],
@@ -488,13 +455,13 @@ class TestChromaVectorStoreWindowExtendAndMerge:
         }
         mocker.patch("ai4rag.rag.vector_store.chroma.Chroma", return_value=mock_client)
         vector_store = ChromaVectorStore(embedding_model=mock_embedding_model)
-        document = Document(
-            page_content="Chunk 2",
+        chunk = AI4RAGChunk(
+            text="Chunk 2",
             metadata={"document_id": "doc1", "sequence_number": 2},
         )
-        result = vector_store._window_extend_and_merge(document, window_size=1)
-        assert isinstance(result, Document)
-        assert "Chunk" in result.page_content  # Should contain merged content
+        result = vector_store._window_extend_and_merge(chunk, window_size=1)
+        assert isinstance(result, AI4RAGChunk)
+        assert "Chunk" in result.text  # Should contain merged content
 
 
 class TestChromaVectorStoreGetWindowDocuments:

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -2,12 +2,12 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from unittest.mock import MagicMock
 import logging
+from unittest.mock import MagicMock
 
 import pytest
-from ai4rag.rag.chunking.chunk import AI4RAGChunk
 
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
 from ai4rag.rag.vector_store.ogx import OGXVectorStore
 

--- a/tests/unit/ai4rag/rag/vector_store/test_ogx.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_ogx.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import logging
 
 import pytest
-from langchain_core.documents import Document
+from ai4rag.rag.chunking.chunk import AI4RAGChunk
 
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
 from ai4rag.rag.vector_store.ogx import OGXVectorStore
@@ -178,8 +178,8 @@ class TestOGXVectorStoreSearch:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        assert isinstance(result[0], Document)
-        assert result[0].page_content == "Test content"
+        assert isinstance(result[0], AI4RAGChunk)
+        assert result[0].text == "Test content"
         assert result[0].metadata == {"doc_id": "doc1", "seq": 1}
 
     def test_search_with_scores(self, mock_embedding_model, mock_ogx_client):
@@ -196,7 +196,7 @@ class TestOGXVectorStoreSearch:
         assert len(result) == 1
         assert isinstance(result[0], tuple)
         assert len(result[0]) == 2
-        assert isinstance(result[0][0], Document)
+        assert isinstance(result[0][0], AI4RAGChunk)
         assert isinstance(result[0][1], float)
         assert result[0][1] == 0.95
 
@@ -248,7 +248,7 @@ class TestOGXVectorStoreSearch:
 
         assert len(result) == 3
         for i, (doc, score) in enumerate(result):
-            assert doc.page_content == f"Content {i}"
+            assert doc.text == f"Content {i}"
             assert score == 0.9 - i * 0.1
 
 
@@ -414,8 +414,8 @@ class TestOGXVectorStoreAddDocuments:
         )
 
         docs = [
-            Document(page_content="Doc 1", metadata={"document_id": "doc1"}),
-            Document(page_content="Doc 2", metadata={"document_id": "doc2"}),
+            AI4RAGChunk(text="Doc 1", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Doc 2", metadata={"document_id": "doc2"}),
         ]
 
         vector_store.add_documents(docs)
@@ -430,7 +430,7 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [Document(page_content="Test", metadata={"document_id": "doc1"})]
+        docs = [AI4RAGChunk(text="Test", metadata={"document_id": "doc1"})]
 
         vector_store.add_documents(docs)
 
@@ -441,7 +441,7 @@ class TestOGXVectorStoreAddDocuments:
         assert "content" in chunks[0]
         assert "embedding" in chunks[0]
         assert "chunk_id" in chunks[0]
-        assert chunks[0]["chunk_id"] == str(hash(docs[0].page_content))
+        assert chunks[0]["chunk_id"] == str(hash(docs[0].text))
         assert chunks[0]["chunk_metadata"] == {"document_id": "doc1"}
         assert chunks[0]["metadata"] == {"document_id": "doc1"}
 
@@ -453,7 +453,7 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
+        docs = [AI4RAGChunk(text=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
 
         vector_store.add_documents(docs)
 
@@ -471,8 +471,8 @@ class TestOGXVectorStoreAddDocuments:
         )
 
         docs = [
-            Document(
-                page_content="Test",
+            AI4RAGChunk(
+                text="Test",
                 metadata={"document_id": "doc1", "custom_field": "value"},
             )
         ]
@@ -497,7 +497,7 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [Document(page_content="Test", metadata={"document_id": "doc1"})]
+        docs = [AI4RAGChunk(text="Test", metadata={"document_id": "doc1"})]
 
         vector_store.add_documents(docs)
 
@@ -511,7 +511,7 @@ class TestOGXVectorStoreAddDocuments:
             provider_id="milvus",
         )
 
-        docs = [Document(page_content=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
+        docs = [AI4RAGChunk(text=f"Doc {i}", metadata={"document_id": f"doc{i}"}) for i in range(5)]
 
         vector_store.add_documents(docs, batch_size=2)
 
@@ -759,9 +759,9 @@ class TestOGXVectorStoreDuplicateChunks:
 
         # Create documents with identical content (will generate same hash)
         docs = [
-            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
-            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
-            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc1"}),
         ]
 
         with caplog.at_level(logging.WARNING, logger="ai4rag"):
@@ -784,9 +784,9 @@ class TestOGXVectorStoreDuplicateChunks:
         )
 
         docs = [
-            Document(page_content="Unique content 1", metadata={"document_id": "doc1"}),
-            Document(page_content="Unique content 2", metadata={"document_id": "doc2"}),
-            Document(page_content="Unique content 3", metadata={"document_id": "doc3"}),
+            AI4RAGChunk(text="Unique content 1", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Unique content 2", metadata={"document_id": "doc2"}),
+            AI4RAGChunk(text="Unique content 3", metadata={"document_id": "doc3"}),
         ]
 
         # Should not raise an error
@@ -808,9 +808,9 @@ class TestOGXVectorStoreDuplicateChunks:
         )
 
         docs = [
-            Document(page_content="Unique content", metadata={"document_id": "doc1"}),
-            Document(page_content="Duplicate content", metadata={"document_id": "doc2"}),
-            Document(page_content="Duplicate content", metadata={"document_id": "doc2"}),
+            AI4RAGChunk(text="Unique content", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc2"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc2"}),
         ]
 
         with caplog.at_level(logging.WARNING, logger="ai4rag"):
@@ -833,8 +833,8 @@ class TestOGXVectorStoreDuplicateChunks:
         )
 
         docs = [
-            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
-            Document(page_content="Duplicate content", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Duplicate content", metadata={"document_id": "doc1"}),
         ]
 
         vector_store.add_documents(docs)
@@ -855,8 +855,8 @@ class TestOGXVectorStoreDuplicateChunks:
         )
 
         docs = [
-            Document(page_content="Not unique 1", metadata={"document_id": "doc1"}),
-            Document(page_content="Not unique 1", metadata={"document_id": "doc2"}),
+            AI4RAGChunk(text="Not unique 1", metadata={"document_id": "doc1"}),
+            AI4RAGChunk(text="Not unique 1", metadata={"document_id": "doc2"}),
         ]
 
         with caplog.at_level(logging.WARNING, logger="ai4rag"):

--- a/tests/unit/ai4rag/search_space/src/test_search_space.py
+++ b/tests/unit/ai4rag/search_space/src/test_search_space.py
@@ -11,6 +11,7 @@ from ai4rag.search_space.src.search_space import (
     SearchSpace,
     SearchSpaceValueError,
     _rule_adjust_window_to_retrieval_method,
+    _rule_chunk_overlap_for_chunking_method,
     _rule_chunk_size_bigger_than_chunk_overlap,
     _rule_chunk_size_within_embedding_context_length,
     _rule_ranker_alpha_for_weighted_only,
@@ -43,6 +44,26 @@ def test_rule_chunk_size_bigger_than_chunk_overlap_returns(combination, expected
 def test_rule_chunk_size_bigger_than_chunk_overlap_raises():
     with pytest.raises(SearchSpaceValueError):
         _ = _rule_chunk_size_bigger_than_chunk_overlap({"chunk_size": 512})
+
+
+@pytest.mark.parametrize(
+    "combination, expected_value",
+    (
+        ({"chunking_method": "hybrid", "chunk_overlap": 0}, True),
+        ({"chunking_method": "hybrid", "chunk_overlap": 128}, False),
+        ({"chunking_method": "recursive", "chunk_overlap": 128}, True),
+        ({"chunking_method": "recursive", "chunk_overlap": 0}, False),
+    ),
+)
+def test_rule_chunk_overlap_for_chunking_method(combination, expected_value):
+    val = _rule_chunk_overlap_for_chunking_method(combination)
+    assert val == expected_value
+
+
+def test_rule_chunk_overlap_for_chunking_method_missing_fields():
+    assert _rule_chunk_overlap_for_chunking_method({"chunking_method": "recursive"}) is True
+    assert _rule_chunk_overlap_for_chunking_method({"chunk_overlap": 0}) is True
+    assert _rule_chunk_overlap_for_chunking_method({}) is True
 
 
 @pytest.mark.parametrize(
@@ -81,29 +102,36 @@ class _MockEmbeddingModelWithDictParams:
 @pytest.mark.parametrize(
     "combination, expected_value",
     (
-        # chunk_size=512 → estimated_tokens = 512 / 4 = 128, context=256 → True
+        # chunk_size in tokens, 10% safety margin: chunk_size <= context_length * 0.9
+        (
+            {
+                "chunk_size": 128,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            True,
+        ),
         (
             {
                 "chunk_size": 512,
                 "embedding_model": _MockEmbeddingModelWithParams(256),
             },
+            False,
+        ),
+        # exact boundary: chunk_size == context_length → False (exceeds 90% margin)
+        (
+            {
+                "chunk_size": 256,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
+            False,
+        ),
+        # within margin: chunk_size <= context_length * 0.9 → True
+        (
+            {
+                "chunk_size": 230,
+                "embedding_model": _MockEmbeddingModelWithParams(256),
+            },
             True,
-        ),
-        # chunk_size=2048 → estimated_tokens = 2048 / 4 = 512, context=256 → False
-        (
-            {
-                "chunk_size": 2048,
-                "embedding_model": _MockEmbeddingModelWithParams(256),
-            },
-            False,
-        ),
-        # Exact boundary: chunk_size=1024 → estimated_tokens = 256, context=256 → True
-        (
-            {
-                "chunk_size": 1024,
-                "embedding_model": _MockEmbeddingModelWithParams(256),
-            },
-            False,
         ),
     ),
 )

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ wheels = [
 name = "ai4rag"
 source = { editable = "." }
 dependencies = [
+    { name = "docling-core", extra = ["chunking-openai"] },
     { name = "langchain" },
     { name = "langchain-chroma" },
     { name = "langchain-text-splitters" },
@@ -89,6 +90,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'code-check'" },
     { name = "docling", marker = "extra == 'dev'" },
+    { name = "docling-core", extras = ["chunking-openai"] },
     { name = "dotenv", marker = "extra == 'dev'" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'code-check'" },
@@ -810,6 +812,15 @@ wheels = [
 chunking = [
     { name = "semchunk" },
     { name = "transformers" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
+    { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-python" },
+    { name = "tree-sitter-typescript" },
+]
+chunking-openai = [
+    { name = "semchunk" },
+    { name = "tiktoken" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-javascript" },
@@ -3998,6 +4009,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'code-check'" },
     { name = "docling", marker = "extra == 'dev'" },
-    { name = "docling-core", extras = ["chunking-openai"] },
+    { name = "docling-core", extras = ["chunking-openai"], specifier = "~=2.74.1" },
     { name = "dotenv", marker = "extra == 'dev'" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'code-check'" },

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 name = "ai4rag"
 source = { editable = "." }
 dependencies = [
-    { name = "docling-core", extra = ["chunking-openai"] },
+    { name = "docling-core", extra = ["chunking", "chunking-openai"] },
     { name = "langchain" },
     { name = "langchain-chroma" },
     { name = "langchain-text-splitters" },
@@ -90,7 +90,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'code-check'" },
     { name = "docling", marker = "extra == 'dev'" },
-    { name = "docling-core", extras = ["chunking-openai"], specifier = "~=2.74.1" },
+    { name = "docling-core", extras = ["chunking", "chunking-openai"], specifier = "~=2.74.1" },
     { name = "dotenv", marker = "extra == 'dev'" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'code-check'" },


### PR DESCRIPTION
Assisted-by: Claude Code

## Description
Introduces `DoclingChunker` — a structure-aware, token-bounded chunker wrapping docling's `HybridChunker` — and migrates the entire pipeline from langchain's `Document` to `DoclingDocument` (input) and `AI4RAGChunk` (internal chunk representation).

## Motivation
The pipeline previously relied on langchain's `Document` as the universal data carrier, which discarded document structure (headings, tables, figures) during ingestion. By adopting `DoclingDocument` as the input type and introducing a framework-agnostic `AI4RAGChunk` dataclass, the pipeline can now:

- Preserve document hierarchy during chunking via the new `DoclingChunker` (uses docling's `HybridChunker` under the hood).
- Decouple the internal chunk representation from langchain, making it easier to swap or add chunking/vector-store backends.
- Express chunk sizes in **tokens** (via tiktoken) rather than characters, aligning chunk budgets with embedding model context windows.

## Changes

### New modules
- **`ai4rag/rag/chunking/chunk.py`** — `AI4RAGChunk` frozen dataclass (`text`, `metadata`) used across the pipeline.
- **`ai4rag/rag/chunking/docling_chunker.py`** — `DoclingChunker` wrapping `HybridChunker` with token-aware splitting, heading contextualization, and peer merging.

### Pipeline migration (`Document` -> `DoclingDocument` / `AI4RAGChunk`)
- **`BaseChunker`** — removed `Generic[ChunkT]`; input is now `Sequence[DoclingDocument]`, output is `list[AI4RAGChunk]`.
- **`LangChainChunker`** — accepts `DoclingDocument`, converts to markdown internally, uses tiktoken-based `length_function` instead of `len`, and returns `AI4RAGChunk`.
- **`BaseVectorStore` / `ChromaVectorStore` / `OGXVectorStore`** — `add_documents` and `search` operate on `AI4RAGChunk`; Chroma converts to/from langchain `Document` at the boundary.
- **`Retriever`** — returns `list[AI4RAGChunk]`.
- **`SimpleRAG`** — type-widened to `BaseChunker` / `BaseVectorStore`; accesses `chunk.text` instead of `doc.page_content`.
- **`AI4RAGExperiment` / `ModelsPreSelector`** — accept `list[DoclingDocument]`; route `"hybrid"` chunking method to `DoclingChunker`.
- **`FileStore` (dev_utils)** — returns `list[DoclingDocument]` directly; adds JSON caching layer for converted documents.

### Search space & constraints
- Added `"hybrid"` to default chunking methods; added `512` to chunk sizes and `0` to chunk overlaps.
- New rule `_rule_chunk_overlap_for_chunking_method` — enforces overlap=0 for hybrid, overlap>0 for recursive.
- `_rule_chunk_size_within_embedding_context_length` — simplified to direct token comparison with 10% safety margin (no more chars-to-tokens heuristic).
- `ChunkingConstraints.MIN_CHUNK_OVERLAP` lowered to `0`; `METHODS` updated to `["recursive", "hybrid"]`.

### Miscellaneous
- `OGXEmbeddingModel._BATCH_SIZE` extracted as class constant (was hardcoded `2048`, now `1024`).
- `docling-core[chunking-openai]~=2.74.1` added to `pyproject.toml` dependencies.

## Testing
- New test suite: `tests/unit/ai4rag/rag/chunking/test_docling_chunker.py` — covers initialization, splitting, serialization, and equality.
- All existing test suites updated to use `DoclingDocument` fixtures and assert on `AI4RAGChunk` outputs.
- New tests for `_rule_chunk_overlap_for_chunking_method` search space rule.
- Updated `_rule_chunk_size_within_embedding_context_length` test parameters to reflect token-based comparison.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Code follows style guide
- [ ] All checks passing
