### PR TITLE
fix(hpo): wire random_state parameter for deterministic optimization

### DIFF
--- a/ai4rag/core/hpo/base_optimizer.py
+++ b/ai4rag/core/hpo/base_optimizer.py
@@ -28,6 +28,12 @@ class OptimizerSettings:
     ----------
     max_evals : int
         Maximum number of evaluations performed during optimization process.
+    random_state : int, default=64
+        Seed for random number generator controlling exploration order.
+        Use the same seed across runs to get deterministic evaluation
+        sequences (given deterministic objective function scores).
+        Does NOT control: LLM temperature, benchmark sampling, or other
+        non-optimizer randomness.
 
     Methods
     -------
@@ -36,6 +42,7 @@ class OptimizerSettings:
     """
 
     max_evals: int
+    random_state: int = 64
 
     def to_dict(self) -> dict:
         """

--- a/ai4rag/core/hpo/base_optimizer.py
+++ b/ai4rag/core/hpo/base_optimizer.py
@@ -32,8 +32,6 @@ class OptimizerSettings:
         Seed for random number generator controlling exploration order.
         Use the same seed across runs to get deterministic evaluation
         sequences (given deterministic objective function scores).
-        Does NOT control: LLM temperature, benchmark sampling, or other
-        non-optimizer randomness.
 
     Methods
     -------

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -75,6 +75,7 @@ class GAMOptimizer(BaseOptimizer):
         self.evaluations = []
         self._evaluated_combinations = []
         self._encoders_with_columns: list[tuple[str, LabelEncoder]] = []
+        self._rng = random.Random(self.settings.random_state)
 
         if known_observations:
             self._load_known_observations(known_observations)
@@ -193,7 +194,7 @@ class GAMOptimizer(BaseOptimizer):
             return
 
         combinations_local = [c for c in copy(self._search_space.combinations) if c not in self._evaluated_combinations]
-        random.shuffle(combinations_local)
+        self._rng.shuffle(combinations_local)
 
         gen = (x for x in combinations_local)
 

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -29,6 +29,8 @@ class GAMOptSettings(OptimizerSettings):
 
     Parameters
     ----------
+    max_evals : int
+        Maximum number of evaluations performed during optimization process.
     n_random_nodes : int, default=4
         Number of random configurations to evaluate before starting GAM iterations.
     evals_per_trial : int, default=1
@@ -36,7 +38,7 @@ class GAMOptSettings(OptimizerSettings):
     random_state : int, default=64
         Inherited from OptimizerSettings. Controls shuffle order of initial
         random exploration phase. Does NOT control GAM model randomness
-        (GAM training is deterministic) or LLM generation stochasticity.
+        (GAM training is deterministic).
     """
 
     n_random_nodes: int = 4
@@ -85,7 +87,6 @@ class GAMOptimizer(BaseOptimizer):
         self.evaluations = []
         self._evaluated_combinations = []
         self._encoders_with_columns: list[tuple[str, LabelEncoder]] = []
-        self._rng = random.Random(self.settings.random_state)
 
         if known_observations:
             self._load_known_observations(known_observations)
@@ -204,7 +205,7 @@ class GAMOptimizer(BaseOptimizer):
             return
 
         combinations_local = [c for c in copy(self._search_space.combinations) if c not in self._evaluated_combinations]
-        self._rng.shuffle(combinations_local)
+        random.Random(self.settings.random_state).shuffle(combinations_local)
 
         gen = (x for x in combinations_local)
 

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -26,11 +26,21 @@ class GAMOptSettings(OptimizerSettings):
     Settings for the GAMOptimizer. For the detailed description
     of parameters for Generalized Additive Models, please see pygam
     documentation.
+
+    Parameters
+    ----------
+    n_random_nodes : int, default=4
+        Number of random configurations to evaluate before starting GAM iterations.
+    evals_per_trial : int, default=1
+        Number of configurations to evaluate per GAM iteration.
+    random_state : int, default=64
+        Inherited from OptimizerSettings. Controls shuffle order of initial
+        random exploration phase. Does NOT control GAM model randomness
+        (GAM training is deterministic) or LLM generation stochasticity.
     """
 
     n_random_nodes: int = 4
     evals_per_trial: int = 1
