### PR TITLE
tweaked chunk_size for "speed" AutoRAG pipeline preset

### DIFF
--- a/ai4rag/components/optimization/search_space_preparation.py
+++ b/ai4rag/components/optimization/search_space_preparation.py
@@ -18,6 +18,8 @@ from ai4rag.core.experiment.mps import ModelsPreSelector
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
 from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 from ai4rag.search_space.prepare.prepare_search_space import prepare_search_space_with_ogx
+from ai4rag.search_space.src.parameter import Parameter
+from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
 
 _logger = logging.getLogger("search-space-preparation")
 _logger.addHandler(handler)
@@ -192,6 +194,19 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
     documents = load_docling_documents(extracted_text_path)
 
     search_space = prepare_search_space_with_ogx(payload, client=ogx_client, benchmark_data=benchmark_df)
+
+    # this is equivalent of `preset="speed"`. I check it like this not to add another argument to already big func signature
+    # this is a tmp approach -- optimal solution is to change the `prepare_search_space_with_ogx` func to accept different params than models only
+    # but this will take more time which currently we do not have
+    if inference_max_threads == 4:
+        speed_parameters = [
+            search_space._search_space["foundation_model"],
+            search_space._search_space["embedding_model"],
+            Parameter("chunk_size", "C", values=[128, 256]),
+            Parameter("chunking_method", "C", values=["recursive"]),
+        ]
+        # recreate the search space with constrained chunk_sizes and models validated by all of the checks in `prepare_search_space_with_ogx` func
+        search_space = AI4RAGSearchSpace(params=speed_parameters)
 
     # Run model pre-selection when the number of models exceeds the caps
     fm_values = search_space["foundation_model"].values

--- a/ai4rag/components/optimization/search_space_preparation.py
+++ b/ai4rag/components/optimization/search_space_preparation.py
@@ -116,6 +116,7 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
     random_seed: int = _DEFAULT_SEED,
     chunking_methods: list[str] | None = None,
     inference_max_threads: int = 10,
