### PR TITLE
fix(embedding): truncate chunks exceeding context length in OGXEmbeddingModel

### DIFF
--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -127,7 +127,9 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
 
         return [
             data.embedding
-            for data in self.client.embeddings.create(input=text_input, model=self.model_id).data
+            for data in self.client.embeddings.create(
+                input=text_input, model=self.model_id, extra_body={"truncate_prompt_tokens": -1}
+            ).data
             if not isinstance(data.embedding, str)
         ]
 

--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -15,7 +15,7 @@ __all__ = ["OGXEmbeddingModel", "OGXEmbeddingParams"]
 
 
 MIN_CONTEXT_LENGTH = 700
-_CHARS_PER_TOKEN = 5
+_CHARS_PER_TOKEN = 3
 _TRUNCATION_MARGINS = (0.05, 0.10)
 
 
@@ -93,6 +93,11 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
         remaining interval is smaller than 256 tokens, keeping the number
         of API calls to roughly 5.
 
+        Calls the embedding API directly with ``truncate_prompt_tokens``
+        set to ``None`` so that oversized probes are rejected by the
+        server rather than silently truncated (the server may default
+        to ``-1`` which auto-truncates to ``max_model_len``).
+
         Raises
         ------
         RuntimeError
@@ -103,7 +108,11 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
             mid = (lo + hi) // 2
             probe_text = "word " * mid
             try:
-                self._embed_text(text_input=probe_text)
+                self.client.embeddings.create(
+                    input=probe_text,
+                    model=self.model_id,
+                    extra_body={"truncate_prompt_tokens": None},
+                )
                 best = mid
                 lo = mid + 1
             except Exception:  # pylint: disable=broad-exception-caught
@@ -177,7 +186,8 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
         Raises
         ------
         BadRequestError
-            When all truncation attempts fail.
+            When all truncation attempts fail (the original error is
+            re-raised).
         """
         try:
             return self._call_embedding_api(text_input)

--- a/ai4rag/rag/embedding/ogx.py
+++ b/ai4rag/rag/embedding/ogx.py
@@ -5,7 +5,9 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from ogx_client import OgxClient
+from ogx_client import BadRequestError, OgxClient
+
+from ai4rag import logger
 
 from .base_model import BaseEmbeddingModel
 
@@ -13,6 +15,8 @@ __all__ = ["OGXEmbeddingModel", "OGXEmbeddingParams"]
 
 
 MIN_CONTEXT_LENGTH = 700
+_CHARS_PER_TOKEN = 5
+_TRUNCATION_MARGINS = (0.05, 0.10)
 
 
 @dataclass
@@ -111,20 +115,19 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
             "Provide 'context_length' explicitly or ensure the embedding service is reachable."
         )
 
-    def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
-        """Embeds documents.
+    def _call_embedding_api(self, text_input: list[str] | str) -> list[list[float]]:
+        """Send a raw embedding request to the OGX server.
 
         Parameters
         ----------
         text_input : list[str] | str
-            List of text-like chunks or single text-like chunk.
+            Single text or a list of texts to embed.
 
         Returns
         -------
         list[list[float]]
-            Embeddings made from the list of texts or a single text.
+            Embedding vectors corresponding to the input texts.
         """
-
         return [
             data.embedding
             for data in self.client.embeddings.create(
@@ -132,6 +135,65 @@ class OGXEmbeddingModel(BaseEmbeddingModel[OgxClient, OGXEmbeddingParams]):
             ).data
             if not isinstance(data.embedding, str)
         ]
+
+    def _truncate_text(self, text: str, margin: float) -> str:
+        """Truncate text to fit within the model's context length.
+
+        Uses a character-based token estimate (``_CHARS_PER_TOKEN`` chars per
+        token) and reduces the allowed length by the given margin.
+
+        Parameters
+        ----------
+        text : str
+            Text to truncate.
+        margin : float
+            Fraction of context length to cut (e.g. 0.05 for 5%).
+
+        Returns
+        -------
+        str
+            Truncated text, or the original if it already fits.
+        """
+        max_chars = int(self._params.context_length * (1 - margin) * _CHARS_PER_TOKEN)
+        return text[:max_chars]
+
+    def _embed_text(self, text_input: list[str] | str) -> list[list[float]]:
+        """Embed text with automatic batch-level truncation fallback.
+
+        Attempts the batch call as-is first. On ``BadRequestError``, retries
+        the entire batch with progressively stronger truncation margins
+        (5%, then 10%). If all attempts fail, the last error is re-raised.
+
+        Parameters
+        ----------
+        text_input : list[str] | str
+            Single text or a list of texts to embed.
+
+        Returns
+        -------
+        list[list[float]]
+            Embedding vectors corresponding to the input texts.
+
+        Raises
+        ------
+        BadRequestError
+            When all truncation attempts fail.
+        """
+        try:
+            return self._call_embedding_api(text_input)
+        except BadRequestError:
+            texts = [text_input] if isinstance(text_input, str) else text_input
+            for margin in _TRUNCATION_MARGINS:
+                truncated = [self._truncate_text(t, margin) for t in texts]
+                try:
+                    return self._call_embedding_api(truncated)
+                except BadRequestError:
+                    logger.warning(
+                        "Batch embedding failed after truncating %.0f%% of context length. Model: %s.",
+                        margin * 100,
+                        self.model_id,
+                    )
+            raise
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embeds given list of strings.

