### PR TITLE
feat(search_space): Introduce minimal required context_length for embedding models (700 tokens)

### DIFF
--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -13,6 +13,9 @@ from .base_model import BaseEmbeddingModel
 __all__ = ["OGXEmbeddingModel", "OGXEmbeddingParams"]
 
 
+MIN_CONTEXT_LENGTH = 700
+
+
 @dataclass
 class OGXEmbeddingParams:
     """OGX parameters to be used to create embeddings."""
@@ -40,7 +43,7 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
 
     @params.setter
     def params(self, params: dict | OGXEmbeddingParams | None) -> None:
-        """Set model params."""
+        """Set model params and validate context length."""
         if params is None:
             self._params = OGXEmbeddingParams()
         elif isinstance(params, OGXEmbeddingParams):
@@ -53,6 +56,12 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
             self._params.embedding_dimension = self._detect_embedding_dimension()
         if self._params.context_length is None:
             self._params.context_length = self._detect_context_length()
+
+        if self._params.context_length < MIN_CONTEXT_LENGTH:
+            raise ValueError(
+                f"Embedding model {self.model_id} supports `context_length` {self._params.context_length}. "
+                f"Minimal required value is {MIN_CONTEXT_LENGTH}. Use embedding model with greater `context_length`."
+            )
 
     def _detect_embedding_dimension(self) -> int:
         """Detect embedding dimension by making a minimal embedding call.

--- a/ai4rag/utils/constants.py
+++ b/ai4rag/utils/constants.py
@@ -7,17 +7,11 @@ from typing import Any
 __all__ = [
     "ConstantMeta",
     "AI4RAGParamNames",
-    "GenerationConstants",
     "ChunkingConstraints",
     "ExperimentStep",
     "RetrievalConstraints",
-    "SearchSpaceValidationErrors",
-    "DEFAULT_WORD_TO_TOKEN_RATIO",
     "ChatGenerationConstants",
-    "DefaultVectorStoreFieldNames",
 ]
-
-DEFAULT_WORD_TO_TOKEN_RATIO = 1.5
 
 
 class ConstantMeta(type):
@@ -101,14 +95,6 @@ class ExperimentStep(metaclass=ConstantMeta):
     EVALUATION = "evaluation"
 
 
-class GenerationConstants(metaclass=ConstantMeta):
-    """Constants used for setting the generation (inference) parameters."""
-
-    MAX_NEW_TOKENS = 1000
-    MIN_NEW_TOKENS = 1
-    DECODING_METHOD = "greedy"
-
-
 class ChatGenerationConstants(metaclass=ConstantMeta):
     """Constants used for setting the generation (inference) parameters for chat models only."""
 
@@ -119,10 +105,10 @@ class ChatGenerationConstants(metaclass=ConstantMeta):
 class ChunkingConstraints(metaclass=ConstantMeta):
     """Constants used to define chunking constraints on what below parameters can be."""
 
-    MIN_CHUNK_SIZE = 128
+    MIN_CHUNK_SIZE = 512
     MAX_CHUNK_SIZE = 2048
     MIN_CHUNK_OVERLAP = 0
-    MAX_CHUNK_OVERLAP = 512
+    MAX_CHUNK_OVERLAP = 256
     METHODS = ["recursive", "hybrid"]
 
 
@@ -138,29 +124,3 @@ class RetrievalConstraints(metaclass=ConstantMeta):
     RANKER_STRATEGIES = ["rrf", "weighted", "normalized"]
     MIN_RANKER_K = 1
     MAX_RANKER_K = 100
-
-
-class DefaultVectorStoreFieldNames(metaclass=ConstantMeta):
-    """Constants used as field names during index building for Milvus and Elasticsearch"""
-
-    CHUNK_SEQUENCE_NUMBER_FIELD = "sequence_number"
-    DENSE_EMBEDDINGS_FIELD = "vector"
-    SPARSE_EMBEDDINGS_FIELD = "sparse_embeddings"
-    MILVUS_TEXT_FIELD = "text"
-    ELASTICSEARCH_TEXT_FIELD = "text_field"
-    METADATA_DOCUMENT_NAME_FIELD = "document_id"
-
-
-class SearchSpaceValidationErrors(metaclass=ConstantMeta):
-    """Constants used to define payload validation errors."""
-
-    UNEXPECTED_KEYWORD_ARGUMENT = "unexpected_keyword_argument"
-    LITERAL_ERROR = "literal_error"
-    TOO_SHORT = "too_short"
-    TOO_LONG = "too_long"
-    LESS_THAN_EQUAL = "less_than_equal"
-    GREATER_THAN_EQUAL = "greater_than_equal"
-    INT_FROM_FLOAT = "int_from_float"
-    INT_PARSING = "int_parsing"
-    INT_TYPE = "int_type"
-    LIST_TYPE = "list_type"

--- a/tests/unit/ai4rag/rag/embedding/test_ogx.py
+++ b/tests/unit/ai4rag/rag/embedding/test_ogx.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from ai4rag.rag.embedding.ogx import OGXEmbeddingModel, OGXEmbeddingParams
+from ai4rag.rag.embedding.ogx import MIN_CONTEXT_LENGTH, OGXEmbeddingModel, OGXEmbeddingParams
 
 
 def _make_mock_ogx_embedding_response(mocker, embeddings):
@@ -31,11 +31,11 @@ class TestOGXEmbeddingModel:
 
     def test_init_with_explicit_dimension(self, mock_ogx_client):
         """Test initialization with explicit embedding_dimension and context_length does not trigger auto-detection."""
-        params = OGXEmbeddingParams(embedding_dimension=768, context_length=512)
+        params = OGXEmbeddingParams(embedding_dimension=768, context_length=1024)
         model = OGXEmbeddingModel(client=mock_ogx_client, model_id="all-MiniLM-L6-v2", params=params)
 
         assert model.params.embedding_dimension == 768
-        assert model.params.context_length == 512
+        assert model.params.context_length == 1024
         mock_ogx_client.embeddings.create.assert_not_called()
 
     def test_init_with_dict_params_with_dimension(self, mock_ogx_client):
@@ -43,11 +43,11 @@ class TestOGXEmbeddingModel:
         model = OGXEmbeddingModel(
             client=mock_ogx_client,
             model_id="all-MiniLM-L6-v2",
-            params={"embedding_dimension": 384, "context_length": 512},
+            params={"embedding_dimension": 384, "context_length": 1024},
         )
 
         assert model.params.embedding_dimension == 384
-        assert model.params.context_length == 512
+        assert model.params.context_length == 1024
         mock_ogx_client.embeddings.create.assert_not_called()
 
     def test_init_without_params_auto_detects_dimension(self, mock_ogx_client):
@@ -157,7 +157,7 @@ class TestOGXEmbeddingModel:
         model = OGXEmbeddingModel(
             client=mock_ogx_client,
             model_id="all-MiniLM-L6-v2",
-            params=OGXEmbeddingParams(embedding_dimension=3, context_length=512),
+            params=OGXEmbeddingParams(embedding_dimension=3, context_length=1024),
         )
         mock_ogx_client.embeddings.create.return_value = _make_mock_ogx_embedding_response(
             mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
@@ -174,7 +174,7 @@ class TestOGXEmbeddingModel:
         model = OGXEmbeddingModel(
             client=mock_ogx_client,
             model_id="all-MiniLM-L6-v2",
-            params=OGXEmbeddingParams(embedding_dimension=3, context_length=512),
+            params=OGXEmbeddingParams(embedding_dimension=3, context_length=1024),
         )
 
         batch_size = OGXEmbeddingModel._BATCH_SIZE
@@ -197,7 +197,7 @@ class TestOGXEmbeddingModel:
         model = OGXEmbeddingModel(
             client=mock_ogx_client,
             model_id="all-MiniLM-L6-v2",
-            params=OGXEmbeddingParams(embedding_dimension=3, context_length=512),
+            params=OGXEmbeddingParams(embedding_dimension=3, context_length=1024),
         )
         mock_ogx_client.embeddings.create.return_value = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3]])
 
@@ -205,12 +205,68 @@ class TestOGXEmbeddingModel:
 
         assert embedding == [0.1, 0.2, 0.3]
 
+    def test_explicit_context_length_below_minimum_raises(self, mock_ogx_client):
+        """Test that explicit context_length below MIN_CONTEXT_LENGTH raises ValueError."""
+        params = OGXEmbeddingParams(embedding_dimension=384, context_length=MIN_CONTEXT_LENGTH - 1)
+        with pytest.raises(ValueError, match="Minimal required value is"):
+            OGXEmbeddingModel(client=mock_ogx_client, model_id="small-ctx-model", params=params)
+
+    def test_explicit_context_length_at_minimum_succeeds(self, mock_ogx_client):
+        """Test that context_length exactly at MIN_CONTEXT_LENGTH is accepted."""
+        params = OGXEmbeddingParams(embedding_dimension=384, context_length=MIN_CONTEXT_LENGTH)
+        model = OGXEmbeddingModel(client=mock_ogx_client, model_id="boundary-model", params=params)
+
+        assert model.params.context_length == MIN_CONTEXT_LENGTH
+
+    def test_dict_params_context_length_below_minimum_raises(self, mock_ogx_client):
+        """Test that dict params with context_length below minimum raises ValueError."""
+        with pytest.raises(ValueError, match="Minimal required value is"):
+            OGXEmbeddingModel(
+                client=mock_ogx_client,
+                model_id="small-ctx-model",
+                params={"embedding_dimension": 384, "context_length": 200},
+            )
+
+    def test_auto_detected_context_length_below_minimum_raises(self, mocker):
+        """Test that auto-detected context_length below MIN_CONTEXT_LENGTH raises ValueError."""
+        mock_client = mocker.MagicMock()
+        dim_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+
+        call_count = [0]
+
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return dim_response
+            text = kwargs.get("input", "")
+            if isinstance(text, str) and len(text) > 500 * 5:
+                raise ValueError("Input too long")
+            return dim_response
+
+        mock_client.embeddings.create.side_effect = side_effect
+
+        with pytest.raises(ValueError, match="Minimal required value is"):
+            OGXEmbeddingModel(client=mock_client, model_id="tiny-ctx-model", params=None)
+
+    def test_context_length_error_message_contains_model_id_and_values(self, mock_ogx_client):
+        """Test that the ValueError message includes model_id, actual value, and minimum."""
+        ctx_len = 300
+        model_id = "test-model-xyz"
+        params = OGXEmbeddingParams(embedding_dimension=384, context_length=ctx_len)
+
+        with pytest.raises(ValueError, match=model_id) as exc_info:
+            OGXEmbeddingModel(client=mock_ogx_client, model_id=model_id, params=params)
+
+        message = str(exc_info.value)
+        assert str(ctx_len) in message
+        assert str(MIN_CONTEXT_LENGTH) in message
+
     def test_model_repr(self, mock_ogx_client):
         """Test string representation."""
         model = OGXEmbeddingModel(
             client=mock_ogx_client,
             model_id="all-MiniLM-L6-v2",
-            params=OGXEmbeddingParams(embedding_dimension=384, context_length=512),
+            params=OGXEmbeddingParams(embedding_dimension=384, context_length=1024),
         )
 
         assert repr(model) == "all-MiniLM-L6-v2"

--- a/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_ogx_utils.py
@@ -59,7 +59,7 @@ class TestValidateEmbeddingModel:
         model = OGXEmbeddingModel(
             model_id="test-model",
             client=mock_client,
-            params=OGXEmbeddingParams(embedding_dimension=768, context_length=512),
+            params=OGXEmbeddingParams(embedding_dimension=768, context_length=1024),
         )
 
         result = _validate_embedding_model(model)
@@ -73,7 +73,7 @@ class TestValidateEmbeddingModel:
         model = OGXEmbeddingModel(
             model_id="test-model",
             client=mock_client,
-            params=OGXEmbeddingParams(embedding_dimension=768, context_length=512),
+            params=OGXEmbeddingParams(embedding_dimension=768, context_length=1024),
         )
 
         mock_client.embeddings.create.side_effect = Exception("Model error")
@@ -168,7 +168,7 @@ class TestValidateAvailabilityAndCreateModels:
         m.custom_metadata = {"model_type": "llm"}
         return m
 
-    def _make_emb_registry_mock(self, model_id: str, dim: int = 768, ctx: int = 512) -> Mock:
+    def _make_emb_registry_mock(self, model_id: str, dim: int = 768, ctx: int = 1024) -> Mock:
         m = Mock()
         m.id = model_id
         m.custom_metadata = {"model_type": "embedding", "embedding_dimension": dim, "context_length": ctx}
@@ -194,7 +194,7 @@ class TestValidateAvailabilityAndCreateModels:
     def test_returns_embedding_instances_for_valid_models(self, mocker):
         """Returns OGXEmbeddingModel instances for each valid embedding model."""
         mock_client = MagicMock()
-        registered = [self._make_emb_registry_mock("emb-1", dim=768, ctx=512)]
+        registered = [self._make_emb_registry_mock("emb-1", dim=768, ctx=1024)]
         mocker.patch("ai4rag.search_space.prepare.ogx_utils._validate_embedding_model", return_value=True)
 
         result = _validate_availability_and_create_models(

--- a/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
@@ -317,12 +317,12 @@ class TestPrepareSearchSpaceWithOgx:
 
         mock_emb_ok = Mock()
         mock_emb_ok.id = "emb-ok"
-        mock_emb_ok.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_emb_ok.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 1024}
         mock_emb_ok.metadata = {}
 
         mock_emb_bad = Mock()
         mock_emb_bad.id = "emb-bad"
-        mock_emb_bad.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 512}
+        mock_emb_bad.custom_metadata = {"model_type": "embedding", "embedding_dimension": 768, "context_length": 1024}
         mock_emb_bad.metadata = {}
 
         mock_client.models.list.return_value.data = [mock_llm, mock_emb_ok, mock_emb_bad]


### PR DESCRIPTION
## Description
Added validation of minimal required context_length for embedding models to make sure experiments will not fail on minial chunk sizes.

## Motivation
Some embedding models support very small context length (e.g. 256 tokens). Such models will keep on failing in ai4rag experiments, as minimal supported chunk size is 512 tokens.

## Changes
- Remove constant artifacts that are no longer valid and used
- Introduce check for embedding model context_length
- Update tests and test new check

## Testing
Via unit tests

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
