### PR TITLE
Release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ It accepts a variety of RAG Templates and a search space definition, then return
 
 ai4RAG can run experiments using an [OGX](https://github.com/ogx-ai/ogx) server for embeddings, vector storage, and text generation. Use the official client and API docs to connect and extend:
 
-- **Client:** [ogx-client](https://pypi.org/project/ogx-client/) >= 0.7.0 (Python package used by ai4RAG; installs with this project).
-- **Server:** [OGX](https://github.com/ogx-ai/ogx) >= 0.7.0.
+- **Client:** [ogx-client](https://pypi.org/project/ogx-client/) >= 1.0.0 (Python package used by ai4RAG; installs with this project).
+- **Server:** [OGX](https://github.com/ogx-ai/ogx) >= 1.0.0.
 - **API reference:** [OGX API docs](https://ogx-ai.github.io/docs/) — HTTP API used by the client.
 
 **Features used by ai4rag**
@@ -48,6 +48,10 @@ When using the OGX backend, ai4rag relies on:
 - **Vector stores** — Create, retrieve, and delete vector store instances (e.g. Milvus) with a chosen embedding model and dimension. See [Vector stores](https://ogx-ai.github.io/docs/api/creates-a-vector-store) in the API docs.
 - **Vector IO** — Insert document chunks (with embeddings) into a store and run similarity search (query) for retrieval. See [Vector IO](https://ogx-ai.github.io/docs/api/search-for-chunks-in-a-vector-store) and insert/query endpoints.
 - **Chat / responses** — Foundation model integration for answer generation (e.g. chat completions or responses API) when evaluating RAG patterns.
+
+## Document processing
+
+ai4RAG uses [`docling-core`](https://github.com/docling-project/docling-core) for document representation and chunking. Documents are represented as `DoclingDocument` instances, and the `DoclingChunker` leverages docling's `HybridChunker` for structure-aware, token-aware chunking. Both `docling-core` and `ogx-client` are installed automatically with `ai4rag`.
 
 
 ## Quick start
@@ -76,7 +80,7 @@ client = OgxClient(base_url=os.getenv("BASE_URL"), api_key=os.getenv("API_KEY"))
 
 ### Prepare knowledge base documents
 Prepare a set of documents to serve as the knowledge base for retrieval.
-These documents will be used to ground the LLM's responses and should be stored in a local directory.
+Documents are represented as `DoclingDocument` instances (from the [`docling-core`](https://github.com/DS4SD/docling-core) library) and should be stored in a local directory.
 
 > [!note]
 > If you are using the project locally, you can load documents using the `FileStore` class from the `dev_utils` module.
@@ -151,11 +155,30 @@ search_space = AI4RAGSearchSpace(
                     client=client,
                     params={"embedding_dimension": 768, "context_length": 8192},
                 )
-            ]
-        )
+            ],
+        ),
+        Parameter(
+            name="chunking_method",
+            param_type="C",
+            values=["recursive", "hybrid"],
+        ),
+        Parameter(
+            name="chunk_size",
+            param_type="C",
+            values=[512, 1024, 2048],
+        ),
+        Parameter(
+            name="chunk_overlap",
+            param_type="C",
+            values=[0, 128, 256],
+        ),
     ]
 )
 ```
+
+> [!tip]
+> `chunking_method` controls the chunking strategy: `"recursive"` uses LangChain's `RecursiveCharacterTextSplitter`, while `"hybrid"` uses docling's structure-aware `HybridChunker` (requires `chunk_overlap=0`).
+> When omitted, both methods are included by default.
 
 > [!tip]
 > To run automatic models discovery with OGX you may use `prepare_search_space_with_ogx()` from `ai4rag.search_space.prepare_search_space`.

--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.0](https://github.com/IBM/ai4rag/releases/tag/v0.7.0)
+
+### Added
+- `DoclingChunker` — structure-aware, token-aware chunker wrapping docling's `HybridChunker`, operating directly on `DoclingDocument` objects and preserving document hierarchy (headings, tables, figures) during chunking
+- `AI4RAGChunk` — framework-agnostic chunk dataclass replacing langchain `Document` as the pipeline's canonical chunk representation
+- `"hybrid"` chunking method in the default search space, enabling `DoclingChunker` alongside the existing `"recursive"` method
+- Search space validation rule `_rule_chunk_overlap_for_chunking_method` enforcing chunker-specific overlap constraints (`hybrid` requires overlap = 0; `recursive` requires overlap > 0)
+- Minimum context length validation for embedding models — models with `context_length` below 700 tokens are now rejected during initialization with a descriptive error
+
+### Changed
+- **Breaking:** `BaseChunker.split_documents()` now accepts `Sequence[DoclingDocument]` and returns `list[AI4RAGChunk]` (was `Sequence[Document]` → `list[Document]`)
+- **Breaking:** `BaseVectorStore.add_documents()` now accepts `Sequence[AI4RAGChunk]` (was `Sequence[Document]`)
+- **Breaking:** `BaseVectorStore.search()` now returns `list[AI4RAGChunk]` (was `list[dict]`)
+- `LangChainChunker` updated to accept `DoclingDocument` input (converts to markdown internally) and return `AI4RAGChunk` output
+- `ChromaVectorStore` and `OGXVectorStore` updated to work with `AI4RAGChunk`, with internal conversions handled transparently
+- `OGXEmbeddingModel` embedding batch size reduced from 2048 to 1024
+- Added `docling-core` as a project dependency
+
+---
+
 ## [0.6.3](https://github.com/IBM/ai4rag/releases/tag/v0.6.3)
 
 ### Fixed

--- a/docs/api-reference/rag/chunking.md
+++ b/docs/api-reference/rag/chunking.md
@@ -1,5 +1,28 @@
 # Chunking API
 
+## AI4RAGChunk
+
+::: ai4rag.rag.chunking.chunk.AI4RAGChunk
+    options:
+      show_root_heading: true
+      show_source: true
+
+## BaseChunker
+
+::: ai4rag.rag.chunking.base_chunker.BaseChunker
+    options:
+      show_root_heading: true
+      show_source: true
+
+## DoclingChunker
+
+::: ai4rag.rag.chunking.docling_chunker.DoclingChunker
+    options:
+      show_root_heading: true
+      show_source: true
+
+## LangChainChunker
+
 ::: ai4rag.rag.chunking.langchain_chunker.LangChainChunker
     options:
       show_root_heading: true

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -428,7 +428,6 @@ class AI4RAGSearchSpace(SearchSpace):
         params: list[Parameter] | None = None,
         rules: list[RuleFunction] | None = None,
         vector_store_type: str = "ogx",
-        ogx_vector_io_provider_id: str = "milvus",
     ):
 ```
 
@@ -436,30 +435,32 @@ class AI4RAGSearchSpace(SearchSpace):
 
 **Base Rules (always applied):**
 
-1. **Chunk size > 2 × chunk overlap**
-   - Ensures sufficient non-overlapping content
-   - Skipped when `chunk_size == 0` (structural-only splitting)
+1. **Chunk overlap consistent with chunking method**
+   - `chunking_method == "hybrid"` (DoclingChunker) requires `chunk_overlap == 0`
+   - `chunking_method == "recursive"` (LangChainChunker) requires `chunk_overlap > 0`
 
-2. **Window size ↔ retrieval method consistency**
+2. **Chunk size > 2 × chunk overlap**
+   - Ensures sufficient non-overlapping content
+
+3. **Window size ↔ retrieval method consistency**
    - `window_size == 0` requires `retrieval_method == "simple"`
    - `window_size > 0` requires `retrieval_method == "window"`
 
-3. **Chunk size within embedding context length**
-   - Estimates token count: `estimated_tokens = chunk_size / 3.6`
-   - Verifies `estimated_tokens <= embedding_model.params.context_length`
-   - Conservative ratio prevents runtime failures
+4. **Chunk size within embedding context length**
+   - Verifies `chunk_size <= context_length * 0.9` (both in tokens)
+   - 10% safety margin accounts for tokenizer divergence
 
 **Hybrid Search Rules (only for `vector_store_type != "chroma"`):**
 
-4. **Search mode ↔ ranker parameter consistency**
+5. **Search mode ↔ ranker parameter consistency**
    - When `search_mode == "vector"`: all ranker params must be sentinels (`""`, `0`, `1`)
    - When `search_mode == "hybrid"`: `ranker_strategy` must be non-empty
 
-5. **Ranker K for RRF only**
+6. **Ranker K for RRF only**
    - `ranker_k > 0` only when `ranker_strategy == "rrf"`
    - `ranker_k == 0` (sentinel) for all other strategies
 
-6. **Ranker alpha for weighted only**
+7. **Ranker alpha for weighted only**
    - `ranker_alpha != 1` only when `ranker_strategy == "weighted"`
    - `ranker_alpha == 1` (sentinel, means 100% dense) for all other strategies
 
@@ -620,7 +621,7 @@ The `ExperimentExceptionHandler` can be extended to customize error handling beh
 - Configurable via `max_threads` in `query_rag()`
 
 **Batch Embedding:**
-- OGXEmbeddingModel processes documents in batches of 2048 chunks
+- OGXEmbeddingModel processes documents in batches of 1024 chunks
 - Prevents API request size limits
 - Applied in both indexing and query phases
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -22,7 +22,7 @@ The indexing phase transforms raw documents into searchable vector embeddings st
 ```mermaid
 sequenceDiagram
     participant Exp as AI4RAGExperiment
-    participant LC as LangChainChunker
+    participant LC as BaseChunker
     participant EM as OGXEmbeddingModel
     participant VS as OGXVectorStore
     participant OGXClient as OGX Client
@@ -31,19 +31,18 @@ sequenceDiagram
     alt Collection exists
         Note over Exp: Reuse existing collection
     else New collection needed
-        Exp->>LC: split_documents(documents)
+        Exp->>LC: split_documents(DoclingDocuments)
         activate LC
-        LC->>LC: set document_id if missing
         LC->>LC: apply chunking method
-        LC->>LC: set sequence_number
-        LC-->>Exp: chunks (with metadata)
+        LC->>LC: set document_id and sequence_number
+        LC-->>Exp: AI4RAGChunks (with metadata)
         deactivate LC
 
         Exp->>VS: add_documents(chunks)
         activate VS
-        VS->>EM: embed_documents([chunk.page_content])
+        VS->>EM: embed_documents([chunk.text])
         activate EM
-        loop Batches of 2048 chunks
+        loop Batches of 1024 chunks
             EM->>OGXClient: embeddings.create(batch)
             OGXClient-->>EM: embeddings
         end
@@ -63,58 +62,32 @@ sequenceDiagram
 
 **Input Documents:**
 
-Documents are provided as `list[Document]` where each `Document` must have:
-
-```python
-Document(
-    page_content="Document text content...",
-    metadata={
-        "document_id": "unique_doc_id",  # Required
-        # other metadata fields...
-    }
-)
-```
-
-If `document_id` is missing, the chunker auto-generates it via `hash(page_content)`.
+Documents are provided as `list[DoclingDocument]` (from the `docling-core` library). Each document is a structured representation of a parsed file, with the document name used as `document_id`. If the name is not set, a content-based hash is generated instead.
 
 ### Chunking
 
-**LangChainChunker** splits documents into smaller chunks:
+The configured chunker (`DoclingChunker` or `LangChainChunker`) splits `DoclingDocument` objects into `AI4RAGChunk` instances. Both chunkers use tiktoken for token counting.
 
-**Step 1: Split Documents**
+**DoclingChunker** (structure-aware): Operates directly on the document structure, preserving headings and tables. Does not support overlap.
 
-Uses `RecursiveCharacterTextSplitter` with configured parameters:
+**LangChainChunker** (token-based): Converts each `DoclingDocument` to markdown internally, then applies `RecursiveCharacterTextSplitter` with token-based length measurement.
 
-```python
-chunker = LangChainChunker(
-    method="recursive",
-    chunk_size=512,          # Max chunk size in characters
-    chunk_overlap=128,       # Overlap between chunks
-    separators=["\n\n", r"(?<=\. )", "\n", " ", ""]  # Split hierarchy
-)
-```
-
-**Splitting hierarchy:**
-
-1. Try splitting on double newlines (`\n\n`)
-2. If chunks still too large, try sentence boundaries (`(?<=\. )`)
-3. Then single newlines, spaces, characters
-
-**Step 2: Add Metadata**
+**Metadata:**
 
 Each chunk receives:
 
 ```python
-chunk.metadata = {
-    "document_id": "original_doc_id",    # Inherited from parent document
-    "sequence_number": 1,                 # Position within document
-    "start_index": 0,                     # Character offset in original
-    # ... original metadata preserved ...
-}
+AI4RAGChunk(
+    text="Chunk text content...",
+    metadata={
+        "document_id": "original_doc_id",    # From document name or content hash
+        "sequence_number": 1,                 # Position within document
+        # chunker-specific keys (e.g. "start_index" for LangChain, "headings" for Docling)
+    }
+)
 ```
 
 **Sequence numbering:**
-- Chunks sorted by `(document_id, start_index)`
 - Sequence numbers assigned sequentially per document
 - Enables window-based retrieval (adjacent chunks)
 
@@ -122,13 +95,13 @@ chunk.metadata = {
 
 ```python
 [
-    Document(
-        page_content="First chunk text...",
-        metadata={"document_id": "doc1", "sequence_number": 1, "start_index": 0}
+    AI4RAGChunk(
+        text="First chunk text...",
+        metadata={"document_id": "doc1", "sequence_number": 1}
     ),
-    Document(
-        page_content="Second chunk text (with overlap)...",
-        metadata={"document_id": "doc1", "sequence_number": 2, "start_index": 384}
+    AI4RAGChunk(
+        text="Second chunk text...",
+        metadata={"document_id": "doc1", "sequence_number": 2}
     ),
     # ...
 ]
@@ -154,13 +127,13 @@ If `embedding_dimension` or `context_length` not provided:
 
 **Batch Processing:**
 
-Embeddings created in batches of 2048 chunks to respect API limits:
+Embeddings created in batches of 1024 chunks to respect API limits:
 
 ```python
 def embed_documents(texts: list[str]) -> list[list[float]]:
     embeddings = []
-    for idx in range(0, len(texts), 2048):
-        batch = texts[idx : idx + 2048]
+    for idx in range(0, len(texts), 1024):
+        batch = texts[idx : idx + 1024]
         batch_embeddings = self.client.embeddings.create(
             input=batch,
             model=self.model_id
@@ -203,7 +176,7 @@ Chunks inserted in batches of 2048:
 ```python
 chunks = [
     {
-        "content": chunk.page_content,
+        "content": chunk.text,
         "chunk_metadata": chunk.metadata,
         "chunk_id": chunk.metadata["document_id"],
         "embedding_model": embedding_model.model_id,
@@ -382,12 +355,12 @@ response = client.vector_io.query(...)
 
 Combines dense vector search with sparse keyword search (e.g., BM25), then re-ranks using specified strategy.
 
-**Step 3: Convert to Documents**
+**Step 3: Convert to AI4RAGChunks**
 
 ```python
 reference_documents = [
-    Document(
-        page_content=chunk.content,
+    AI4RAGChunk(
+        text=chunk.content,
         metadata=chunk.chunk_metadata.to_dict()
     )
     for chunk in response.chunks
@@ -401,8 +374,8 @@ reference_documents = [
 ```python
 # Default context_template_text: "{document}\n"
 context = "\n".join([
-    foundation_model.context_template_text.format(document=doc.page_content)
-    for doc in reference_documents
+    foundation_model.context_template_text.format(document=chunk.text)
+    for chunk in reference_documents
 ])
 ```
 
@@ -863,13 +836,13 @@ with ThreadPoolExecutor(max_workers=10) as executor:
 **Implementation:**
 
 ```python
-for idx in range(0, len(texts), 2048):
-    batch = texts[idx : idx + 2048]
+for idx in range(0, len(texts), 1024):
+    batch = texts[idx : idx + 1024]
     embeddings.extend(embed_batch(batch))
 ```
 
 **Constraints:**
-- OGX max batch size: 2048 chunks
+- OGX max batch size: 1024 chunks
 - Smaller batches = more API calls = slower
 
 ### 3. Collection Reuse
@@ -915,11 +888,11 @@ cache_key = hash((
 **Documents → Chunks:**
 
 ```python
-Document(page_content="Long text...", metadata={"document_id": "doc1"})
-↓ (LangChainChunker)
+DoclingDocument(name="doc1", ...)
+↓ (DoclingChunker or LangChainChunker)
 [
-    Document(page_content="Chunk 1", metadata={"document_id": "doc1", "sequence_number": 1}),
-    Document(page_content="Chunk 2", metadata={"document_id": "doc1", "sequence_number": 2}),
+    AI4RAGChunk(text="Chunk 1", metadata={"document_id": "doc1", "sequence_number": 1}),
+    AI4RAGChunk(text="Chunk 2", metadata={"document_id": "doc1", "sequence_number": 2}),
     ...
 ]
 ```
@@ -954,8 +927,8 @@ Collection "xyz" in OGX vector DB
 [0.05, -0.12, ...]
 ↓ (OGXVectorStore.search via vector_io.query)
 [
-    Document(page_content="Paris is the capital...", metadata={...}),
-    Document(page_content="France's capital city...", metadata={...}),
+    AI4RAGChunk(text="Paris is the capital...", metadata={...}),
+    AI4RAGChunk(text="France's capital city...", metadata={...}),
     ...
 ]
 ```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -105,9 +105,9 @@ graph TB
 
 **Chunking** (`ai4rag/rag/chunking/`)
 
-- Splits documents into chunks
+- Splits `DoclingDocument` objects into `AI4RAGChunk` instances
+- Two chunker implementations: `DoclingChunker` (structure-aware, via docling `HybridChunker`) and `LangChainChunker` (token-based, via LangChain `RecursiveCharacterTextSplitter`)
 - Configurable chunk size and overlap
-- Uses LangChain text splitters
 
 **Embedding** (`ai4rag/rag/embedding/`)
 
@@ -231,7 +231,8 @@ ai4rag is designed for extensibility:
 
 - **Python**: 3.12 & 3.13
 - **OGX**: Model and vector store integration
-- **LangChain**: Document chunking and processing
+- **Docling Core**: Document representation and structure-aware chunking
+- **LangChain**: Token-based text splitting
 - **Unitxt**: Evaluation metrics
 - **Pandas**: Results management
 - **Pydantic**: Data validation

--- a/docs/architecture/rag-components.md
+++ b/docs/architecture/rag-components.md
@@ -46,34 +46,41 @@ classDiagram
         +embedding_model: BaseEmbeddingModel
         +distance_metric: str
         +collection_name: str
-        +search(query, k)* list
-        +add_documents(docs)* void
+        +search(query, k)* AI4RAGChunk[]
+        +add_documents(AI4RAGChunk[])* void
     }
 
     class OGXVectorStore {
         +client: OgxClient
-        +search(query, k, search_mode, ranker_*) list
-        +add_documents(docs) void
+        +search(query, k, search_mode, ranker_*) AI4RAGChunk[]
+        +add_documents(AI4RAGChunk[]) void
     }
 
     class ChromaVectorStore {
-        +search(query, k) list
-        +window_search(query, k, window_size) list
-        +add_documents(docs) list
+        +search(query, k) AI4RAGChunk[]
+        +window_search(query, k, window_size) AI4RAGChunk[]
+        +add_documents(AI4RAGChunk[]) void
     }
 
     class BaseChunker {
         <<abstract>>
-        +split_documents(docs)* list
+        +split_documents(DoclingDocument[])* AI4RAGChunk[]
         +to_dict()* dict
         +from_dict(d)* BaseChunker
+    }
+
+    class DoclingChunker {
+        +max_tokens: int
+        +contextualize: bool
+        +merge_peers: bool
+        +split_documents(DoclingDocument[]) AI4RAGChunk[]
     }
 
     class LangChainChunker {
         +method: str
         +chunk_size: int
         +chunk_overlap: int
-        +split_documents(docs) list
+        +split_documents(DoclingDocument[]) AI4RAGChunk[]
     }
 
     class Retriever {
@@ -97,10 +104,10 @@ classDiagram
     }
 
     class SimpleRAG {
-        +chunker: LangChainChunker
+        +chunker: BaseChunker
         +embedding_model: BaseEmbeddingModel
         +vector_store: BaseVectorStore
-        +build_index(docs) void
+        +build_index(DoclingDocument[]) void
         +generate(question) dict
         +generate_stream(question) iterator
     }
@@ -109,6 +116,7 @@ classDiagram
     BaseEmbeddingModel <|-- OGXEmbeddingModel
     BaseVectorStore <|-- OGXVectorStore
     BaseVectorStore <|-- ChromaVectorStore
+    BaseChunker <|-- DoclingChunker
     BaseChunker <|-- LangChainChunker
     BaseRAGTemplate <|-- SimpleRAG
 
@@ -116,7 +124,7 @@ classDiagram
     Retriever --> BaseVectorStore : uses
     BaseRAGTemplate --> BaseFoundationModel : uses
     BaseRAGTemplate --> Retriever : uses
-    SimpleRAG --> LangChainChunker : uses
+    SimpleRAG --> BaseChunker : uses
 ```
 
 ---
@@ -179,7 +187,7 @@ Template for formatting each retrieved document:
 ```
 
 Placeholder:
-- `{document}`: Individual chunk's `page_content`
+- `{document}`: Individual chunk's text content
 
 **Customization Example:**
 
@@ -364,10 +372,10 @@ def _detect_context_length(self) -> int:
 
 ```python
 def embed_documents(self, texts: list[str]) -> list[list[float]]:
-    """Process in batches of 2048 to respect API limits."""
+    """Process in batches of 1024 to respect API limits."""
     embeddings = []
-    for idx in range(0, len(texts), 2048):
-        batch = texts[idx : idx + 2048]
+    for idx in range(0, len(texts), 1024):
+        batch = texts[idx : idx + 1024]
         batch_embeddings = self._embed_text(batch)
         embeddings.extend(batch_embeddings)
     return embeddings
@@ -425,12 +433,12 @@ class BaseVectorStore(ABC):
 
 ```python
 @abstractmethod
-def search(self, query: str, k: int, **kwargs) -> list[Document]:
+def search(self, query: str, k: int, **kwargs) -> list[AI4RAGChunk]:
     """Search for k most relevant chunks."""
 
 @abstractmethod
-def add_documents(self, documents: Sequence[Document]) -> None:
-    """Add documents to the collection."""
+def add_documents(self, documents: Sequence[AI4RAGChunk]) -> None:
+    """Add chunks to the collection."""
 
 @property
 @abstractmethod
@@ -469,7 +477,7 @@ def search(
     k: int = 5,
     include_scores: bool = False,
     **kwargs
-) -> list[Document] | list[tuple[Document, float]]:
+) -> list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]:
     """Vector similarity search."""
 ```
 
@@ -483,7 +491,7 @@ def window_search(
     window_size: int = 2,
     include_scores: bool = False,
     **kwargs
-) -> list[Document]:
+) -> list[AI4RAGChunk]:
     """Retrieve chunks + adjacent chunks (window) from same document."""
 ```
 
@@ -495,7 +503,7 @@ For each retrieved chunk:
    - Same `document_id`
    - `sequence_number` in `[seq - window_size, seq + window_size]`
 3. Sort by `sequence_number`
-4. Merge into single document (concatenate `page_content`)
+4. Merge into single chunk (concatenate text)
 
 **Example:**
 
@@ -509,8 +517,8 @@ For each retrieved chunk:
 **Batch Document Addition:**
 
 ```python
-def add_documents(self, documents: list, max_batch_size: int = 2048) -> list[str]:
-    """Add documents in batches of max_batch_size."""
+def add_documents(self, documents: list[AI4RAGChunk], max_batch_size: int = 2048) -> list[str]:
+    """Add chunks in batches of max_batch_size."""
     for batch_start in range(0, len(docs), max_batch_size):
         batch = docs[batch_start : batch_start + max_batch_size]
         self._vector_store.add_documents(batch, ids=ids)
@@ -529,11 +537,11 @@ vector_store.add_documents(chunked_documents)
 
 # Search
 results = vector_store.search(query="What is X?", k=5)
-# Returns: [Document(...), Document(...), ...]
+# Returns: [AI4RAGChunk(...), AI4RAGChunk(...), ...]
 
 # Window search
 results = vector_store.window_search(query="What is X?", k=5, window_size=2)
-# Returns: [merged_doc_1, merged_doc_2, ...]
+# Returns: [merged_chunk_1, merged_chunk_2, ...]
 ```
 
 ### OGXVectorStore
@@ -599,7 +607,7 @@ def search(
     ranker_k: int | None = None,
     ranker_alpha: float | None = None,
     **kwargs
-) -> list[Document]:
+) -> list[AI4RAGChunk]:
 ```
 
 **Search Modes:**
@@ -680,13 +688,13 @@ def _validate_search_params(search_mode, ranker_strategy, ranker_k, ranker_alpha
 **Document Addition:**
 
 ```python
-def add_documents(self, documents: list[Document], batch_size: int = 2048):
-    """Add documents with embeddings to OGX vector store."""
+def add_documents(self, documents: list[AI4RAGChunk], batch_size: int = 2048):
+    """Add chunks with embeddings to OGX vector store."""
     chunks = [
         {
-            "content": doc.page_content,
-            "chunk_metadata": doc.metadata,
-            "chunk_id": doc.metadata["document_id"],
+            "content": chunk.text,
+            "chunk_metadata": chunk.metadata,
+            "chunk_id": chunk.metadata["document_id"],
             "embedding_model": self.embedding_model.model_id,
             "embedding_dimension": self.embedding_model.params.embedding_dimension,
             "embedding": embedding_vector,
@@ -740,16 +748,27 @@ results = vector_store.search(
 
 ## Chunking
 
-Chunkers split documents into smaller, overlapping chunks for embedding and retrieval.
+Chunkers split `DoclingDocument` objects into `AI4RAGChunk` instances for embedding and retrieval.
+
+### AI4RAGChunk
+
+Framework-agnostic chunk representation used across the pipeline:
+
+```python
+@dataclass(frozen=True)
+class AI4RAGChunk:
+    text: str                                  # Chunk content
+    metadata: dict[str, Any] = field(default_factory=dict)  # document_id, sequence_number, etc.
+```
 
 ### BaseChunker
 
 Abstract base class for chunkers:
 
 ```python
-class BaseChunker(ABC, Generic[ChunkT]):
+class BaseChunker(ABC):
     @abstractmethod
-    def split_documents(self, documents: Sequence[ChunkT]) -> list[ChunkT]:
+    def split_documents(self, documents: Sequence[DoclingDocument]) -> list[AI4RAGChunk]:
         """Split documents into smaller chunks."""
 
     @abstractmethod
@@ -762,12 +781,44 @@ class BaseChunker(ABC, Generic[ChunkT]):
         """Deserialize chunker configuration."""
 ```
 
-### LangChainChunker
+### DoclingChunker
 
-LangChain-based chunking with metadata management:
+Structure-aware, token-aware chunker wrapping docling's `HybridChunker`. Preserves document hierarchy (headings, tables, figures) during chunking:
 
 ```python
-class LangChainChunker(BaseChunker[Document]):
+class DoclingChunker(BaseChunker):
+    def __init__(
+        self,
+        max_tokens: int = 8192,
+        contextualize: bool = True,
+        tokenizer: BaseTokenizer | None = None,
+        merge_peers: bool = True,
+    ):
+```
+
+**Key Features:**
+
+- Operates directly on `DoclingDocument` objects
+- Token-bounded chunks aligned to the embedding model
+- When `contextualize=True`, enriches each chunk with its heading hierarchy
+- Merges adjacent undersized chunks that share the same heading context
+- Does **not** support chunk overlap (overlap must be `0`)
+
+**Usage:**
+
+```python
+chunker = DoclingChunker(max_tokens=1024, contextualize=True)
+
+chunks = chunker.split_documents(docling_documents)
+# Returns: list[AI4RAGChunk] with document_id, sequence_number, and headings metadata
+```
+
+### LangChainChunker
+
+Token-based chunking via LangChain's `RecursiveCharacterTextSplitter`, adapted for `DoclingDocument` input:
+
+```python
+class LangChainChunker(BaseChunker):
     def __init__(
         self,
         method: Literal["recursive"] = "recursive",
@@ -779,15 +830,15 @@ class LangChainChunker(BaseChunker[Document]):
 
 **Chunking Method:**
 
-Currently supports `"recursive"`:
+Currently supports `"recursive"`. Converts each `DoclingDocument` to markdown internally, then applies token-based splitting via tiktoken:
 
 ```python
 text_splitter = RecursiveCharacterTextSplitter(
     chunk_size=chunk_size,
     chunk_overlap=chunk_overlap,
     separators=["\n\n", r"(?<=\. )", "\n", " ", ""],
-    length_function=len,
-    add_start_index=True,  # Adds "start_index" to metadata
+    length_function=lambda text: len(encoding.encode(text)),  # tiktoken-based
+    add_start_index=True,
 )
 ```
 
@@ -834,13 +885,12 @@ def _set_sequence_number_in_metadata(chunks):
 **Output Chunk Structure:**
 
 ```python
-Document(
-    page_content="Chunk text content...",
+AI4RAGChunk(
+    text="Chunk text content...",
     metadata={
         "document_id": "doc1",
         "sequence_number": 3,
         "start_index": 1024,
-        # ... original document metadata preserved ...
     }
 )
 ```
@@ -854,8 +904,8 @@ chunker = LangChainChunker(
     chunk_overlap=128
 )
 
-chunks = chunker.split_documents(documents)
-# Returns: list[Document] with sequence_number and start_index metadata
+chunks = chunker.split_documents(docling_documents)
+# Returns: list[AI4RAGChunk] with sequence_number and start_index metadata
 ```
 
 ---
@@ -897,7 +947,7 @@ class Retriever:
 **Retrieve Method:**
 
 ```python
-def retrieve(self, query: str, **kwargs) -> list[Document]:
+def retrieve(self, query: str, **kwargs) -> list[AI4RAGChunk]:
     """Retrieve relevant documents from vector store."""
     _number_of_chunks = kwargs.get("number_of_chunks", self.number_of_chunks)
 
@@ -932,7 +982,7 @@ retriever = Retriever(
 )
 
 docs = retriever.retrieve("What is X?")
-# Returns: [Document(...), Document(...), ...]  (5 chunks)
+# Returns: [AI4RAGChunk(...), AI4RAGChunk(...), ...]  (5 chunks)
 
 # Hybrid retrieval with RRF
 retriever = Retriever(
@@ -973,7 +1023,7 @@ class BaseRAGTemplate(ABC):
 
 ```python
 @abstractmethod
-def build_index(self, documents: list[Document], **kwargs) -> None:
+def build_index(self, documents: list[DoclingDocument], **kwargs) -> None:
     """Index documents into vector store."""
 
 @abstractmethod
@@ -995,7 +1045,7 @@ class SimpleRAG(BaseRAGTemplate):
         self,
         foundation_model: BaseFoundationModel,
         retriever: Retriever,
-        chunker: LangChainChunker | None = None,
+        chunker: BaseChunker | None = None,
         embedding_model: BaseEmbeddingModel | None = None,
         vector_store: BaseVectorStore | None = None,
     ):
@@ -1004,7 +1054,7 @@ class SimpleRAG(BaseRAGTemplate):
 **build_index() Method:**
 
 ```python
-def build_index(self, documents: list[Document], **kwargs) -> None:
+def build_index(self, documents: list[DoclingDocument], **kwargs) -> None:
     """Index documents: chunk → embed → store."""
     chunks = self.chunker.split_documents(documents)
     self.vector_store.add_documents(chunks)
@@ -1022,9 +1072,9 @@ def generate(self, question: str, **kwargs) -> dict[str, Any]:
     # 2. Format context
     context = "\n".join([
         self.foundation_model.context_template_text.format(
-            document=doc.page_content
+            document=chunk.text
         )
-        for doc in reference_documents
+        for chunk in reference_documents
     ])
 
     # 3. Format user message
@@ -1080,7 +1130,7 @@ print(result["answer"])
 # "Based on the provided documents, Paris is the capital of France."
 
 print(result["reference_documents"])
-# [Document(...), Document(...), ...]
+# [AI4RAGChunk(...), AI4RAGChunk(...), ...]
 ```
 
 **Within AI4RAGExperiment:**
@@ -1201,11 +1251,11 @@ class CustomEmbeddingModel(BaseEmbeddingModel[MyClient, MyParams]):
 
 ```python
 class CustomVectorStore(BaseVectorStore):
-    def search(self, query: str, k: int, **kwargs) -> list[Document]:
+    def search(self, query: str, k: int, **kwargs) -> list[AI4RAGChunk]:
         # Your implementation
         pass
 
-    def add_documents(self, documents: Sequence[Document]) -> None:
+    def add_documents(self, documents: Sequence[AI4RAGChunk]) -> None:
         # Your implementation
         pass
 
@@ -1218,7 +1268,7 @@ class CustomVectorStore(BaseVectorStore):
 
 ```python
 class CustomRAG(BaseRAGTemplate):
-    def build_index(self, documents: list[Document], **kwargs) -> None:
+    def build_index(self, documents: list[DoclingDocument], **kwargs) -> None:
         # Your indexing logic
         pass
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,7 +6,7 @@ For the sake of quick-start OGX server will be used, but this can be run with in
 ---
 
 ## Data loading
-To run the experiment you need to provide documents in the format of LangChain's `Document` instances with proper metadata.
+To run the experiment you need to provide documents as `DoclingDocument` instances (from the `docling-core` library).
 For the development purposes you may use `FileStore` implementation from `dev_utils`, but this will be available only when cloning the repository, as this is not part of the project.
 
 ---

--- a/docs/user-guide/search-space.md
+++ b/docs/user-guide/search-space.md
@@ -244,9 +244,9 @@ If you don't specify certain parameters, `AI4RAGSearchSpace` uses sensible defau
 
 | Parameter | Default (OGX) | Default (ChromaDB) | Type |
 |-----------|----------------------|-------------------|------|
-| `chunking_method` | `("recursive",)` | `("recursive",)` | Categorical |
-| `chunk_size` | `(1024, 2048)` | `(1024, 2048)` | Categorical |
-| `chunk_overlap` | `(128, 256)` | `(128, 256)` | Categorical |
+| `chunking_method` | `("recursive", "hybrid")` | `("recursive", "hybrid")` | Categorical |
+| `chunk_size` | `(512, 1024, 2048)` | `(512, 1024, 2048)` | Categorical |
+| `chunk_overlap` | `(0, 128, 256)` | `(0, 128, 256)` | Categorical |
 | `retrieval_method` | `("simple",)` | `("simple", "window")` | Categorical |
 | `window_size` | `(0,)` | `(0, 1, 3, 5)` | Categorical |
 | `number_of_chunks` | `(3, 5, 10)` | `(3, 5, 10)` | Categorical |
@@ -334,23 +334,43 @@ search_space = AI4RAGSearchSpace(
 
 ---
 
-### Rule 3: Chunk Size Within Embedding Context Length
+### Rule 3: Chunk Overlap Consistent with Chunking Method
 
-**Rule**: Estimated token count of `chunk_size` must fit within the embedding model's `context_length`.
+**Rule**:
 
-**How it works**: Uses a conservative ratio of **3.6 characters per token** to estimate tokens:
+- When `chunking_method == "hybrid"` (DoclingChunker), `chunk_overlap` must be `0` — the chunker does not support overlap
+- When `chunking_method == "recursive"` (LangChainChunker), `chunk_overlap` must be `> 0` — splitting without overlap loses context between chunks
+
+**Example**:
 
 ```python
-estimated_tokens = chunk_size / 3.6
+# Valid
+{"chunking_method": "hybrid", "chunk_overlap": 0}      ✓
+{"chunking_method": "recursive", "chunk_overlap": 128}  ✓
+
+# Invalid (filtered out)
+{"chunking_method": "hybrid", "chunk_overlap": 128}     ✗
+{"chunking_method": "recursive", "chunk_overlap": 0}    ✗
+```
+
+---
+
+### Rule 4: Chunk Size Within Embedding Context Length
+
+**Rule**: `chunk_size` (in tokens) must fit within the embedding model's `context_length`, with a 10% safety margin to account for tokenizer divergence.
+
+**How it works**: Both chunkers express `chunk_size` in tokens, so the comparison is direct:
+
+```python
+chunk_size <= context_length * 0.9
 
 # Example
 chunk_size = 1024
-estimated_tokens = 1024 / 3.6 ≈ 284 tokens
-
-# Check: 284 <= context_length (e.g., 8192) ✓
+context_length = 8192
+# Check: 1024 <= 8192 * 0.9 = 7372.8 ✓
 ```
 
-**Why**: If chunks exceed the embedding model's context window, embedding generation will fail or be truncated.
+**Why**: If chunks exceed the embedding model's context window, embedding generation will fail or be truncated. The 10% margin accounts for tokenizer divergence between the chunker's tiktoken encoder and the embedding model's native tokenizer.
 
 **Example**:
 
@@ -362,15 +382,15 @@ embedding = OGXEmbeddingModel(
 )
 
 # Valid
-{"chunk_size": 1024, "embedding_model": embedding}  # ~284 tokens ✓
+{"chunk_size": 256, "embedding_model": embedding}   # 256 <= 460.8 ✓
 
 # Invalid (filtered out)
-{"chunk_size": 2048, "embedding_model": embedding}  # ~569 tokens ✗ (exceeds 512)
+{"chunk_size": 512, "embedding_model": embedding}    # 512 <= 460.8 ✗
 ```
 
 ---
 
-### Rule 4: Hybrid Search Ranker Consistency
+### Rule 5: Hybrid Search Ranker Consistency
 
 **Rule**: Ranker parameters must only be set when `search_mode == "hybrid"`.
 
@@ -399,7 +419,7 @@ embedding = OGXEmbeddingModel(
 
 ---
 
-### Rule 5: ranker_k Only for RRF
+### Rule 6: ranker_k Only for RRF
 
 **Rule**:
 
@@ -420,7 +440,7 @@ embedding = OGXEmbeddingModel(
 
 ---
 
-### Rule 6: ranker_alpha Only for Weighted
+### Rule 7: ranker_alpha Only for Weighted
 
 **Rule**:
 
@@ -578,7 +598,7 @@ search_space = AI4RAGSearchSpace(
         Parameter(name="embedding_model", param_type="C", values=[embedding]),
 
         # Chunking
-        Parameter(name="chunking_method", param_type="C", values=["recursive", "markdown"]),
+        Parameter(name="chunking_method", param_type="C", values=["recursive", "hybrid"]),
         Parameter(name="chunk_size", param_type="C", values=[512, 1024, 1536]),
         Parameter(name="chunk_overlap", param_type="C", values=[64, 128, 200]),
 


### PR DESCRIPTION
# Release v0.7.0

## Summary

This release introduces the `DoclingChunker` and the `AI4RAGChunk` dataclass, establishing a framework-agnostic chunking pipeline that operates natively on `DoclingDocument` objects. The chunking and vector store interfaces have been unified around `AI4RAGChunk`, replacing the previous dependency on langchain `Document` and raw dicts. Additionally, embedding models are now validated against a minimum context length to prevent silent failures with undersized models.

## Changes

### Added
- `DoclingChunker` — structure-aware, token-aware chunker wrapping docling's `HybridChunker`, operating directly on `DoclingDocument` objects and preserving document hierarchy (headings, tables, figures) during chunking
- `AI4RAGChunk` — framework-agnostic chunk dataclass replacing langchain `Document` as the pipeline's canonical chunk representation
- `"hybrid"` chunking method in the default search space, enabling `DoclingChunker` alongside the existing `"recursive"` method
- Search space validation rule `_rule_chunk_overlap_for_chunking_method` enforcing chunker-specific overlap constraints (`hybrid` requires overlap = 0; `recursive` requires overlap > 0)
- Minimum context length validation for embedding models — models with `context_length` below 700 tokens are now rejected during initialization with a descriptive error

### Changed
- **Breaking:** `BaseChunker.split_documents()` now accepts `Sequence[DoclingDocument]` and returns `list[AI4RAGChunk]` (was `Sequence[Document]` → `list[Document]`)
- **Breaking:** `BaseVectorStore.add_documents()` now accepts `Sequence[AI4RAGChunk]` (was `Sequence[Document]`)
- **Breaking:** `BaseVectorStore.search()` now returns `list[AI4RAGChunk]` (was `list[dict]`)
- `LangChainChunker` updated to accept `DoclingDocument` input (converts to markdown internally) and return `AI4RAGChunk` output
- `ChromaVectorStore` and `OGXVectorStore` updated to work with `AI4RAGChunk`, with internal conversions handled transparently
- `OGXEmbeddingModel` embedding batch size reduced from 2048 to 1024
- Added `docling-core` as a project dependency

## Migration notes

**Chunker interface change:** If you have a custom `BaseChunker` subclass, update `split_documents()` to accept `Sequence[DoclingDocument]` and return `list[AI4RAGChunk]`. The `LangChainChunker` demonstrates how to convert `DoclingDocument` to markdown internally for text-based splitting.

**Vector store interface change:** If you have a custom `BaseVectorStore` subclass, update `add_documents()` to accept `Sequence[AI4RAGChunk]` and `search()` to return `list[AI4RAGChunk]`. See `ChromaVectorStore` for an example of bridging between `AI4RAGChunk` and a provider-specific document type.

**Embedding model validation:** Embedding models with `context_length` below 700 tokens will now raise a `ValueError` during initialization. If you encounter this, switch to an embedding model with a larger context window.

**New dependency:** `docling-core` is now required. Run `uv sync` (or `pip install -e .`) to pick it up.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.7.0`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