+    **kwargs: Any,
 ) -> SearchSpaceReport:
     """Run model pre-selection and prepare a search-space report.
 
@@ -181,6 +182,7 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
     _validate_model_list(generation_models, "generation_models")
     _validate_chunking_methods(chunking_methods)
 
+    preset = kwargs.get("preset", None)
     # Build payload and create search space via OGX
     payload: dict[str, list[dict[str, str]]] = {}
     if generation_models:
@@ -195,16 +197,15 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
 
     search_space = prepare_search_space_with_ogx(payload, client=ogx_client, benchmark_data=benchmark_df)
 
-    # this is equivalent of `preset="speed"`. I check it like this not to add another arg to already big func signature
     # this is a tmp approach -- optimal solution is to change the `prepare_search_space_with_ogx`
     # func to accept different params than models only
     # but this will take more time which currently we do not have
-    if inference_max_threads == 4:
+    if preset == "speed":
         speed_parameters = [
             search_space["foundation_model"],
             search_space["embedding_model"],
             Parameter("chunk_size", "C", values=[128, 256]),
-            Parameter("chunking_method", "C", values=["recursive"]),
+            Parameter("chunking_method", "C", values=chunking_methods),
         ]
         # recreate the search space with constrained chunk_sizes and models
         # validated by all of the checks in `prepare_search_space_with_ogx` func

--- a/ai4rag/components/optimization/search_space_preparation.py
+++ b/ai4rag/components/optimization/search_space_preparation.py
@@ -195,17 +195,19 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
 
     search_space = prepare_search_space_with_ogx(payload, client=ogx_client, benchmark_data=benchmark_df)
 
-    # this is equivalent of `preset="speed"`. I check it like this not to add another argument to already big func signature
-    # this is a tmp approach -- optimal solution is to change the `prepare_search_space_with_ogx` func to accept different params than models only
+    # this is equivalent of `preset="speed"`. I check it like this not to add another arg to already big func signature
+    # this is a tmp approach -- optimal solution is to change the `prepare_search_space_with_ogx`
+    # func to accept different params than models only
     # but this will take more time which currently we do not have
     if inference_max_threads == 4:
         speed_parameters = [
-            search_space._search_space["foundation_model"],
-            search_space._search_space["embedding_model"],
+            search_space["foundation_model"],
+            search_space["embedding_model"],
             Parameter("chunk_size", "C", values=[128, 256]),
             Parameter("chunking_method", "C", values=["recursive"]),
         ]
-        # recreate the search space with constrained chunk_sizes and models validated by all of the checks in `prepare_search_space_with_ogx` func
+        # recreate the search space with constrained chunk_sizes and models
+        # validated by all of the checks in `prepare_search_space_with_ogx` func
         search_space = AI4RAGSearchSpace(params=speed_parameters)
 
     # Run model pre-selection when the number of models exceeds the caps

--- a/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
+++ b/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
@@ -240,10 +240,10 @@ class TestValidateChunkingMethods:
 
 
 class TestSpeedPresetSearchSpace:
-    """Test that inference_max_threads=4 triggers the speed preset path."""
+    """Test that preset='speed' constrains the search space."""
 
     def test_speed_preset_constrains_chunk_sizes(self, mock_ogx_client):
-        """When inference_max_threads=4, the report must contain only chunk_size [128, 256]."""
+        """When preset='speed', the report must contain only chunk_size [128, 256]."""
         from unittest.mock import patch
 
         from ai4rag.components.optimization import search_space_preparation as mod
@@ -281,7 +281,7 @@ class TestSpeedPresetSearchSpace:
                 test_data_path="dummy.json",
                 extracted_text_path="dummy_dir",
                 ogx_client=mock_ogx_client,
-                inference_max_threads=4,
+                preset="speed",
             )
 
         assert report.search_space["chunk_size"] == [128, 256]

--- a/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
+++ b/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
@@ -239,6 +239,54 @@ class TestValidateChunkingMethods:
 # ---------------------------------------------------------------------------
 
 
+class TestSpeedPresetSearchSpace:
+    """Test that inference_max_threads=4 triggers the speed preset path."""
+
+    def test_speed_preset_constrains_chunk_sizes(self, mock_ogx_client):
+        """When inference_max_threads=4, the report must contain only chunk_size [128, 256]."""
+        from unittest.mock import patch
+
+        from ai4rag.components.optimization import search_space_preparation as mod
+        from ai4rag.search_space.src.parameter import Parameter
+
+        fake_fm = MagicMock()
+        fake_fm.model_id = "fm-a"
+
+        fake_em = MagicMock()
+        fake_em.model_id = "em-a"
+        # Required by _rule_chunk_size_within_embedding_context_length
+        # which compares chunk_size against embedding context_length.
+        fake_em.params.context_length = 8192
+
+        search_space_items = {
+            "chunking_method": Parameter(name="chunking_method", values=["recursive", "hybrid"]),
+            "chunk_size": Parameter(name="chunk_size", values=[512, 1024, 2048]),
+            "foundation_model": Parameter(name="foundation_model", values=[fake_fm]),
+            "embedding_model": Parameter(name="embedding_model", values=[fake_em]),
+        }
+        fake_search_space = MagicMock()
+        fake_search_space._search_space = search_space_items
+        fake_search_space.__getitem__ = lambda self, key: search_space_items[key]
+
+        fake_benchmark_df = MagicMock(spec=mod.pd.DataFrame)
+        fake_benchmark_df.__len__ = lambda self: 1
+
+        with (
+            patch.object(mod, "prepare_search_space_with_ogx", return_value=fake_search_space),
+            patch.object(mod.pd, "read_json", return_value=fake_benchmark_df),
+            patch.object(mod, "load_docling_documents", return_value=[]),
+            patch.object(mod, "BenchmarkData"),
+        ):
+            report = prepare_search_space_report(
+                test_data_path="dummy.json",
+                extracted_text_path="dummy_dir",
+                ogx_client=mock_ogx_client,
+                inference_max_threads=4,
+            )
+
+        assert report.search_space["chunk_size"] == [128, 256]
+
+
 class TestUnsupportedChunkingMethods:
     """Test that providing chunking methods not in the search space raises."""
 


### PR DESCRIPTION

## Description
Modified search space for `speed` preset of KFP AutoRAG pipeline:
- chunk sizes should define lower values

## Motivation
Preset `speed` has to be lower in terms of resources consumption and faster

## Changes
- search space is modified whenever `speed` preset is enabled

## Testing
unit tests, ensured there is no regression

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Code follows style guide
- [x] All checks passing