-    random_state: int = 64
 
 
 class GAMOptimizer(BaseOptimizer):

--- a/ai4rag/core/hpo/random_opt.py
+++ b/ai4rag/core/hpo/random_opt.py
@@ -23,8 +23,7 @@ class RandomOptSettings(OptimizerSettings):
         Maximum number of configurations to evaluate.
     random_state : int, default=64
         Inherited from OptimizerSettings. Controls shuffle order of
-        search space combinations. Does NOT control LLM generation
-        stochasticity or benchmark sampling randomness.
+        search space combinations.
     """
 
 
@@ -36,7 +35,6 @@ class RandomOptimizer(BaseOptimizer):
     ):
         super().__init__(objective_function, search_space, settings)
         self._evaluated_combinations = []
-        self._rng = random.Random(self.settings.random_state)
 
     def search(self) -> dict[str, Any]:
         """
@@ -54,7 +52,7 @@ class RandomOptimizer(BaseOptimizer):
             When there were no successful evaluations for given constraints.
         """
         combinations = list(self._search_space.combinations)
-        self._rng.shuffle(combinations)
+        random.Random(self.settings.random_state).shuffle(combinations)
 
         for idx in range(self.settings.max_evals):
             score = self._objective_function(combinations[idx])

--- a/ai4rag/core/hpo/random_opt.py
+++ b/ai4rag/core/hpo/random_opt.py
@@ -15,9 +15,17 @@ __all__ = ["RandomOptimizer", "RandomOptSettings", "FailedIterationError"]
 
 @dataclass
 class RandomOptSettings(OptimizerSettings):
-    """Settings for random optimizer."""
+    """Settings for random optimizer.
 
-    random_state: int = 64
+    Parameters
+    ----------
+    max_evals : int
+        Maximum number of configurations to evaluate.
+    random_state : int, default=64
+        Inherited from OptimizerSettings. Controls shuffle order of
+        search space combinations. Does NOT control LLM generation
+        stochasticity or benchmark sampling randomness.
+    """
 
 
 class RandomOptimizer(BaseOptimizer):

--- a/ai4rag/core/hpo/random_opt.py
+++ b/ai4rag/core/hpo/random_opt.py
@@ -17,6 +17,8 @@ __all__ = ["RandomOptimizer", "RandomOptSettings", "FailedIterationError"]
 class RandomOptSettings(OptimizerSettings):
     """Settings for random optimizer."""
 
+    random_state: int = 64
+
 
 class RandomOptimizer(BaseOptimizer):
     """Optimizer running random search on the given search space."""
@@ -26,6 +28,7 @@ class RandomOptimizer(BaseOptimizer):
     ):
         super().__init__(objective_function, search_space, settings)
         self._evaluated_combinations = []
+        self._rng = random.Random(self.settings.random_state)
 
     def search(self) -> dict[str, Any]:
         """
