### PR TITLE
changed max_threads to inference_max_threads keyword arg

### DIFF
--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -60,7 +60,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     test_data_key: str = "",
     input_data_key: str = "",
     optimization_settings: dict | None = None,
-    max_threads: int = 10,
+    inference_max_threads: int = 10,
 ) -> OptimizationResult:
     """Run a full AI4RAG optimization experiment and generate output artefacts.
 
@@ -91,7 +91,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     optimization_settings
         Optional dictionary with ``"metric"`` and/or
         ``"max_number_of_rag_patterns"`` overrides.
-    max_threads
+    inference_max_threads
         Maximum number of concurrent threads used when querying the
         RAG service during benchmark evaluation.  Lower values reduce
         per-request concurrency (useful when each request carries more
@@ -161,7 +161,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         documents=documents,
         optimization_metric=optimization_metric,
         ogx_vector_io_provider_id=vector_io_provider_id,
-        max_threads=max_threads,
+        inference_max_threads=inference_max_threads,
     )
 
     # --- Run the optimization loop ---

--- a/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
+++ b/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
@@ -232,23 +232,23 @@ class TestRunRagOptimizationValidation:
 
 
 # ---------------------------------------------------------------------------
-# run_rag_optimization -- max_threads parameter
+# run_rag_optimization -- inference_max_threads parameter
 # ---------------------------------------------------------------------------
 
 
-class TestRunRagOptimizationMaxThreads:
-    """Tests for the max_threads parameter on run_rag_optimization."""
+class TestRunRagOptimizationInferenceMaxThreads:
+    """Tests for the inference_max_threads parameter on run_rag_optimization."""
 
-    def test_max_threads_has_default_of_ten(self):
-        """The max_threads parameter must have a default value of 10."""
+    def test_inference_max_threads_has_default_of_ten(self):
+        """The inference_max_threads parameter must have a default value of 10."""
         import inspect
 
         sig = inspect.signature(run_rag_optimization)
-        param = sig.parameters["max_threads"]
+        param = sig.parameters["inference_max_threads"]
         assert param.default == 10
 
-    def test_max_threads_is_accepted(self, mock_ogx_client):
-        """Passing max_threads alongside an invalid input must still raise
+    def test_inference_max_threads_is_accepted(self, mock_ogx_client):
+        """Passing inference_max_threads alongside an invalid input must still raise
         the expected validation error (not a TypeError from an unknown param)."""
         with pytest.raises(ValueError, match="non-empty string"):
             run_rag_optimization(
@@ -259,5 +259,5 @@ class TestRunRagOptimizationMaxThreads:
                 ogx_client=mock_ogx_client,
                 vector_io_provider_id="",
                 test_data_key="bench.json",
-                max_threads=4,
+                inference_max_threads=4,
             )


### PR DESCRIPTION
## Description
Small fix in keyword parameter naming.

## Motivation
AI4RAGExperiment class expected `inference_max_threads` keyword argument. The calling functions exposed (and passed down) a `max_thread` parameter rendering the whole threads handling functionality completely ineffective.

## Changes
- changed `max_threads` to `inference_max_threads`

## Testing
How did you test this?

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Code follows style guide
- [x] All checks passing