--- a/tests/unit/ai4rag/rag/embedding/test_ogx.py
+++ b/tests/unit/ai4rag/rag/embedding/test_ogx.py
@@ -3,9 +3,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 
+import httpx
 import pytest
+from ogx_client import BadRequestError
 
-from ai4rag.rag.embedding.ogx import MIN_CONTEXT_LENGTH, OGXEmbeddingModel, OGXEmbeddingParams
+from ai4rag.rag.embedding.ogx import (
+    _CHARS_PER_TOKEN,
+    _TRUNCATION_MARGINS,
+    MIN_CONTEXT_LENGTH,
+    OGXEmbeddingModel,
+    OGXEmbeddingParams,
+)
+
+
+def _make_bad_request_error():
+    """Create a BadRequestError for testing."""
+    return BadRequestError(
+        message="Input too long",
+        response=httpx.Response(status_code=400, request=httpx.Request("POST", "http://test")),
+        body=None,
+    )
 
 
 def _make_mock_ogx_embedding_response(mocker, embeddings):
@@ -271,3 +288,130 @@ class TestOGXEmbeddingModel:
 
         assert repr(model) == "all-MiniLM-L6-v2"
         assert str(model) == "all-MiniLM-L6-v2"
+
+
+class TestEmbeddingTruncationFallback:
+    """Test suite for the progressive truncation fallback in _embed_text."""
+
+    CONTEXT_LENGTH = 1024
+
+    @pytest.fixture
+    def model(self, mocker):
+        mock_client = mocker.MagicMock()
+        return OGXEmbeddingModel(
+            client=mock_client,
+            model_id="test-model",
+            params=OGXEmbeddingParams(embedding_dimension=3, context_length=self.CONTEXT_LENGTH),
+        )
+
+    def test_batch_success_no_fallback(self, model, mocker):
+        """When the batch call succeeds, no fallback is triggered."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        model.client.embeddings.create.return_value = ok_response
+
+        result = model.embed_documents(["short text", "another"])
+
+        assert len(result) == 2
+        assert model.client.embeddings.create.call_count == 1
+
+    def test_first_truncation_retries_entire_batch(self, model, mocker):
+        """When batch fails, the entire batch is retried with 5% truncation."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+        model.client.embeddings.create.side_effect = [
+            _make_bad_request_error(),  # original batch fails
+            ok_response,  # 5% truncated batch succeeds
+        ]
+
+        result = model.embed_documents(["text1", "text2"])
+
+        assert len(result) == 2
+        assert model.client.embeddings.create.call_count == 2
+
+    def test_first_truncation_margin_truncates_oversized(self, model, mocker):
+        """5% truncation clips oversized texts to the expected character limit."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+        oversized_text = "x" * (self.CONTEXT_LENGTH * _CHARS_PER_TOKEN + 500)
+
+        model.client.embeddings.create.side_effect = [
+            _make_bad_request_error(),
+            ok_response,
+        ]
+
+        result = model.embed_documents([oversized_text])
+
+        assert len(result) == 1
+        retry_input = model.client.embeddings.create.call_args_list[-1].kwargs["input"]
+        expected_max = int(self.CONTEXT_LENGTH * (1 - _TRUNCATION_MARGINS[0]) * _CHARS_PER_TOKEN)
+        assert len(retry_input[0]) == expected_max
+
+    def test_second_truncation_margin_succeeds(self, model, mocker):
+        """When 5% truncation also fails, 10% truncation is attempted as a batch."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+        oversized_text = "x" * (self.CONTEXT_LENGTH * _CHARS_PER_TOKEN + 500)
+
+        model.client.embeddings.create.side_effect = [
+            _make_bad_request_error(),  # original batch fails
+            _make_bad_request_error(),  # 5% truncated batch fails
+            ok_response,  # 10% truncated batch succeeds
+        ]
+
+        result = model.embed_documents([oversized_text])
+
+        assert len(result) == 1
+        assert model.client.embeddings.create.call_count == 3
+        retry_input = model.client.embeddings.create.call_args_list[-1].kwargs["input"]
+        expected_max = int(self.CONTEXT_LENGTH * (1 - _TRUNCATION_MARGINS[1]) * _CHARS_PER_TOKEN)
+        assert len(retry_input[0]) == expected_max
+
+    def test_all_truncations_fail_raises(self, model):
+        """When all truncation attempts fail, BadRequestError is re-raised."""
+        model.client.embeddings.create.side_effect = _make_bad_request_error()
+
+        with pytest.raises(BadRequestError):
+            model.embed_documents(["x" * 100_000])
+
+    def test_short_texts_unchanged_after_truncation(self, model, mocker):
+        """Short texts are not affected by the truncation slice."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        short_text = "short"
+
+        model.client.embeddings.create.side_effect = [
+            _make_bad_request_error(),
+            ok_response,
+        ]
+
+        result = model.embed_documents([short_text, short_text])
+
+        assert len(result) == 2
+        retry_input = model.client.embeddings.create.call_args_list[-1].kwargs["input"]
+        assert retry_input[0] == short_text
+        assert retry_input[1] == short_text
+
+    def test_truncation_preserves_document_order(self, model, mocker):
+        """Embeddings maintain 1:1 correspondence with input texts after fallback."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+        model.client.embeddings.create.side_effect = [
+            _make_bad_request_error(),
+            ok_response,
+        ]
+
+        result = model.embed_documents(["a", "b", "c"])
+
+        assert result == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    def test_embed_query_fallback(self, model, mocker):
+        """embed_query also benefits from the truncation fallback."""
+        ok_response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+        oversized_query = "x" * (self.CONTEXT_LENGTH * _CHARS_PER_TOKEN + 500)
+
+        model.client.embeddings.create.side_effect = [
+            _make_bad_request_error(),  # original fails
+            _make_bad_request_error(),  # 5% truncation fails
+            ok_response,  # 10% truncation succeeds
+        ]
+
+        result = model.embed_query(oversized_query)
+
+        assert result == [0.1, 0.2, 0.3]