@@ -42,8 +45,8 @@ class RandomOptimizer(BaseOptimizer):
         OptimizationError
             When there were no successful evaluations for given constraints.
         """
-        combinations = self._search_space.combinations
-        random.shuffle(combinations)
+        combinations = list(self._search_space.combinations)
+        self._rng.shuffle(combinations)
 
         for idx in range(self.settings.max_evals):
             score = self._objective_function(combinations[idx])

--- a/docs/user-guide/optimizers.md
+++ b/docs/user-guide/optimizers.md
@@ -266,7 +266,8 @@ No model training, no prediction - just random sampling.
 from ai4rag.core.hpo.random_opt import RandomOptSettings
 
 optimizer_settings = RandomOptSettings(
-    max_evals=10  # Only required parameter
+    max_evals=10,       # Number of configurations to evaluate (required)
+    random_state=64     # Random seed for reproducibility (default: 64)
 )
 ```
 

--- a/tests/unit/ai4rag/core/hpo/test_base_optimizer.py
+++ b/tests/unit/ai4rag/core/hpo/test_base_optimizer.py
@@ -59,7 +59,7 @@ class TestOptimizerSettings:
         settings = OptimizerSettings(max_evals=20)
         settings_dict = settings.to_dict()
 
-        assert settings_dict == {"max_evals": 20}
+        assert settings_dict == {"max_evals": 20, "random_state": 64}
         assert isinstance(settings_dict, dict)
 
 

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -771,3 +771,79 @@ class TestGAMOptimizerKnownObservations:
         # Mutating optimizer's evaluations should not affect the original
         optimizer.evaluations[0]["score"] = 999
         assert known[0]["score"] == 0.3
+
+
+class TestGAMOptimizerDeterminism:
+    """Test deterministic behavior with random_state."""
+
+    @pytest.fixture
+    def mock_search_space(self):
+        """Create a mock search space with predefined combinations."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"param1": "a", "param2": 1},
+            {"param1": "b", "param2": 2},
+            {"param1": "c", "param2": 3},
+            {"param1": "d", "param2": 4},
+            {"param1": "e", "param2": 5},
+            {"param1": "f", "param2": 6},
+        ]
+        mock_space.max_combinations = 6
+        return mock_space
+
+    def test_gam_optimizer_deterministic_with_same_random_state(self, mock_search_space):
+        """Test that GAMOptimizer produces identical evaluation order with same random_state."""
+        settings = GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=42)
+
+        # Mock objective to return deterministic scores based on param2 value
+        def deterministic_objective(params):
+            return params["param2"] / 10.0
+
+        # First run
+        optimizer1 = GAMOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        optimizer1.evaluate_initial_random_nodes()
+        evals1 = [e["param1"] for e in optimizer1.evaluations]
+
+        # Second run with same random_state
+        optimizer2 = GAMOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        optimizer2.evaluate_initial_random_nodes()
+        evals2 = [e["param1"] for e in optimizer2.evaluations]
+
+        # Should evaluate same combinations in same order
+        assert evals1 == evals2
+        assert len(evals1) == 3
+
+    def test_gam_optimizer_different_with_different_random_state(self, mock_search_space):
+        """Test that GAMOptimizer produces different evaluation order with different random_state."""
+
+        def deterministic_objective(params):
+            return params["param2"] / 10.0
+
+        # First run with random_state=42
+        optimizer1 = GAMOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=42),
+        )
+        optimizer1.evaluate_initial_random_nodes()
+        evals1 = [e["param1"] for e in optimizer1.evaluations]
+
+        # Second run with random_state=99
+        optimizer2 = GAMOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=99),
+        )
+        optimizer2.evaluate_initial_random_nodes()
+        evals2 = [e["param1"] for e in optimizer2.evaluations]
+
+        # Should evaluate different combinations or different order
+        assert evals1 != evals2

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -250,10 +250,9 @@ class TestGAMOptimizer:
         # ceil((6 - 4) / 2) = ceil(1) = 1
         assert iterations_limit == 1
 
-    def test_evaluate_initial_random_nodes(self, mock_search_space, optimizer_settings, mocker):
+    def test_evaluate_initial_random_nodes(self, mock_search_space, optimizer_settings):
         """Test the evaluate_initial_random_nodes method."""
         objective_func = MagicMock(side_effect=[0.3, 0.7, 0.5])
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -272,7 +271,7 @@ class TestGAMOptimizer:
         for evaluation in optimizer.evaluations:
             assert "score" in evaluation
 
-    def test_evaluate_initial_random_nodes_with_failures(self, mock_search_space, optimizer_settings, mocker):
+    def test_evaluate_initial_random_nodes_with_failures(self, mock_search_space, optimizer_settings):
         """Test evaluate_initial_random_nodes skips failed iterations (score=None) when counting successes."""
         # First fails (returns None), second succeeds, third fails (returns None), fourth succeeds, fifth succeeds
         objective_func = MagicMock(
@@ -284,7 +283,6 @@ class TestGAMOptimizer:
                 0.3,
             ]
         )
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -302,12 +300,11 @@ class TestGAMOptimizer:
         failed_evals = [e for e in optimizer.evaluations if e["score"] is None]
         assert len(failed_evals) == 2
 
