### PR TITLE
fix(assets): merge HPO user prompt rules into Responses export system

### DIFF
--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -87,7 +87,7 @@ _USER_GROUNDING_SKIP_PREFIXES = (
     "Do not use outside knowledge",
     "If the documents do not contain the answer",
 )
-_USER_RAG_SCAFFOLD_PREFIXES = (
+_USER_RAG_GROUNDING_PREFIXES = (
     "You are a specialized Retrieval Augmented Generation",
     "Prioritize correctness and ensure your response is grounded",
 )
@@ -126,15 +126,11 @@ def _is_citation_related_line(line: str) -> bool:
     if not stripped:
         return False
     lower = stripped.lower()
-    if any(stripped.startswith(prefix) for prefix in _OGX_DUPLICATIVE_LINE_PREFIXES if "cite" in prefix.lower()):
+    if any(stripped.startswith(prefix) for prefix in _CITATION_PREFIXES):
         return True
     if any(fragment.lower() in lower for fragment in _HPO_CITATION_FRAGMENTS):
         return True
-    if "[1], [2]" in stripped:
-        return True
-    if "document numbers for every factual claim" in lower:
-        return True
-    return False
+    return any(sub.lower() in lower for sub in _CITATION_SUBSTRINGS)
 
 
 def _filter_ogx_duplicative_sentences(line: str) -> str:
@@ -201,7 +197,13 @@ def _strip_ogx_runtime_instructions(text: str) -> str:
 
 
 def _join_answer_scaffold_blocks(lines: list[str]) -> str:
-    """Group lines into blocks separated when an answer-scaffold line starts."""
+    """Group lines into paragraph blocks, starting a new block when an answer-scaffold line appears.
+
+    Scaffold lines are specifically in the form ``Answer (...)`` — e.g.
+    ``"Answer (max 150 words):"`` — as produced by HPO prompt templates.
+    Other leading text such as ``"Answer:"`` or ``"Response:"`` does NOT
+    trigger a new block.
+    """
     if not lines:
         return ""
 
@@ -218,15 +220,12 @@ def _join_answer_scaffold_blocks(lines: list[str]) -> str:
     return "\n\n".join(blocks)
 
 
-def _should_skip_redundant_user_line(stripped: str, system_has_grounding: bool, system_has_citation: bool) -> bool:
+def _should_skip_redundant_user_line(stripped: str, system_has_grounding: bool) -> bool:
     """Return whether a user-template line duplicates system policy for export."""
     if _is_citation_related_line(stripped):
         return True
-    if system_has_citation and stripped.startswith("You MUST cite sources"):
-        return True
-    # Check both grounding prefixes and RAG scaffold prefixes (non-OGX user supplements)
     return system_has_grounding and any(
-        stripped.startswith(prefix) for prefix in _GROUNDING_PREFIXES + _USER_RAG_SCAFFOLD_PREFIXES
+        stripped.startswith(prefix) for prefix in _GROUNDING_PREFIXES + _USER_RAG_GROUNDING_PREFIXES
     )
 
 
@@ -296,17 +295,13 @@ def _extract_static_user_without_reference_slot(text: str) -> str:
 def _system_has_grounding_policy(system: str) -> bool:
     """Return whether the system prompt already states an explicit document-only grounding rule.
 
-    Matches only explicit "answer ONLY using" / "answer using ONLY" instructions.
+    Uses the same prefix list as sentence-level filtering so that adding a new
+    OGX phrase to ``_GROUNDING_PREFIXES`` automatically covers system detection too.
     Does NOT match descriptive personas like "retrieval-augmented assistant" without
-    an explicit grounding constraint — those are system role definitions, not
-    retrieval policies that would make user grounding instructions redundant.
+    an explicit grounding constraint.
     """
     normalized = system.lower()
-    return (
-        "answer using only the provided documents" in normalized
-        or "answer only using information from the documents" in normalized
-        or "answer only using information from documents" in normalized
-    )
+    return any(prefix.lower() in normalized for prefix in _GROUNDING_PREFIXES)
 
 
 def _filter_static_user_for_responses(system: str, static_user: str) -> str:
@@ -320,12 +315,11 @@ def _filter_static_user_for_responses(system: str, static_user: str) -> str:
         return ""
 
     system_has_grounding = _system_has_grounding_policy(system)
-    system_has_citation = "MUST cite sources" in system
 
     filtered_lines: list[str] = []
     for line in static_user.splitlines():
         stripped = line.strip()
-        if not stripped or _should_skip_redundant_user_line(stripped, system_has_grounding, system_has_citation):
+        if not stripped or _should_skip_redundant_user_line(stripped, system_has_grounding):
             continue
         filtered_lines.append(stripped)
 

--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -116,12 +116,7 @@ def _line_is_ogx_duplicative(line: str) -> bool:
 
 def _normalize_answer_scaffold(line: str) -> str:
     """Drop citation hints from answer scaffolds; OGX owns citation via annotations."""
-    return (
-        line.replace(", with citations", "")
-        .replace("with citations", "")
-        .replace("  ", " ")
-        .strip()
-    )
+    return line.replace(", with citations", "").replace("with citations", "").replace("  ", " ").strip()
 
 
 def _strip_ogx_runtime_instructions(text: str) -> str:
@@ -170,10 +165,7 @@ def _strip_citation_instructions(text: str) -> str:
 def _system_has_grounding_policy(system: str) -> bool:
     """Return whether the system prompt already states a document-only grounding policy."""
     normalized = system.lower()
-    return (
-        "answer using only the provided documents" in normalized
-        or "retrieval-augmented assistant" in normalized
-    )
+    return "answer using only the provided documents" in normalized or "retrieval-augmented assistant" in normalized
 
 
 def _filter_static_user_for_responses(system: str, static_user: str) -> str:

--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -52,6 +52,21 @@ _SYSTEM_GROUNDING_PHRASES = (
     "Answer using ONLY the provided documents.",
     "Answer using ONLY information from documents retrieved via file search.",
 )
+_GROUNDING_DUPLICATE_PREFIXES = (
+    "Answer ONLY using information from the documents",
+    "Do not use outside knowledge",
+    "If the documents do not contain the answer",
+    "You are a specialized Retrieval Augmented Generation",
+    "Prioritize correctness and ensure your response is grounded",
+)
+_USER_GROUNDING_SKIP_PREFIXES = (
+    _HPO_GROUNDING_PREFIX,
+    "Do not use outside knowledge",
+    "If the documents do not contain the answer",
+)
+_DOCUMENT_LABELS = ("Documents:", "Context:", "[Document]")
+_QUESTION_PREFIXES = ("Question:", "Q:", "[conversation]:")
+_LEGACY_DOCUMENT_MARKERS = ("Documents:\n", "Context:\n", "[Document]\n")
 
 
 def _sentence_is_ogx_duplicative(sentence: str) -> bool:
@@ -162,6 +177,96 @@ def _strip_citation_instructions(text: str) -> str:
     return _strip_ogx_runtime_instructions(text)
 
 
+def _join_answer_scaffold_blocks(lines: list[str]) -> str:
+    """Group lines into blocks separated when an answer-scaffold line starts."""
+    if not lines:
+        return ""
+
+    blocks: list[str] = []
+    current_block: list[str] = []
+    for line in lines:
+        if line.startswith("Answer (") and current_block:
+            blocks.append("\n".join(current_block))
+            current_block = [line]
+        else:
+            current_block.append(line)
+    if current_block:
+        blocks.append("\n".join(current_block))
+    return "\n\n".join(blocks)
+
+
+def _should_skip_redundant_user_line(stripped: str, system_has_grounding: bool, system_has_citation: bool) -> bool:
+    """Return whether a user-template line duplicates system policy for export."""
+    if _is_citation_related_line(stripped):
+        return True
+    if system_has_citation and stripped.startswith("You MUST cite sources"):
+        return True
+    return system_has_grounding and any(stripped.startswith(prefix) for prefix in _GROUNDING_DUPLICATE_PREFIXES)
+
+
+def _should_skip_user_export_line(stripped: str) -> bool:
+    """Return whether a merged user line is OGX-owned and must not be exported."""
+    if any(stripped.startswith(prefix) for prefix in _USER_GROUNDING_SKIP_PREFIXES):
+        return True
+    return _is_citation_related_line(stripped)
+
+
+def _strip_document_slot_prefix(prefix: str) -> str:
+    """Remove structural labels that wrap the reference-documents slot."""
+    for label in _DOCUMENT_LABELS:
+        if prefix == label:
+            return ""
+        if prefix.endswith(label):
+            return prefix[: -len(label)].strip()
+    return prefix
+
+
+def _extract_static_suffix_line(stripped: str) -> str | None:
+    """Return static instruction text from one post-documents template line."""
+    if not stripped or stripped == ":" or stripped in _DOCUMENT_SLOT_MARKERS:
+        return None
+    if "{question}" in stripped:
+        without_question = stripped.replace("{question}", "").strip()
+        for question_prefix in _QUESTION_PREFIXES:
+            if without_question.startswith(question_prefix):
+                without_question = without_question[len(question_prefix) :].strip()
+        without_question = without_question.lstrip(":.").strip()
+        return without_question or None
+    if stripped.startswith(_QUESTION_PREFIXES):
+        return None
+    if "{multilingual_support}" in stripped:
+        return None
+    return stripped
+
+
+def _extract_static_user_from_reference_slot(text: str) -> str:
+    """Extract static instructions from a template that contains ``{reference_documents}``."""
+    before, after = text.split("{reference_documents}", 1)
+    parts: list[str] = []
+    prefix = _strip_document_slot_prefix(before.strip())
+    if prefix:
+        parts.append(prefix)
+
+    suffix_lines = [
+        line_text
+        for line_text in (_extract_static_suffix_line(line.strip()) for line in after.splitlines())
+        if line_text
+    ]
+    if suffix_lines:
+        parts.append("\n".join(suffix_lines))
+    return "\n\n".join(parts).strip()
+
+
+def _extract_static_user_without_reference_slot(text: str) -> str:
+    """Extract static instructions from legacy templates without an explicit doc slot."""
+    doc_idx = len(text)
+    for marker in _LEGACY_DOCUMENT_MARKERS:
+        idx = text.find(marker)
+        if idx != -1:
+            doc_idx = min(doc_idx, idx)
+    return text[:doc_idx].strip()
+
+
 def _system_has_grounding_policy(system: str) -> bool:
     """Return whether the system prompt already states a document-only grounding policy."""
     normalized = system.lower()
@@ -187,38 +292,11 @@ def _filter_static_user_for_responses(system: str, static_user: str) -> str:
     filtered_lines: list[str] = []
     for line in static_user.splitlines():
         stripped = line.strip()
-        if not stripped:
-            continue
-        if _is_citation_related_line(stripped):
-            continue
-        if system_has_grounding and stripped.startswith("Answer ONLY using information from the documents"):
-            continue
-        if system_has_grounding and stripped.startswith("Do not use outside knowledge"):
-            continue
-        if system_has_grounding and stripped.startswith("If the documents do not contain the answer"):
-            continue
-        if system_has_citation and stripped.startswith("You MUST cite sources"):
-            continue
-        if system_has_grounding and stripped.startswith("You are a specialized Retrieval Augmented Generation"):
-            continue
-        if system_has_grounding and stripped.startswith("Prioritize correctness and ensure your response is grounded"):
+        if not stripped or _should_skip_redundant_user_line(stripped, system_has_grounding, system_has_citation):
             continue
         filtered_lines.append(stripped)
 
-    if not filtered_lines:
-        return ""
-
-    blocks: list[str] = []
-    current_block: list[str] = []
-    for line in filtered_lines:
-        if line.startswith("Answer (") and current_block:
-            blocks.append("\n".join(current_block))
-            current_block = [line]
-        else:
-            current_block.append(line)
-    if current_block:
-        blocks.append("\n".join(current_block))
-    return "\n\n".join(blocks)
+    return _join_answer_scaffold_blocks(filtered_lines)
 
 
 def _adapt_system_for_responses_export(system: str) -> str:
@@ -234,34 +312,13 @@ def _adapt_static_user_for_responses_export(static_user: str) -> str:
     adapted_lines: list[str] = []
     for line in static_user.splitlines():
         stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith(_HPO_GROUNDING_PREFIX):
-            continue
-        if stripped.startswith("Do not use outside knowledge"):
-            continue
-        if stripped.startswith("If the documents do not contain the answer"):
-            continue
-        if _is_citation_related_line(stripped):
+        if not stripped or _should_skip_user_export_line(stripped):
             continue
         cleaned = _strip_ogx_runtime_instructions(stripped)
         if cleaned:
             adapted_lines.append(cleaned)
 
-    if not adapted_lines:
-        return ""
-
-    blocks: list[str] = []
-    current_block: list[str] = []
-    for line in adapted_lines:
-        if line.startswith("Answer (") and current_block:
-            blocks.append("\n".join(current_block))
-            current_block = [line]
-        else:
-            current_block.append(line)
-    if current_block:
-        blocks.append("\n".join(current_block))
-    return "\n\n".join(blocks)
+    return _join_answer_scaffold_blocks(adapted_lines)
 
 
 def _extract_static_user_instructions(user_message_text: str) -> str:
@@ -274,51 +331,11 @@ def _extract_static_user_instructions(user_message_text: str) -> str:
         return ""
 
     text = str(user_message_text).strip()
-    parts: list[str] = []
-
     if "{reference_documents}" in text:
-        before, after = text.split("{reference_documents}", 1)
-        prefix = before.strip()
-        for label in ("Documents:", "Context:", "[Document]"):
-            if prefix == label:
-                prefix = ""
-            elif prefix.endswith(label):
-                prefix = prefix[: -len(label)].strip()
-        if prefix:
-            parts.append(prefix)
+        return _extract_static_user_from_reference_slot(text)
 
-        suffix_lines: list[str] = []
-        for line in after.splitlines():
-            stripped = line.strip()
-            if not stripped or stripped == ":" or stripped in _DOCUMENT_SLOT_MARKERS:
-                continue
-            if "{question}" in stripped:
-                without_question = stripped.replace("{question}", "").strip()
-                for question_prefix in ("Question:", "Q:", "[conversation]:"):
-                    if without_question.startswith(question_prefix):
-                        without_question = without_question[len(question_prefix) :].strip()
-                without_question = without_question.lstrip(":.").strip()
-                if without_question:
-                    suffix_lines.append(without_question)
-                continue
-            if stripped.startswith("Question:") or stripped.startswith("Q:"):
-                continue
-            if "{multilingual_support}" in stripped:
-                continue
-            suffix_lines.append(stripped)
-        if suffix_lines:
-            parts.append("\n".join(suffix_lines))
-    else:
-        doc_idx = len(text)
-        for marker in ("Documents:\n", "Context:\n", "[Document]\n"):
-            idx = text.find(marker)
-            if idx != -1:
-                doc_idx = min(doc_idx, idx)
-        prefix = text[:doc_idx].strip()
-        if prefix:
-            parts.append(prefix)
-
-    return "\n\n".join(parts).strip()
+    prefix = _extract_static_user_without_reference_slot(text)
+    return prefix
 
 
 def build_responses_system_input(generation: dict) -> str:

--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -2,25 +2,56 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+"""Map HPO Chat Completions prompts to exported Responses ``input[system]`` text.
+
+OGX-owned phrases are defined below and must stay aligned with
+``benchmarking/rag/config.yaml`` (``file_search_params``, ``context_prompt_params``,
+``annotation_prompt_params``). If OGX injection strings change, update the lists here.
+"""
+
+import re
 
 _USER_QUERY_PLACEHOLDER = "<user_query_placeholder>"
 _EMPTY_SYSTEM_FALLBACK = "You are a helpful assistant."
 _EXPORT_SLOT_MARKERS = ("{reference_documents}", "{question}", "{multilingual_support}")
 
-# Structural markers wrapping the document slot — not instruction text for export.
+# Suffix lines after ``{reference_documents}``: drop structural wrappers (e.g. ``[End]``).
 _DOCUMENT_SLOT_MARKERS = frozenset({"[Document]", "[End]", "Documents:", "Context:"})
 
-_HPO_GROUNDING_PREFIX = "Answer ONLY using information from the documents below"
+# ============================================================================
+# OGX Runtime Injection Strings
+# ============================================================================
+# These phrases are injected by OGX at file_search runtime via
+# benchmarking/rag/config.yaml (file_search_params, context_prompt_params,
+# annotation_prompt_params). HPO export must NOT duplicate them in
+# responses_template.input[system].
+#
+# If OGX changes injection strings in config.yaml, update these lists.
+# ============================================================================
+
+# Citation-related phrases
+_CITATION_PREFIXES = (
+    "You MUST cite sources",
+    "Cite sources immediately",
+)
+_CITATION_SUBSTRINGS = (
+    "[1], [2]",
+    "<|file-id|>",
+    "cite as <|",
+    "file citations",
+    "document numbers for every factual claim",
+)
 _HPO_CITATION_INSTRUCTION = (
     "You MUST cite sources using [1], [2], etc. matching the document numbers for every factual claim."
 )
+_HPO_CITATION_FRAGMENTS = (
+    _HPO_CITATION_INSTRUCTION,
+    "You MUST cite sources using [1], [2], etc.",
+    "You MUST cite sources using [1], [2].",
+)
 
-# Phrases injected by OGX at file_search runtime (benchmarking/rag/config.yaml:
-# file_search_params, context_prompt_params, annotation_prompt_params). Export must
-# not repeat or substitute equivalent wording in responses_template.input[system].
-_OGX_DUPLICATIVE_LINE_PREFIXES = (
-    "You MUST cite sources",
-    "Cite sources immediately",
+# Grounding/retrieval-related phrases
+_GROUNDING_PREFIXES = (
     "Answer ONLY using information from the documents",
     "Answer ONLY using information from documents retrieved",
     "Answer using ONLY the provided documents",
@@ -28,6 +59,20 @@ _OGX_DUPLICATIVE_LINE_PREFIXES = (
     "Do not use outside knowledge",
     "If the retrieved documents do not contain",
     "If the documents do not contain",
+)
+_GROUNDING_SUBSTRINGS = (
+    "documents below",
+    "retrieved via file search",
+    "retrieved to help answer the user",
+    "supporting information only in answering",
+)
+_SYSTEM_GROUNDING_PHRASES = (
+    "Answer using ONLY the provided documents.",
+    "Answer using ONLY information from documents retrieved via file search.",
+)
+
+# File search tool markers
+_FILE_SEARCH_MARKERS = (
     "file_search tool found",
     "BEGIN of file_search tool results",
     "END of file_search tool results",
@@ -35,40 +80,33 @@ _OGX_DUPLICATIVE_LINE_PREFIXES = (
     "Use them as supporting information only",
     "Do not add extra punctuation. Use only the file IDs",
 )
-_OGX_DUPLICATIVE_SUBSTRINGS = (
-    "[1], [2]",
-    "<|file-id|>",
-    "cite as <|",
-    "documents below",
-    "retrieved via file search",
-    "file citations",
-    "retrieved to help answer the user",
-    "supporting information only in answering",
-)
-_HPO_CITATION_FRAGMENTS = (
-    _HPO_CITATION_INSTRUCTION,
-    "You MUST cite sources using [1], [2], etc.",
-    "You MUST cite sources using [1], [2].",
-)
-_SYSTEM_GROUNDING_PHRASES = (
-    "Answer using ONLY the provided documents.",
-    "Answer using ONLY information from documents retrieved via file search.",
-)
-_GROUNDING_DUPLICATE_PREFIXES = (
-    "Answer ONLY using information from the documents",
+
+# User template duplicate detection (pass 1 filtering)
+_USER_GROUNDING_SKIP_PREFIXES = (
+    "Answer ONLY using information from the documents below",
     "Do not use outside knowledge",
     "If the documents do not contain the answer",
+)
+_USER_RAG_SCAFFOLD_PREFIXES = (
     "You are a specialized Retrieval Augmented Generation",
     "Prioritize correctness and ensure your response is grounded",
 )
-_USER_GROUNDING_SKIP_PREFIXES = (
-    _HPO_GROUNDING_PREFIX,
-    "Do not use outside knowledge",
-    "If the documents do not contain the answer",
-)
+
+# Document and question slot markers
 _DOCUMENT_LABELS = ("Documents:", "Context:", "[Document]")
 _QUESTION_PREFIXES = ("Question:", "Q:", "[conversation]:")
 _LEGACY_DOCUMENT_MARKERS = ("Documents:\n", "Context:\n", "[Document]\n")
+
+# Combined line prefixes for sentence-level filtering
+_OGX_DUPLICATIVE_LINE_PREFIXES = _CITATION_PREFIXES + _GROUNDING_PREFIXES + _FILE_SEARCH_MARKERS
+
+# Combined substrings for partial-match filtering
+_OGX_DUPLICATIVE_SUBSTRINGS = _CITATION_SUBSTRINGS + _GROUNDING_SUBSTRINGS
+
+
+def _collapse_whitespace(text: str) -> str:
+    """Collapse repeated interior spaces after phrase removal."""
+    return re.sub(r" +", " ", text).strip()
 
 
 def _sentence_is_ogx_duplicative(sentence: str) -> bool:
@@ -122,18 +160,10 @@ def _filter_ogx_duplicative_sentences(line: str) -> str:
     return result
 
 
-def _line_is_ogx_duplicative(line: str) -> bool:
-    """Return whether a line duplicates OGX file_search runtime prompt injection."""
-    stripped = line.strip()
-    if not stripped:
-        return False
-    filtered = _filter_ogx_duplicative_sentences(stripped)
-    return not filtered
-
-
 def _normalize_answer_scaffold(line: str) -> str:
     """Drop citation hints from answer scaffolds; OGX owns citation via annotations."""
-    return line.replace(", with citations", "").replace("with citations", "").replace("  ", " ").strip()
+    normalized = line.replace(", with citations", "").replace("with citations", "")
+    return _collapse_whitespace(normalized)
 
 
 def _strip_ogx_runtime_instructions(text: str) -> str:
@@ -143,6 +173,7 @@ def _strip_ogx_runtime_instructions(text: str) -> str:
 
     for phrase in _SYSTEM_GROUNDING_PHRASES:
         text = text.replace(phrase, "").replace(phrase.rstrip("."), "")
+    text = _collapse_whitespace(text)
 
     lines: list[str] = []
     for line in text.splitlines():
@@ -151,7 +182,7 @@ def _strip_ogx_runtime_instructions(text: str) -> str:
             if lines and lines[-1] != "":
                 lines.append("")
             continue
-        if _line_is_ogx_duplicative(stripped) or _is_citation_related_line(stripped):
+        if _is_citation_related_line(stripped):
             continue
 
         cleaned = _filter_ogx_duplicative_sentences(stripped)
@@ -160,23 +191,13 @@ def _strip_ogx_runtime_instructions(text: str) -> str:
                 cleaned = cleaned.replace(fragment, "").strip()
                 break
         cleaned = _normalize_answer_scaffold(cleaned)
-        if cleaned and not _line_is_ogx_duplicative(cleaned):
+        if cleaned:
             lines.append(cleaned)
 
     result = "\n".join(lines)
     while "\n\n\n" in result:
         result = result.replace("\n\n\n", "\n\n")
     return result.strip()
-
-
-def _is_citation_line(line: str) -> bool:
-    """Return whether a line is an HPO citation instruction."""
-    return _line_is_ogx_duplicative(line) and "cite" in line.lower()
-
-
-def _strip_citation_instructions(text: str) -> str:
-    """Remove citation instructions from export text (OGX annotation_prompt_params)."""
-    return _strip_ogx_runtime_instructions(text)
 
 
 def _join_answer_scaffold_blocks(lines: list[str]) -> str:
@@ -203,7 +224,10 @@ def _should_skip_redundant_user_line(stripped: str, system_has_grounding: bool, 
         return True
     if system_has_citation and stripped.startswith("You MUST cite sources"):
         return True
-    return system_has_grounding and any(stripped.startswith(prefix) for prefix in _GROUNDING_DUPLICATE_PREFIXES)
+    # Check both grounding prefixes and RAG scaffold prefixes (non-OGX user supplements)
+    return system_has_grounding and any(
+        stripped.startswith(prefix) for prefix in _GROUNDING_PREFIXES + _USER_RAG_SCAFFOLD_PREFIXES
+    )
 
 
 def _should_skip_user_export_line(stripped: str) -> bool:
@@ -270,20 +294,27 @@ def _extract_static_user_without_reference_slot(text: str) -> str:
 
 
 def _system_has_grounding_policy(system: str) -> bool:
-    """Return whether the system prompt already states a document-only grounding policy."""
+    """Return whether the system prompt already states an explicit document-only grounding rule.
+
+    Matches only explicit "answer ONLY using" / "answer using ONLY" instructions.
+    Does NOT match descriptive personas like "retrieval-augmented assistant" without
+    an explicit grounding constraint — those are system role definitions, not
+    retrieval policies that would make user grounding instructions redundant.
+    """
     normalized = system.lower()
-    return "answer using only the provided documents" in normalized or "retrieval-augmented assistant" in normalized
+    return (
+        "answer using only the provided documents" in normalized
+        or "answer only using information from the documents" in normalized
+        or "answer only using information from documents" in normalized
+    )
 
 
 def _filter_static_user_for_responses(system: str, static_user: str) -> str:
     """Drop user-template lines that duplicate system policy for Responses export.
 
-    HPO user templates combine static rules with ``{reference_documents}`` and
-    ``{question}`` slots. After stripping those slots, some rule lines overlap
-    with ``system_message_text`` (PR #75 ``_RAG_SYSTEM_PREFIX`` and family
-    personas). Responses receives documents via ``file_search`` and the
-    question via ``input[role=user]``, so only non-redundant supplements belong
-    in ``input[role=system]``.
+    Pass 1 of 2: compare against ``original_system`` (author intent before OGX
+    stripping). Removes user lines that repeat grounding or citation policy already
+    present in the HPO system prompt.
     """
     if not static_user.strip():
         return ""
@@ -307,7 +338,10 @@ def _adapt_system_for_responses_export(system: str) -> str:
 
 
 def _adapt_static_user_for_responses_export(static_user: str) -> str:
-    """Drop merged user supplements that OGX injects at file_search runtime."""
+    """Drop merged user supplements that OGX injects at file_search runtime.
+
+    Pass 2 of 2: strip OGX-runtime phrases from user lines that survived pass 1.
+    """
     if not static_user.strip():
         return ""
 
@@ -360,22 +394,22 @@ def build_responses_system_input(generation: dict) -> str:
     presentation, and citation instructions owned by OGX ``config.yaml`` are
     stripped rather than rephrased into the exported system input.
     """
-    system = _adapt_system_for_responses_export((generation.get("system_message_text") or "").strip())
+    original_system = (generation.get("system_message_text") or "").strip()
+    exported_system = _adapt_system_for_responses_export(original_system)
     user_template = generation.get("user_message_text") or ""
-    raw_system = (generation.get("system_message_text") or "").strip()
 
+    # Pass 1: dedupe vs original_system; pass 2: strip OGX-owned user supplements.
     static_user = _adapt_static_user_for_responses_export(
         _filter_static_user_for_responses(
-            raw_system,
+            original_system,
             _extract_static_user_instructions(user_template),
         ),
     )
 
-    # Merge system and static user, handling empty cases
-    if system and static_user:
-        result = f"{system}\n\n{static_user}"
+    if exported_system and static_user:
+        result = f"{exported_system}\n\n{static_user}"
     else:
-        result = system or static_user
+        result = exported_system or static_user
 
     # Fallback for completely empty patterns (rare edge case)
     if not result or not result.strip() or _is_placeholder_only_export(result):
@@ -398,6 +432,12 @@ def build_pattern_json(
     detected_language : dict | None, default=None
         Language detection result (``{"code": "...", "name": "..."}``) stored
         on ``generation`` before building the Responses export.
+
+    Notes
+    -----
+    ``pattern["settings"]["generation"]`` must include ``model_id``,
+    ``temperature``, ``max_completion_tokens``, ``system_message_text``, and
+    ``user_message_text`` (as produced by the experiment payload).
 
     Returns
     -------
@@ -446,6 +486,7 @@ def build_pattern_json(
             "impact_factor": ranker_k,
         }
     elif search_mode == "hybrid" and ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
+        # ``ranker_alpha == 1.0`` intentionally falls through to ``else`` (semantic-only default).
         pattern["settings"]["responses_template"]["tools"][0]["ranking_options"] = {
             "ranker": "weighted",
             "alpha": ranker_alpha,

--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -4,6 +4,8 @@
 # -----------------------------------------------------------------------------
 
 _USER_QUERY_PLACEHOLDER = "<user_query_placeholder>"
+_EMPTY_SYSTEM_FALLBACK = "You are a helpful assistant."
+_EXPORT_SLOT_MARKERS = ("{reference_documents}", "{question}", "{multilingual_support}")
 
 # Structural markers wrapping the document slot — not instruction text for export.
 _DOCUMENT_SLOT_MARKERS = frozenset({"[Document]", "[End]", "Documents:", "Context:"})
@@ -338,6 +340,16 @@ def _extract_static_user_instructions(user_message_text: str) -> str:
     return prefix
 
 
+def _is_placeholder_only_export(text: str) -> bool:
+    """Return whether export text contains only unresolved HPO template slots."""
+    cleaned = text.strip()
+    if not cleaned:
+        return True
+    for marker in _EXPORT_SLOT_MARKERS:
+        cleaned = cleaned.replace(marker, "")
+    return not cleaned.strip()
+
+
 def build_responses_system_input(generation: dict) -> str:
     """Build Responses API system input aligned with HPO chat/completion prompts.
 
@@ -358,11 +370,18 @@ def build_responses_system_input(generation: dict) -> str:
             _extract_static_user_instructions(user_template),
         ),
     )
-    if not static_user:
-        return system
-    if not system:
-        return static_user
-    return f"{system}\n\n{static_user}"
+
+    # Merge system and static user, handling empty cases
+    if system and static_user:
+        result = f"{system}\n\n{static_user}"
+    else:
+        result = system or static_user
+
+    # Fallback for completely empty patterns (rare edge case)
+    if not result or not result.strip() or _is_placeholder_only_export(result):
+        return _EMPTY_SYSTEM_FALLBACK
+
+    return result
 
 
 def build_pattern_json(

--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -2,11 +2,365 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+
+_USER_QUERY_PLACEHOLDER = "<user_query_placeholder>"
+
+# Structural markers wrapping the document slot — not instruction text for export.
+_DOCUMENT_SLOT_MARKERS = frozenset({"[Document]", "[End]", "Documents:", "Context:"})
+
+_HPO_GROUNDING_PREFIX = "Answer ONLY using information from the documents below"
+_HPO_CITATION_INSTRUCTION = (
+    "You MUST cite sources using [1], [2], etc. matching the document numbers for every factual claim."
+)
+
+# Phrases injected by OGX at file_search runtime (benchmarking/rag/config.yaml:
+# file_search_params, context_prompt_params, annotation_prompt_params). Export must
+# not repeat or substitute equivalent wording in responses_template.input[system].
+_OGX_DUPLICATIVE_LINE_PREFIXES = (
+    "You MUST cite sources",
+    "Cite sources immediately",
+    "Answer ONLY using information from the documents",
+    "Answer ONLY using information from documents retrieved",
+    "Answer using ONLY the provided documents",
+    "Answer using ONLY information from documents",
+    "Do not use outside knowledge",
+    "If the retrieved documents do not contain",
+    "If the documents do not contain",
+    "file_search tool found",
+    "BEGIN of file_search tool results",
+    "END of file_search tool results",
+    "The above results were retrieved to help answer",
+    "Use them as supporting information only",
+    "Do not add extra punctuation. Use only the file IDs",
+)
+_OGX_DUPLICATIVE_SUBSTRINGS = (
+    "[1], [2]",
+    "<|file-id|>",
+    "cite as <|",
+    "documents below",
+    "retrieved via file search",
+    "file citations",
+    "retrieved to help answer the user",
+    "supporting information only in answering",
+)
+_HPO_CITATION_FRAGMENTS = (
+    _HPO_CITATION_INSTRUCTION,
+    "You MUST cite sources using [1], [2], etc.",
+    "You MUST cite sources using [1], [2].",
+)
+_SYSTEM_GROUNDING_PHRASES = (
+    "Answer using ONLY the provided documents.",
+    "Answer using ONLY information from documents retrieved via file search.",
+)
+
+
+def _sentence_is_ogx_duplicative(sentence: str) -> bool:
+    """Return whether a sentence duplicates OGX file_search runtime injection."""
+    stripped = sentence.strip().rstrip(".")
+    if not stripped:
+        return True
+    if any(stripped.startswith(prefix.rstrip(".")) for prefix in _OGX_DUPLICATIVE_LINE_PREFIXES):
+        return True
+    normalized = stripped.lower()
+    return any(fragment.lower() in normalized for fragment in _OGX_DUPLICATIVE_SUBSTRINGS)
+
+
+def _is_citation_related_line(line: str) -> bool:
+    """Return whether an entire line should be dropped as citation guidance."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    lower = stripped.lower()
+    if any(stripped.startswith(prefix) for prefix in _OGX_DUPLICATIVE_LINE_PREFIXES if "cite" in prefix.lower()):
+        return True
+    if any(fragment.lower() in lower for fragment in _HPO_CITATION_FRAGMENTS):
+        return True
+    if "[1], [2]" in stripped:
+        return True
+    if "document numbers for every factual claim" in lower:
+        return True
+    return False
+
+
+def _filter_ogx_duplicative_sentences(line: str) -> str:
+    """Remove OGX-duplicative sentences while keeping persona or policy sentences."""
+    stripped = line.strip()
+    if not stripped or _is_citation_related_line(stripped):
+        return ""
+
+    # Split on ". " only — avoids breaking abbreviations such as "i.e.,"
+    parts = [part.strip() for part in stripped.split(". ") if part.strip()]
+    if len(parts) <= 1:
+        if _sentence_is_ogx_duplicative(stripped.rstrip(".")):
+            return ""
+        return stripped
+
+    kept = [part.rstrip(".") for part in parts if not _sentence_is_ogx_duplicative(part.rstrip("."))]
+    if not kept:
+        return ""
+
+    result = ". ".join(kept)
+    if stripped.endswith("."):
+        result += "."
+    return result
+
+
+def _line_is_ogx_duplicative(line: str) -> bool:
+    """Return whether a line duplicates OGX file_search runtime prompt injection."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    filtered = _filter_ogx_duplicative_sentences(stripped)
+    return not filtered
+
+
+def _normalize_answer_scaffold(line: str) -> str:
+    """Drop citation hints from answer scaffolds; OGX owns citation via annotations."""
+    return (
+        line.replace(", with citations", "")
+        .replace("with citations", "")
+        .replace("  ", " ")
+        .strip()
+    )
+
+
+def _strip_ogx_runtime_instructions(text: str) -> str:
+    """Remove text that OGX injects via file_search config at inference time."""
+    if not text.strip():
+        return ""
+
+    for phrase in _SYSTEM_GROUNDING_PHRASES:
+        text = text.replace(phrase, "").replace(phrase.rstrip("."), "")
+
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if lines and lines[-1] != "":
+                lines.append("")
+            continue
+        if _line_is_ogx_duplicative(stripped) or _is_citation_related_line(stripped):
+            continue
+
+        cleaned = _filter_ogx_duplicative_sentences(stripped)
+        for fragment in _HPO_CITATION_FRAGMENTS:
+            if fragment in cleaned:
+                cleaned = cleaned.replace(fragment, "").strip()
+                break
+        cleaned = _normalize_answer_scaffold(cleaned)
+        if cleaned and not _line_is_ogx_duplicative(cleaned):
+            lines.append(cleaned)
+
+    result = "\n".join(lines)
+    while "\n\n\n" in result:
+        result = result.replace("\n\n\n", "\n\n")
+    return result.strip()
+
+
+def _is_citation_line(line: str) -> bool:
+    """Return whether a line is an HPO citation instruction."""
+    return _line_is_ogx_duplicative(line) and "cite" in line.lower()
+
+
+def _strip_citation_instructions(text: str) -> str:
+    """Remove citation instructions from export text (OGX annotation_prompt_params)."""
+    return _strip_ogx_runtime_instructions(text)
+
+
+def _system_has_grounding_policy(system: str) -> bool:
+    """Return whether the system prompt already states a document-only grounding policy."""
+    normalized = system.lower()
+    return (
+        "answer using only the provided documents" in normalized
+        or "retrieval-augmented assistant" in normalized
+    )
+
+
+def _filter_static_user_for_responses(system: str, static_user: str) -> str:
+    """Drop user-template lines that duplicate system policy for Responses export.
+
+    HPO user templates combine static rules with ``{reference_documents}`` and
+    ``{question}`` slots. After stripping those slots, some rule lines overlap
+    with ``system_message_text`` (PR #75 ``_RAG_SYSTEM_PREFIX`` and family
+    personas). Responses receives documents via ``file_search`` and the
+    question via ``input[role=user]``, so only non-redundant supplements belong
+    in ``input[role=system]``.
+    """
+    if not static_user.strip():
+        return ""
+
+    system_has_grounding = _system_has_grounding_policy(system)
+    system_has_citation = "MUST cite sources" in system
+
+    filtered_lines: list[str] = []
+    for line in static_user.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _is_citation_related_line(stripped):
+            continue
+        if system_has_grounding and stripped.startswith("Answer ONLY using information from the documents"):
+            continue
+        if system_has_grounding and stripped.startswith("Do not use outside knowledge"):
+            continue
+        if system_has_grounding and stripped.startswith("If the documents do not contain the answer"):
+            continue
+        if system_has_citation and stripped.startswith("You MUST cite sources"):
+            continue
+        if system_has_grounding and stripped.startswith("You are a specialized Retrieval Augmented Generation"):
+            continue
+        if system_has_grounding and stripped.startswith("Prioritize correctness and ensure your response is grounded"):
+            continue
+        filtered_lines.append(stripped)
+
+    if not filtered_lines:
+        return ""
+
+    blocks: list[str] = []
+    current_block: list[str] = []
+    for line in filtered_lines:
+        if line.startswith("Answer (") and current_block:
+            blocks.append("\n".join(current_block))
+            current_block = [line]
+        else:
+            current_block.append(line)
+    if current_block:
+        blocks.append("\n".join(current_block))
+    return "\n\n".join(blocks)
+
+
+def _adapt_system_for_responses_export(system: str) -> str:
+    """Drop OGX-runtime retrieval/citation text from the HPO system prompt."""
+    return _strip_ogx_runtime_instructions(system)
+
+
+def _adapt_static_user_for_responses_export(static_user: str) -> str:
+    """Drop merged user supplements that OGX injects at file_search runtime."""
+    if not static_user.strip():
+        return ""
+
+    adapted_lines: list[str] = []
+    for line in static_user.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(_HPO_GROUNDING_PREFIX):
+            continue
+        if stripped.startswith("Do not use outside knowledge"):
+            continue
+        if stripped.startswith("If the documents do not contain the answer"):
+            continue
+        if _is_citation_related_line(stripped):
+            continue
+        cleaned = _strip_ogx_runtime_instructions(stripped)
+        if cleaned:
+            adapted_lines.append(cleaned)
+
+    if not adapted_lines:
+        return ""
+
+    blocks: list[str] = []
+    current_block: list[str] = []
+    for line in adapted_lines:
+        if line.startswith("Answer (") and current_block:
+            blocks.append("\n".join(current_block))
+            current_block = [line]
+        else:
+            current_block.append(line)
+    if current_block:
+        blocks.append("\n".join(current_block))
+    return "\n\n".join(blocks)
+
+
+def _extract_static_user_instructions(user_message_text: str) -> str:
+    """Return static instruction text from a HPO user template.
+
+    Strips runtime slots (retrieved documents, question) that Responses API
+    supplies via ``file_search`` and the user ``input`` message respectively.
+    """
+    if not user_message_text:
+        return ""
+
+    text = str(user_message_text).strip()
+    parts: list[str] = []
+
+    if "{reference_documents}" in text:
+        before, after = text.split("{reference_documents}", 1)
+        prefix = before.strip()
+        for label in ("Documents:", "Context:", "[Document]"):
+            if prefix == label:
+                prefix = ""
+            elif prefix.endswith(label):
+                prefix = prefix[: -len(label)].strip()
+        if prefix:
+            parts.append(prefix)
+
+        suffix_lines: list[str] = []
+        for line in after.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped == ":" or stripped in _DOCUMENT_SLOT_MARKERS:
+                continue
+            if "{question}" in stripped:
+                without_question = stripped.replace("{question}", "").strip()
+                for question_prefix in ("Question:", "Q:", "[conversation]:"):
+                    if without_question.startswith(question_prefix):
+                        without_question = without_question[len(question_prefix) :].strip()
+                without_question = without_question.lstrip(":.").strip()
+                if without_question:
+                    suffix_lines.append(without_question)
+                continue
+            if stripped.startswith("Question:") or stripped.startswith("Q:"):
+                continue
+            if "{multilingual_support}" in stripped:
+                continue
+            suffix_lines.append(stripped)
+        if suffix_lines:
+            parts.append("\n".join(suffix_lines))
+    else:
+        doc_idx = len(text)
+        for marker in ("Documents:\n", "Context:\n", "[Document]\n"):
+            idx = text.find(marker)
+            if idx != -1:
+                doc_idx = min(doc_idx, idx)
+        prefix = text[:doc_idx].strip()
+        if prefix:
+            parts.append(prefix)
+
+    return "\n\n".join(parts).strip()
+
+
+def build_responses_system_input(generation: dict) -> str:
+    """Build Responses API system input aligned with HPO chat/completion prompts.
+
+    HPO sends ``system_message_text`` plus a formatted ``user_message_text``
+    (rules, documents, question). Responses uses ``file_search`` for documents
+    and a separate user message for the question. Non-redundant supplements
+    from the user template are merged into export; retrieval framing, chunk
+    presentation, and citation instructions owned by OGX ``config.yaml`` are
+    stripped rather than rephrased into the exported system input.
+    """
+    system = _adapt_system_for_responses_export((generation.get("system_message_text") or "").strip())
+    user_template = generation.get("user_message_text") or ""
+    raw_system = (generation.get("system_message_text") or "").strip()
+
+    static_user = _adapt_static_user_for_responses_export(
+        _filter_static_user_for_responses(
+            raw_system,
+            _extract_static_user_instructions(user_template),
+        ),
+    )
+    if not static_user:
+        return system
+    if not system:
+        return static_user
+    return f"{system}\n\n{static_user}"
+
+
 def build_pattern_json(
     pattern: dict,
     detected_language: dict | None = None,
 ) -> dict:
-    """Update pattern information with detected language and responses template.
+    """Update pattern information with responses template.
 
     Parameters
     ----------
@@ -14,29 +368,33 @@ def build_pattern_json(
         A single evaluation result object carrying ``indexing_params``,
         ``rag_params``, ``pattern_name``, ``collection``, etc.
     detected_language : dict | None, default=None
-        Language detection result (``{"code": "...", "name": "..."}``).
+        Language detection result (``{"code": "...", "name": "..."}``) stored
+        on ``generation`` before building the Responses export.
 
     Returns
     -------
     dict
         Pattern definition suitable for JSON serialisation.
     """
+    generation = pattern["settings"]["generation"]
     if detected_language:
-        pattern["settings"]["generation"]["detected_language"] = detected_language
+        generation["detected_language"] = detected_language
+
+    system_input = build_responses_system_input(generation)
 
     pattern["settings"]["responses_template"] = {
-        "model": pattern["settings"]["generation"]["model_id"],
+        "model": generation["model_id"],
         "stream": False,
         "store": False,
         "input": [
             {
-                "content": [{"text": pattern["settings"]["generation"]["system_message_text"], "type": "input_text"}],
+                "content": [{"text": system_input, "type": "input_text"}],
                 "role": "system",
             },
-            {"content": [{"text": "<user_query_placeholder>", "type": "input_text"}], "role": "user"},
+            {"content": [{"text": _USER_QUERY_PLACEHOLDER, "type": "input_text"}], "role": "user"},
         ],
-        "max_output_tokens": pattern["settings"]["generation"]["max_completion_tokens"],
-        "temperature": pattern["settings"]["generation"]["temperature"],
+        "max_output_tokens": generation["max_completion_tokens"],
+        "temperature": generation["temperature"],
         "tool_choice": {"mode": "required", "tools": [{}], "type": "file_search"},
         "tools": [
             {
@@ -66,7 +424,6 @@ def build_pattern_json(
         }
     else:
         pattern["settings"]["responses_template"]["tools"][0]["ranking_options"] = {
-            # simulate semantic-only search
             "ranker": "weighted",
             "alpha": 1.0,
         }

--- a/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
+++ b/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
@@ -9,6 +9,8 @@ import copy
 import pytest
 
 from ai4rag.components.assets_generator import build_pattern_json
+from ai4rag.components.assets_generator.pattern_builder import build_responses_system_input
+from ai4rag.search_space.src.model_props import get_system_message_text, get_user_message_text
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -72,12 +74,15 @@ class TestBuildPatternJson:
         result = build_pattern_json(pattern)
 
         rt = result["settings"]["responses_template"]
+        generation = result["settings"]["generation"]
+        expected_system = build_responses_system_input(generation)
+
         assert rt["model"] == "ibm/granite-3-8b-instruct"
         assert rt["stream"] is False
         assert rt["store"] is False
         assert rt["input"] == [
             {
-                "content": [{"text": "Answer based on context only.", "type": "input_text"}],
+                "content": [{"text": expected_system, "type": "input_text"}],
                 "role": "system",
             },
             {"content": [{"text": "<user_query_placeholder>", "type": "input_text"}], "role": "user"},
@@ -121,6 +126,7 @@ class TestBuildPatternJson:
 
         ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "rrf", "impact_factor": 60}
+        assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
 
     def test_hybrid_weighted_ranking_options(self):
         """Hybrid search with weighted ranker must set ranker and alpha in ranking_options."""
@@ -133,15 +139,172 @@ class TestBuildPatternJson:
 
         ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "weighted", "alpha": 0.7}
+        assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
 
     def test_simple_retrieval_default_ranking_options(self):
-        """Simple retrieval must have default weights in ranking_options."""
+        """Vector-only search simulates semantic retrieval via weighted ranker alpha=1.0."""
         pattern = _make_pattern()
         build_pattern_json(pattern)
 
         ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "weighted", "alpha": 1.0}
         assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
+
+    def test_export_system_input_merges_non_redundant_user_rules(self):
+        """Legacy user supplements merge; redundant grounding and citations are omitted."""
+        pattern = _make_pattern()
+        pattern["settings"]["generation"]["system_message_text"] = (
+            "You are a retrieval-augmented assistant. Answer using ONLY the provided documents."
+        )
+        pattern["settings"]["generation"]["user_message_text"] = (
+            "Answer ONLY using information from the documents below. "
+            "Do not use outside knowledge.\n"
+            "You MUST cite sources using [1], [2], etc.\n\n"
+            "Documents:\n{reference_documents}\n\n"
+            "Question: {question}\n\n"
+            "Answer (max 150 words, with citations):\n"
+            "You MUST write your entire answer in English only."
+        )
+
+        build_pattern_json(pattern)
+
+        system_text = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
+        assert "retrieval-augmented assistant" in system_text
+        assert "retrieved via file search" not in system_text
+        assert "provided documents" not in system_text.lower()
+        assert "Answer ONLY using information from the documents below" not in system_text
+        assert "must cite sources" not in system_text.lower()
+        assert "file citations" not in system_text.lower()
+        assert "max 150 words" in system_text
+        assert "with citations" not in system_text.lower()
+        assert "English only" in system_text
+        assert "{reference_documents}" not in system_text
+        assert "{question}" not in system_text
+
+    def test_export_system_input_skips_duplicate_citation_and_keeps_answer_scaffold(self):
+        """Citation lines are stripped; answer scaffold and language policy still merge."""
+        pattern = _make_pattern()
+        pattern["settings"]["generation"]["system_message_text"] = (
+            "You are a retrieval-augmented assistant. You MUST cite sources using [1], [2]."
+        )
+        pattern["settings"]["generation"]["user_message_text"] = (
+            "You MUST cite sources using [1], [2], etc.\n\n"
+            "Documents:\n{reference_documents}\n\n"
+            "Question: {question}\n\n"
+            "Answer (max 150 words, with citations):\n"
+            "You MUST write your entire answer in English only."
+        )
+
+        build_pattern_json(pattern)
+
+        system_text = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
+        assert "must cite sources" not in system_text.lower()
+        assert "max 150 words" in system_text
+        assert "English only" in system_text
+
+    def test_build_responses_system_input_legacy_user_prefix(self):
+        """Legacy grounding and citation lines are omitted; persona supplements are kept."""
+        generation = {
+            "system_message_text": "Short system prefix.",
+            "user_message_text": (
+                "Answer ONLY using information from the documents below.\n"
+                "You MUST cite sources using [1], [2].\n\n"
+                "Context: {reference_documents}\n\n"
+                "Question: {question}\n"
+            ),
+        }
+        system_input = build_responses_system_input(generation)
+        assert system_input == "Short system prefix."
+        assert "retrieved via file search" not in system_input
+        assert "must cite sources" not in system_input.lower()
+        assert "documents below" not in system_input
+
+    def test_build_pattern_json_uses_export_parity_system_input(self):
+        """build_pattern_json must use build_responses_system_input(), not raw system text."""
+        model_id = "ibm/granite-3-8b-instruct"
+        pattern = _make_pattern()
+        pattern["settings"]["generation"]["model_id"] = model_id
+        pattern["settings"]["generation"]["system_message_text"] = get_system_message_text(model_id)
+        pattern["settings"]["generation"]["user_message_text"] = get_user_message_text(
+            model_id, language_autodetect=False
+        )
+
+        build_pattern_json(pattern)
+
+        generation = pattern["settings"]["generation"]
+        expected = build_responses_system_input(generation)
+        actual = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
+        assert actual == expected
+        assert actual != generation["system_message_text"]
+        assert "Granite Chat" in actual
+        assert "Retrieval Augmented Generation" in actual
+        assert "i.e.," in actual
+        assert "English only" in actual
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "unknown-model",
+            "ibm/granite-3-8b-instruct",
+            "meta-llama/llama-3-1-8b-instruct",
+            "mistralai/mistral-large",
+            "openai/gpt-oss-120b",
+        ],
+    )
+    def test_export_omits_ogx_duplicative_prompt_text(self, model_id: str):
+        """Export must not duplicate citation/retrieval text that OGX injects at file_search runtime."""
+        generation = {
+            "system_message_text": get_system_message_text(model_id),
+            "user_message_text": get_user_message_text(model_id, language_autodetect=False),
+        }
+        system_text = build_responses_system_input(generation)
+
+        assert "[1], [2]" not in system_text
+        assert "must cite sources" not in system_text.lower()
+        assert "file citations" not in system_text.lower()
+        assert "documents below" not in system_text
+        assert "retrieved via file search" not in system_text
+        assert "retrieved to help answer" not in system_text.lower()
+        assert "<|file-id|>" not in system_text
+        assert "cite sources immediately" not in system_text.lower()
+        assert "supporting information only" not in system_text.lower()
+        assert "{reference_documents}" not in system_text
+        assert "{question}" not in system_text
+        assert "[End]" not in system_text
+
+    def test_export_omits_ogx_config_yaml_instruction_text(self):
+        """Export must not contain verbatim OGX annotation/context template phrases."""
+        generation = {
+            "system_message_text": (
+                "You are a retrieval-augmented assistant. "
+                "Cite sources immediately at the end of sentences before punctuation."
+            ),
+            "user_message_text": (
+                "The above results were retrieved to help answer the user's query. "
+                "Use them as supporting information only in answering this query.\n"
+                "Documents:\n{reference_documents}\n\n"
+                "Question: {question}\n"
+            ),
+        }
+        system_text = build_responses_system_input(generation)
+        assert system_text == "You are a retrieval-augmented assistant."
+
+    @pytest.mark.parametrize(
+        ("model_id", "expected_fragment"),
+        [
+            ("meta-llama/llama-3-1-8b-instruct", "150 words"),
+            ("mistralai/mistral-large", "titles of documents"),
+            ("openai/gpt-oss-120b", "Answer Length: concise"),
+        ],
+    )
+    def test_export_merges_family_specific_user_rules(self, model_id: str, expected_fragment: str):
+        """Each model family must preserve user-only rules in exported system input."""
+        generation = {
+            "system_message_text": get_system_message_text(model_id),
+            "user_message_text": get_user_message_text(model_id, language_autodetect=False),
+        }
+        system_text = build_responses_system_input(generation)
+        assert expected_fragment in system_text
 
     def test_preserves_existing_pattern_fields(self):
         """Existing pattern fields (name, chunking, embedding, etc.) must not be altered."""

--- a/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
+++ b/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
@@ -306,6 +306,44 @@ class TestBuildPatternJson:
         system_text = build_responses_system_input(generation)
         assert expected_fragment in system_text
 
+    def test_build_responses_system_input_handles_empty_inputs(self):
+        """When both system and user are empty or contain only placeholders, return fallback."""
+        # Case 1: Completely empty
+        generation = {
+            "system_message_text": "",
+            "user_message_text": "",
+        }
+        system_text = build_responses_system_input(generation)
+        assert system_text == "You are a helpful assistant."
+
+        # Case 2: Only placeholders in user template
+        generation = {
+            "system_message_text": "",
+            "user_message_text": "{reference_documents}\n{question}",
+        }
+        system_text = build_responses_system_input(generation)
+        assert system_text == "You are a helpful assistant."
+
+        # Case 4: Unresolved question slot only (cookbook-style minimal user template)
+        generation = {
+            "system_message_text": "",
+            "user_message_text": "{question}",
+        }
+        system_text = build_responses_system_input(generation)
+        assert system_text == "You are a helpful assistant."
+
+        # Case 3: Only OGX-duplicative content that gets stripped
+        generation = {
+            "system_message_text": "Answer using ONLY the provided documents.",
+            "user_message_text": (
+                "Answer ONLY using information from the documents below.\n"
+                "You MUST cite sources using [1], [2].\n"
+                "{reference_documents}\n{question}"
+            ),
+        }
+        system_text = build_responses_system_input(generation)
+        assert system_text == "You are a helpful assistant."
+
     def test_preserves_existing_pattern_fields(self):
         """Existing pattern fields (name, chunking, embedding, etc.) must not be altered."""
         pattern = _make_pattern()

--- a/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
+++ b/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
@@ -10,6 +10,7 @@ import pytest
 
 from ai4rag.components.assets_generator import build_pattern_json
 from ai4rag.components.assets_generator.pattern_builder import (
+    _is_placeholder_only_export,
     _normalize_answer_scaffold,
     build_responses_system_input,
 )
@@ -61,6 +62,22 @@ def _make_pattern(**overrides) -> dict:
             target = target[k]
         target[keys[-1]] = value
     return base
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", True),
+        ("   ", True),
+        ("{reference_documents}", True),
+        ("{reference_documents}\n{question}", True),
+        ("foo {reference_documents}", False),
+        ("You are a helpful assistant.", False),
+    ],
+)
+def test_is_placeholder_only_export(text: str, expected: bool):
+    """Placeholder-only export text must trigger the empty-input fallback path."""
+    assert _is_placeholder_only_export(text) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -411,15 +428,6 @@ class TestBuildPatternJson:
         with pytest.raises(KeyError):
             build_pattern_json(pattern)
 
-    def test_empty_system_and_user_returns_fallback(self):
-        """Both empty system and user prompts must trigger fallback assistant text."""
-        generation = {
-            "system_message_text": "",
-            "user_message_text": "",
-        }
-        result = build_responses_system_input(generation)
-        assert result == "You are a helpful assistant."
-
     def test_system_grounding_detection_requires_explicit_policy(self):
         """Grounding detection must require explicit 'ONLY' constraint, not just persona."""
         generation_persona_only = {
@@ -439,6 +447,17 @@ class TestBuildPatternJson:
         # Explicit grounding system SHOULD suppress redundant user grounding
         # Both prompts are OGX-duplicative, so fallback is used
         assert result_explicit == "You are a helpful assistant."
+
+    def test_system_grounding_detection_uses_grounding_prefixes(self):
+        """Grounding detection must cover all ``_GROUNDING_PREFIXES`` entries."""
+        generation = {
+            "system_message_text": "Answer ONLY using information from documents retrieved via file search.",
+            "user_message_text": (
+                "Answer ONLY using information from the documents below.\n{reference_documents}\n{question}"
+            ),
+        }
+        result = build_responses_system_input(generation)
+        assert result == "You are a helpful assistant."
 
     def test_preserves_existing_pattern_fields(self):
         """Existing pattern fields (name, chunking, embedding, etc.) must not be altered."""

--- a/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
+++ b/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
@@ -9,7 +9,10 @@ import copy
 import pytest
 
 from ai4rag.components.assets_generator import build_pattern_json
-from ai4rag.components.assets_generator.pattern_builder import build_responses_system_input
+from ai4rag.components.assets_generator.pattern_builder import (
+    _normalize_answer_scaffold,
+    build_responses_system_input,
+)
 from ai4rag.search_space.src.model_props import get_system_message_text, get_user_message_text
 
 # ---------------------------------------------------------------------------
@@ -150,12 +153,24 @@ class TestBuildPatternJson:
         assert ro == {"ranker": "weighted", "alpha": 1.0}
         assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
 
+    def test_hybrid_weighted_alpha_one_uses_default_ranking(self):
+        """Hybrid weighted with alpha=1.0 uses the default semantic-only simulation branch."""
+        pattern = _make_pattern()
+        pattern["settings"]["retrieval"]["search_mode"] = "hybrid"
+        pattern["settings"]["retrieval"]["ranker_strategy"] = "weighted"
+        pattern["settings"]["retrieval"]["ranker_alpha"] = 1.0
+
+        build_pattern_json(pattern)
+
+        ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
+        assert ro == {"ranker": "weighted", "alpha": 1.0}
+
     def test_export_system_input_merges_non_redundant_user_rules(self):
         """Legacy user supplements merge; redundant grounding and citations are omitted."""
         pattern = _make_pattern()
-        pattern["settings"]["generation"]["system_message_text"] = (
-            "You are a retrieval-augmented assistant. Answer using ONLY the provided documents."
-        )
+        pattern["settings"]["generation"][
+            "system_message_text"
+        ] = "You are a retrieval-augmented assistant. Answer using ONLY the provided documents."
         pattern["settings"]["generation"]["user_message_text"] = (
             "Answer ONLY using information from the documents below. "
             "Do not use outside knowledge.\n"
@@ -184,9 +199,9 @@ class TestBuildPatternJson:
     def test_export_system_input_skips_duplicate_citation_and_keeps_answer_scaffold(self):
         """Citation lines are stripped; answer scaffold and language policy still merge."""
         pattern = _make_pattern()
-        pattern["settings"]["generation"]["system_message_text"] = (
-            "You are a retrieval-augmented assistant. You MUST cite sources using [1], [2]."
-        )
+        pattern["settings"]["generation"][
+            "system_message_text"
+        ] = "You are a retrieval-augmented assistant. You MUST cite sources using [1], [2]."
         pattern["settings"]["generation"]["user_message_text"] = (
             "You MUST cite sources using [1], [2], etc.\n\n"
             "Documents:\n{reference_documents}\n\n"
@@ -222,6 +237,13 @@ class TestBuildPatternJson:
     def test_build_pattern_json_uses_export_parity_system_input(self):
         """build_pattern_json must use build_responses_system_input(), not raw system text."""
         model_id = "ibm/granite-3-8b-instruct"
+        expected = build_responses_system_input(
+            {
+                "system_message_text": get_system_message_text(model_id),
+                "user_message_text": get_user_message_text(model_id, language_autodetect=False),
+            }
+        )
+
         pattern = _make_pattern()
         pattern["settings"]["generation"]["model_id"] = model_id
         pattern["settings"]["generation"]["system_message_text"] = get_system_message_text(model_id)
@@ -231,11 +253,9 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        generation = pattern["settings"]["generation"]
-        expected = build_responses_system_input(generation)
         actual = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
         assert actual == expected
-        assert actual != generation["system_message_text"]
+        assert actual != pattern["settings"]["generation"]["system_message_text"]
         assert "Granite Chat" in actual
         assert "Retrieval Augmented Generation" in actual
         assert "i.e.," in actual
@@ -343,6 +363,82 @@ class TestBuildPatternJson:
         }
         system_text = build_responses_system_input(generation)
         assert system_text == "You are a helpful assistant."
+
+    def test_strip_ogx_runtime_partial_sentence_removal(self):
+        """OGX sentences in a multi-sentence system prompt are removed; others are kept."""
+        generation = {
+            "system_message_text": (
+                "You are an expert assistant. " "Answer using ONLY the provided documents. " "Be concise."
+            ),
+            "user_message_text": "",
+        }
+        result = build_responses_system_input(generation)
+        assert "You are an expert assistant" in result
+        assert "Be concise" in result
+        assert "provided documents" not in result.lower()
+
+    def test_user_grounding_merges_when_system_is_persona_only(self):
+        """Persona-only system must not suppress non-OGX user supplements (e.g. RAG block)."""
+        generation = {
+            "system_message_text": "You are a retrieval-augmented assistant. Use your best judgment.",
+            "user_message_text": (
+                "You are a specialized Retrieval Augmented Generation (RAG) assistant. "
+                "Prioritize correctness and ensure your response is grounded in the documents.\n"
+                "{reference_documents}\n{question}"
+            ),
+        }
+        result = build_responses_system_input(generation)
+        assert "retrieval-augmented assistant" in result
+        assert "specialized Retrieval Augmented Generation" in result
+
+    def test_extract_static_user_pure_text_no_slots(self):
+        """Pure static user text without slots is merged into export."""
+        generation = {
+            "system_message_text": "Short system.",
+            "user_message_text": "Always respond in a formal tone.",
+        }
+        result = build_responses_system_input(generation)
+        assert result == "Short system.\n\nAlways respond in a formal tone."
+
+    def test_normalize_answer_scaffold_strips_with_citations(self):
+        """Answer scaffolds must not retain citation hints owned by OGX."""
+        assert _normalize_answer_scaffold("Answer (max 150 words, with citations):") == "Answer (max 150 words):"
+
+    def test_build_pattern_json_requires_generation_model_id(self):
+        """Malformed generation payloads must raise KeyError for required fields."""
+        pattern = _make_pattern()
+        del pattern["settings"]["generation"]["model_id"]
+        with pytest.raises(KeyError):
+            build_pattern_json(pattern)
+
+    def test_empty_system_and_user_returns_fallback(self):
+        """Both empty system and user prompts must trigger fallback assistant text."""
+        generation = {
+            "system_message_text": "",
+            "user_message_text": "",
+        }
+        result = build_responses_system_input(generation)
+        assert result == "You are a helpful assistant."
+
+    def test_system_grounding_detection_requires_explicit_policy(self):
+        """Grounding detection must require explicit 'ONLY' constraint, not just persona."""
+        generation_persona_only = {
+            "system_message_text": "You are a retrieval-augmented assistant. Use your best judgment.",
+            "user_message_text": "Answer ONLY using information from the documents below.\n{reference_documents}\n{question}",
+        }
+        result_persona = build_responses_system_input(generation_persona_only)
+        # Persona-only system should NOT trigger grounding suppression
+        assert "retrieval-augmented assistant" in result_persona
+        assert "use your best judgment" in result_persona.lower()
+
+        generation_explicit = {
+            "system_message_text": "Answer using ONLY the provided documents.",
+            "user_message_text": "Answer ONLY using information from the documents below.\n{reference_documents}\n{question}",
+        }
+        result_explicit = build_responses_system_input(generation_explicit)
+        # Explicit grounding system SHOULD suppress redundant user grounding
+        # Both prompts are OGX-duplicative, so fallback is used
+        assert result_explicit == "You are a helpful assistant."
 
     def test_preserves_existing_pattern_fields(self):
         """Existing pattern fields (name, chunking, embedding, etc.) must not be altered."""


### PR DESCRIPTION
## Description

HPO optimizes RAG patterns using **Chat Completions** (`system_message_text` + formatted `user_message_text` with inline documents). Exported patterns run on OGX via the **Responses API** + `file_search`, where retrieval context and citations are injected at runtime from `benchmarking/rag/config.yaml`.

Previously, `build_pattern_json()` copied only `system_message_text` into `responses_template.input[system]`, dropping user-template rules (RAG behavior, answer length, language policy) that HPO actually tuned. This PR adds export parity via `build_responses_system_input()` while avoiding duplication of OGX-owned prompt text.

## Motivation

- **Eval / deploy mismatch:** HPO sends grounding, length, and language rules in the user message; export sent a weaker system-only prompt → different behavior at inference.
- **OGX responsibility split:** `context_prompt_params`, `annotation_prompt_params`, and `file_search_params` inject retrieval framing and `<|file-id|>` citations at runtime — export must not repeat or substitute that wording.
- **RHOAIENG-71231:** Complete the Chat Completions → Responses parameter mapping started in the responses_template shape work.

## Changes

- Add **`build_responses_system_input()`** to merge non-redundant static supplements from `user_message_text` into `input[role=system]` (persona, answer length, language policy, family-specific rules).
- Strip runtime slots and OGX-duplicative content: `{reference_documents}`, `{question}`, `[1],[2]` citations, `documents below` grounding, and phrases from OGX `config.yaml` templates — **strip only, no replacement text**.
- Wire **`build_pattern_json()`** to use merged system input; preserve `detected_language` on `generation` before export.
- Keep existing **`responses_template`** API shape: structured `input[]`, `tool_choice: file_search`, `tools[]`, `ranking_options`, `temperature`, `max_output_tokens`, `include`.
- Include **`temperature`** and **`max_completion_tokens`** in experiment generation payload so export can bind generation params.
- Add **21 unit tests** covering export parity, all default model families, legacy prompt patterns, and OGX non-duplication.

## Architecture (3-phase flow)

| Phase | Responsibility |
|-------|----------------|
| **HPO** | Chat Completions with full system + user prompts |
| **Export** | Persona + HPO-only rules in `input[system]`; question placeholder in `input[user]`; `file_search` tool config |
| **OGX runtime** | Chunk presentation, retrieval framing, `<\|file-id\|>` citation instructions |

Reference: [chat_completion_to_responses.md](https://github.com/IBM/architecture-decision-records/blob/main/documentation/components/autorag/features/chat_completion_to_responses.md)

## Testing

- [x] `pytest tests/unit/ai4rag/assets_generator/test_pattern_builder.py` (21 tests)
- [x] `uv run black --check ai4rag/`
- [ ] Functional smoke on OGX rag-benchmarks with `enable_annotations: true` (manual)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (ADR alignment in `architecture-decision-records`)
- [x] Code follows style guide
- [ ] All checks passing (CI)

## Changes
- Bullet point list of changes
- Another change

## Testing
How did you test this?

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
