### PR TITLE
Release 0.9.2

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.2](https://github.com/IBM/ai4rag/releases/tag/v0.9.2)
+
+### Added
+- `chunk_sizes` parameter on `prepare_search_space_report()` for constraining the chunk-size dimension of the search space (e.g. `[256, 512]`)
+
+### Changed
+- Chunking constraint validation (`chunking_methods`, `chunk_sizes`) now happens via Pydantic before any I/O, providing clearer error messages with exact field paths
+- Minimum allowed chunk size lowered from 512 to 128, enabling finer-grained chunking strategies
+- Duplicate values in `chunking_methods` and `chunk_sizes` are now automatically deduplicated
+
+---
+
 ## [0.9.1](https://github.com/IBM/ai4rag/releases/tag/v0.9.1)
 
 ### Fixed

--- a/docs/user-guide/pipeline-components.md
+++ b/docs/user-guide/pipeline-components.md
@@ -122,6 +122,8 @@ report = prepare_search_space_report(
     ogx_client=client,
     embedding_models=["ibm/slate-125m-english-rtrvr"],
     generation_models=["ibm/granite-3.1-8b-instruct"],
+    chunking_methods=["recursive"],   # optional: constrain chunking methods
+    chunk_sizes=[256, 512, 1024],     # optional: constrain chunk sizes
 )
 report.save_yaml("/tmp/search_space.yaml")
 ```


### PR DESCRIPTION
# Release v0.9.2

## Summary

This release adds user-facing control over the chunk-size dimension of the search space and strengthens input validation for chunking parameters. Chunking constraints are now validated via Pydantic before any I/O occurs, and the minimum allowed chunk size has been lowered from 512 to 128 to support finer-grained chunking strategies.

## Changes

### Added
- `chunk_sizes` parameter on `prepare_search_space_report()` for constraining the chunk-size dimension of the search space (e.g. `[256, 512]`)

### Changed
- Chunking constraint validation (`chunking_methods`, `chunk_sizes`) now happens via Pydantic before any I/O, providing clearer error messages with exact field paths
- Minimum allowed chunk size lowered from 512 to 128, enabling finer-grained chunking strategies
- Duplicate values in `chunking_methods` and `chunk_sizes` are now automatically deduplicated

## Migration notes

No breaking changes. The new `chunk_sizes` parameter is optional and defaults to platform defaults when omitted. The lowered minimum chunk size (512 → 128) only expands the accepted range — existing configurations remain valid.

## Checklist

- [ ] `__version__` in `ai4rag/__init__.py` updated to `0.9.2`
- [ ] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