-    def test_evaluate_initial_random_nodes_stops_at_max_iterations(self, mock_search_space, mocker):
+    def test_evaluate_initial_random_nodes_stops_at_max_iterations(self, mock_search_space):
         """Test that evaluate_initial_random_nodes stops at max_iterations."""
         settings = GAMOptSettings(max_evals=4, n_random_nodes=10)
         # All fail
         objective_func = MagicMock(side_effect=[FailedIterationError("Failed")] * 10)
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -341,7 +338,7 @@ class TestGAMOptimizer:
         assert "param1" in column_names
         assert "param2" in column_names
 
-    def test_prepare_encoder_called_only_once(self, mock_search_space, optimizer_settings, mocker):
+    def test_prepare_encoder_called_only_once(self, mock_search_space, optimizer_settings):
         """Test that _prepare_encoder only prepares encoders once."""
         objective_func = MagicMock(return_value=0.5)
 
@@ -371,8 +368,6 @@ class TestGAMOptimizer:
         mock_gam_class.return_value = mock_gam_instance
 
         objective_func = MagicMock(side_effect=[0.3, 0.5, 0.9])  # 2 initial + 1 from iteration
-
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -407,7 +402,6 @@ class TestGAMOptimizer:
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
         objective_func = MagicMock(side_effect=[0.3, 0.5, 0.8, 0.6, 0.4])
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -422,12 +416,11 @@ class TestGAMOptimizer:
         assert result["score"] == 0.8
         assert len(optimizer.evaluations) == 5
 
-    def test_search_all_iterations_failed(self, mock_search_space, mocker):
+    def test_search_all_iterations_failed(self, mock_search_space):
         """Test search when all iterations fail."""
         settings = GAMOptSettings(max_evals=3, n_random_nodes=3)
 
         objective_func = MagicMock(side_effect=[FailedIterationError("Failed")] * 10)
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -465,7 +458,6 @@ class TestGAMOptimizer:
                 0.6,  # GAM iteration 2
             ]
         )
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -489,7 +481,6 @@ class TestGAMOptimizer:
         mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
 
         objective_func = MagicMock(side_effect=[0.3, 0.5, 0.8, 0.6])  # 2 initial + 2 from iteration
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -522,7 +513,6 @@ class TestGAMOptimizer:
                 0.6,  # extra for _run_iteration
             ]
         )
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -609,14 +599,13 @@ class TestGAMOptimizerKnownObservations:
         # Evaluations should still be the 3 known ones
         assert len(optimizer.evaluations) == 3
 
-    def test_known_observations_partial_random_phase(self, mock_search_space, mocker):
+    def test_known_observations_partial_random_phase(self, mock_search_space):
         """When known observations < n_random_nodes, only the gap is filled."""
         known = [
             {"param1": "a", "param2": 1, "score": 0.3},
         ]
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3)
         objective_func = MagicMock(side_effect=[0.5, 0.8])
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -631,14 +620,13 @@ class TestGAMOptimizerKnownObservations:
         assert objective_func.call_count == 2
         assert len(optimizer.evaluations) == 3
 
-    def test_known_observations_excludes_already_evaluated(self, mock_search_space, mocker):
+    def test_known_observations_excludes_already_evaluated(self, mock_search_space):
         """Known observation combinations are excluded from random phase candidates."""
         known = [
             {"param1": "a", "param2": 1, "score": 0.3},
         ]
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3)
         objective_func = MagicMock(side_effect=[0.5, 0.8])
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -668,7 +656,7 @@ class TestGAMOptimizerKnownObservations:
                 known_observations=known,
             )
 
-    def test_known_observations_with_none_scores(self, mock_search_space, mocker):
+    def test_known_observations_with_none_scores(self, mock_search_space):
         """Known observations with None scores don't count as successful."""
         known = [
             {"param1": "a", "param2": 1, "score": None},
@@ -676,7 +664,6 @@ class TestGAMOptimizerKnownObservations:
         ]
         settings = GAMOptSettings(max_evals=6, n_random_nodes=3)
         objective_func = MagicMock(side_effect=[0.5, 0.8])
-        mocker.patch("ai4rag.core.hpo.gam_opt.random.shuffle")
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
@@ -847,3 +834,51 @@ class TestGAMOptimizerDeterminism:
 
         # Should evaluate different combinations or different order
         assert evals1 != evals2