--- a/tests/unit/ai4rag/rag/embedding/test_ogx.py
+++ b/tests/unit/ai4rag/rag/embedding/test_ogx.py
@@ -161,6 +161,21 @@ class TestOGXEmbeddingModel:
         with pytest.raises(RuntimeError, match="Failed to auto-detect 'context_length'"):
             OGXEmbeddingModel(client=mock_client, model_id="test-model", params=None)
 
+    def test_detect_context_length_disables_server_truncation(self, mocker):
+        """Test that context_length probes send truncate_prompt_tokens=None to override server defaults."""
+        mock_client = mocker.MagicMock()
+        response = _make_mock_ogx_embedding_response(mocker, [[0.1, 0.2, 0.3]])
+        mock_client.embeddings.create.return_value = response
+
+        OGXEmbeddingModel(client=mock_client, model_id="test-model", params=OGXEmbeddingParams(embedding_dimension=384))
+
+        probe_calls = [
+            call
+            for call in mock_client.embeddings.create.call_args_list
+            if call.kwargs.get("extra_body") == {"truncate_prompt_tokens": None}
+        ]
+        assert len(probe_calls) > 0, "Detection probes must explicitly disable server-side truncation"
+
     def test_detect_context_length_skipped_when_explicit(self, mock_ogx_client):
         """Test that context_length detection is skipped when explicitly provided."""
         params = OGXEmbeddingParams(embedding_dimension=384, context_length=1024)


### PR DESCRIPTION
## Description

Adds a two-layer defense against `BadRequestError` when embedding chunks that exceed the model's context length in `OGXEmbeddingModel`. The first layer passes `truncate_prompt_tokens: -1` to the vLLM server so it truncates inputs server-side. The second layer is a client-side fallback that progressively truncates oversized texts using character-based token estimates when the server cannot handle truncation on its own.

## Motivation

When chunks exceed the embedding model's `context_length`, the OGX/vLLM server rejects the entire batch with a `BadRequestError`. This causes indexing pipelines to fail on corpora containing long documents. Server-side truncation via `truncate_prompt_tokens` is the preferred fix, but not all vLLM deployments support this parameter — hence the client-side fallback is needed as a safety net.

## Changes

| Area | What changed |
|------|-------------|
| `ai4rag/rag/embedding/ogx.py` | Extracted `_call_embedding_api` from `_embed_text` to isolate the raw API call and add `truncate_prompt_tokens: -1` to the request body |
| `ai4rag/rag/embedding/ogx.py` | Added `_truncate_text` helper that clips text to `context_length * (1 - margin) * _CHARS_PER_TOKEN` characters |
| `ai4rag/rag/embedding/ogx.py` | Rewrote `_embed_text` as an orchestrator: try the batch as-is, then retry the entire batch with 5% and 10% truncation margins on `BadRequestError` |
| `ai4rag/rag/embedding/ogx.py` | Added module constants `_CHARS_PER_TOKEN = 5` and `_TRUNCATION_MARGINS = (0.05, 0.10)` |
| `tests/unit/ai4rag/rag/embedding/test_ogx.py` | Added `TestEmbeddingTruncationFallback` suite (9 tests) covering: no-fallback success, first/second margin retry, all-retries-fail raises, short texts unaffected, document order preserved, and `embed_query` fallback |

## Testing

- [x] `pytest tests/unit/ai4rag/rag/embedding/test_ogx.py` (9 new + existing tests)
- [ ] Functional smoke: index a corpus with chunks near the context boundary and verify no API failures

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Code follows style guide
- [ ] All checks passing