+
+    def test_gam_full_search_deterministic_with_same_random_state(self, mock_search_space, mocker):
+        """Test that full GAMOptimizer.search() produces identical evaluation order with same random_state."""
+        settings = GAMOptSettings(max_evals=6, n_random_nodes=2, evals_per_trial=1, random_state=42)
+
+        # Mock LinearGAM to return deterministic predictions
+        mock_gam = MagicMock()
+        mock_gam.predict.side_effect = [
+            np.array([0.6, 0.7, 0.5, 0.4]),  # First iteration: 4 remaining
+            np.array([0.65, 0.55, 0.45]),  # Second iteration: 3 remaining
+            np.array([0.62, 0.58]),  # Third iteration: 2 remaining
+            np.array([0.60]),  # Fourth iteration: 1 remaining
+        ]
+        mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
+
+        def deterministic_objective(params):
+            return params["param2"] / 10.0
+
+        # First run
+        optimizer1 = GAMOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        result1 = optimizer1.search()
+        evals1 = [(e["param1"], e["param2"]) for e in optimizer1.evaluations]
+
+        # Reset mock
+        mock_gam.predict.side_effect = [
+            np.array([0.6, 0.7, 0.5, 0.4]),
+            np.array([0.65, 0.55, 0.45]),
+            np.array([0.62, 0.58]),
+            np.array([0.60]),
+        ]
+
+        # Second run with same random_state
+        optimizer2 = GAMOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        result2 = optimizer2.search()
+        evals2 = [(e["param1"], e["param2"]) for e in optimizer2.evaluations]
+
+        # Should evaluate same combinations in same order (full search, not just initial phase)
+        assert evals1 == evals2
+        assert result1 == result2
+        assert len(evals1) == 6

--- a/tests/unit/ai4rag/core/hpo/test_random_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_random_opt.py
@@ -2,7 +2,7 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -174,9 +174,11 @@ class TestRandomOptimizer:
         assert result is None
         objective_func.assert_called_once_with(params)
 
-    def test_search_shuffles_combinations(self, mock_search_space, optimizer_settings):
+    @patch("ai4rag.core.hpo.random_opt.random.Random")
+    def test_search_shuffles_combinations(self, mock_random_cls, mock_search_space, optimizer_settings):
         """Test that search shuffles combinations before evaluation."""
         objective_func = MagicMock(return_value=0.5)
+        mock_rng = mock_random_cls.return_value
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -184,13 +186,10 @@ class TestRandomOptimizer:
             settings=optimizer_settings,
         )
 
-        # Mock the optimizer's RNG instance
-        optimizer._rng.shuffle = MagicMock()
-
         optimizer.search()
 
-        # Verify shuffle was called on the RNG instance
-        optimizer._rng.shuffle.assert_called_once()
+        mock_random_cls.assert_called_once_with(optimizer_settings.random_state)
+        mock_rng.shuffle.assert_called_once()
 
     def test_search_respects_max_evals(self, mock_search_space):
         """Test that search respects the max_evals setting."""

--- a/tests/unit/ai4rag/core/hpo/test_random_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_random_opt.py
@@ -35,6 +35,13 @@ class TestRandomOptSettings:
 
         assert settings_dict == {"max_evals": 25, "random_state": 64}
 
+    def test_random_opt_settings_to_dict_custom_random_state(self):
+        """Test to_dict includes custom random_state value."""
+        settings = RandomOptSettings(max_evals=25, random_state=42)
+        settings_dict = settings.to_dict()
+
+        assert settings_dict == {"max_evals": 25, "random_state": 42}
+
 
 class TestRandomOptimizer:
     """Test the RandomOptimizer class."""
@@ -72,13 +79,10 @@ class TestRandomOptimizer:
         assert optimizer.settings == optimizer_settings
         assert optimizer._evaluated_combinations == []
 
-    def test_search_successful_evaluations(self, mock_search_space, optimizer_settings, mocker):
+    def test_search_successful_evaluations(self, mock_search_space, optimizer_settings):
         """Test the search method with successful evaluations."""
         # Mock the objective function to return different scores
         objective_func = MagicMock(side_effect=[0.3, 0.7, 0.5])
-
-        # Mock random.shuffle to make the test deterministic
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -94,7 +98,7 @@ class TestRandomOptimizer:
         assert result["score"] == 0.7
         assert len(optimizer._evaluated_combinations) == 3
 
-    def test_search_with_some_failed_iterations(self, mock_search_space, mocker):
+    def test_search_with_some_failed_iterations(self, mock_search_space):
         """Test search when some iterations fail but some succeed."""
         settings = RandomOptSettings(max_evals=4)
 
@@ -102,8 +106,6 @@ class TestRandomOptimizer:
         objective_func = MagicMock(
             side_effect=[0.3, FailedIterationError("Failed"), 0.8, FailedIterationError("Failed")]
         )
-
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -117,7 +119,7 @@ class TestRandomOptimizer:
         assert result["score"] == 0.8
         assert len(optimizer._evaluated_combinations) == 4
 
-    def test_search_all_iterations_failed(self, mock_search_space, optimizer_settings, mocker):
+    def test_search_all_iterations_failed(self, mock_search_space, optimizer_settings):
         """Test search when all iterations fail."""
         # All evaluations fail
         objective_func = MagicMock(
@@ -127,8 +129,6 @@ class TestRandomOptimizer:
                 FailedIterationError("Failed 3"),
             ]
         )
-
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -192,12 +192,10 @@ class TestRandomOptimizer:
         # Verify shuffle was called on the RNG instance
         optimizer._rng.shuffle.assert_called_once()
 
-    def test_search_respects_max_evals(self, mock_search_space, mocker):
+    def test_search_respects_max_evals(self, mock_search_space):
         """Test that search respects the max_evals setting."""
         settings = RandomOptSettings(max_evals=2)
         objective_func = MagicMock(return_value=0.5)
-
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -211,13 +209,11 @@ class TestRandomOptimizer:
         assert objective_func.call_count == 2
         assert len(optimizer._evaluated_combinations) == 2
 
-    def test_search_returns_highest_score(self, mock_search_space, mocker):
+    def test_search_returns_highest_score(self, mock_search_space):
         """Test that search returns the configuration with the highest score."""
         settings = RandomOptSettings(max_evals=5)
         # Return different scores, highest should be 0.95
         objective_func = MagicMock(side_effect=[0.3, 0.95, 0.5, 0.2, 0.7])
-
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -231,11 +227,9 @@ class TestRandomOptimizer:
         assert result["param1"] == 2
         assert result["param2"] == "b"
 
-    def test_evaluated_combinations_stores_all_evaluations(self, mock_search_space, optimizer_settings, mocker):
+    def test_evaluated_combinations_stores_all_evaluations(self, mock_search_space, optimizer_settings):
         """Test that _evaluated_combinations stores all evaluated parameters."""
         objective_func = MagicMock(side_effect=[0.3, 0.7, 0.5])
-
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -252,7 +246,7 @@ class TestRandomOptimizer:
             assert "param2" in evaluation
             assert "score" in evaluation
 
-    def test_search_filters_out_none_scores(self, mock_search_space, mocker):
+    def test_search_filters_out_none_scores(self, mock_search_space):
         """Test that search correctly filters out evaluations with None scores."""
         settings = RandomOptSettings(max_evals=4)
         # Mix of successful and failed evaluations
@@ -264,8 +258,6 @@ class TestRandomOptimizer:
                 FailedIterationError("Failed"),
             ]
         )
-
-        mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,

--- a/tests/unit/ai4rag/core/hpo/test_random_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_random_opt.py
@@ -33,7 +33,7 @@ class TestRandomOptSettings:
         settings = RandomOptSettings(max_evals=25)
         settings_dict = settings.to_dict()
 
-        assert settings_dict == {"max_evals": 25}
+        assert settings_dict == {"max_evals": 25, "random_state": 64}
 
 
 class TestRandomOptimizer:
@@ -174,10 +174,9 @@ class TestRandomOptimizer:
         assert result is None
         objective_func.assert_called_once_with(params)
 
-    def test_search_shuffles_combinations(self, mock_search_space, optimizer_settings, mocker):
+    def test_search_shuffles_combinations(self, mock_search_space, optimizer_settings):
         """Test that search shuffles combinations before evaluation."""
         objective_func = MagicMock(return_value=0.5)
-        mock_shuffle = mocker.patch("ai4rag.core.hpo.random_opt.random.shuffle")
 
         optimizer = RandomOptimizer(
             objective_function=objective_func,
@@ -185,10 +184,13 @@ class TestRandomOptimizer:
             settings=optimizer_settings,
         )
 
+        # Mock the optimizer's RNG instance
+        optimizer._rng.shuffle = MagicMock()
+
         optimizer.search()
 
-        # Verify shuffle was called
-        mock_shuffle.assert_called_once()
+        # Verify shuffle was called on the RNG instance
+        optimizer._rng.shuffle.assert_called_once()
 
     def test_search_respects_max_evals(self, mock_search_space, mocker):
         """Test that search respects the max_evals setting."""
@@ -277,3 +279,76 @@ class TestRandomOptimizer:
         assert result["score"] == 0.8
         # But _evaluated_combinations should include all attempts
         assert len(optimizer._evaluated_combinations) == 4
+
+
+class TestRandomOptimizerDeterminism:
+    """Test deterministic behavior with random_state."""
+
+    @pytest.fixture
+    def mock_search_space(self):
+        """Create a mock search space with predefined combinations."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"param1": 1, "param2": "a"},
+            {"param1": 2, "param2": "b"},
+            {"param1": 3, "param2": "c"},
+            {"param1": 4, "param2": "d"},
+            {"param1": 5, "param2": "e"},
+        ]
+        return mock_space
+
+    def test_random_optimizer_deterministic_with_same_random_state(self, mock_search_space):
+        """Test that RandomOptimizer produces identical evaluation order with same random_state."""
+        settings = RandomOptSettings(max_evals=3, random_state=42)
+
+        def deterministic_objective(params):
+            return params["param1"] / 10.0
+
+        # First run
+        optimizer1 = RandomOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        result1 = optimizer1.search()
+        evals1 = [e["param1"] for e in optimizer1._evaluated_combinations]
+
+        # Second run with same random_state
+        optimizer2 = RandomOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        result2 = optimizer2.search()
+        evals2 = [e["param1"] for e in optimizer2._evaluated_combinations]
+
+        # Should evaluate same combinations in same order
+        assert evals1 == evals2
+        assert result1 == result2
+
+    def test_random_optimizer_different_with_different_random_state(self, mock_search_space):
+        """Test that RandomOptimizer produces different evaluation order with different random_state."""
+
+        def deterministic_objective(params):
+            return params["param1"] / 10.0
+
+        # First run with random_state=42
+        optimizer1 = RandomOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=RandomOptSettings(max_evals=3, random_state=42),
+        )
+        optimizer1.search()
+        evals1 = [e["param1"] for e in optimizer1._evaluated_combinations]
+
+        # Second run with random_state=99
+        optimizer2 = RandomOptimizer(
+            objective_function=deterministic_objective,
+            search_space=mock_search_space,
+            settings=RandomOptSettings(max_evals=3, random_state=99),
+        )
+        optimizer2.search()
+        evals2 = [e["param1"] for e in optimizer2._evaluated_combinations]
+
+        # Should evaluate different combinations or different order
+        assert evals1 != evals2


### PR DESCRIPTION
Fixes #76

Both GAMOptimizer and RandomOptimizer now use dedicated RNG instances seeded with settings.random_state instead of the global random module. This enables reproducible HPO experiments with identical exploration order across runs.

Changes:
- GAMOptimizer: Add self._rng instance, use in evaluate_initial_random_nodes
- RandomOptimizer: Add random_state to settings, add self._rng instance, use in search
- RandomOptimizer: Copy combinations list before shuffle to avoid mutating original
- Add 4 new determinism tests (2 per optimizer) verifying same/different random_state behavior
- Update test_random_opt_settings_to_dict to expect random_state in output
- Update test_search_shuffles_combinations to mock optimizer._rng instead of global random

All 53 optimizer tests passing (37 GAM + 16 Random).

## Description
Brief summary of changes

## Motivation
Why is this change needed?

## Changes
- Bullet point list of changes
- Another change

## Testing
How did you test this?

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
