### PR TITLE
release 0.9.3

### DIFF
--- a/.claude/commands/generate-release.md
+++ b/.claude/commands/generate-release.md
@@ -35,6 +35,16 @@ Analyse every commit since the latest tag (read relevant changed files if needed
 
 Omit categories that have no entries. Each bullet should be concrete and user-facing (what changed, not the internal implementation detail).
 
+**Every bullet must start with a bold component label** that tells the reader *where* in the project the change lives. Use logical component names (not file paths) — the label should match how a developer thinks about the area. Examples:
+
+- `**Search space preparation** — added chunk_overlaps parameter on prepare_search_space_report()...`
+- `**RAG optimization component** — renamed max_threads to inference_max_threads...`
+- `**Dependencies** — removed the langchain meta-package...`
+- `**Chunker** — DoclingChunker now supports...`
+- `**Vector store** — OGXVectorStore.search() returns...`
+
+If a single change spans multiple components, pick the one most relevant to the user; if genuinely cross-cutting, use a broad label like **Core** or **API**. Use existing labels from prior changelog entries when applicable for consistency. Review older entries in `docs/about/changelog.md` to align with established conventions.
+
 ### 4. Update `docs/about/changelog.md`
 
 Read the existing `docs/about/changelog.md` to understand the format and conventions (Keep a Changelog style, links to GitHub releases). Insert a new section for `RELEASE_VERSION` immediately after the `---` separator that follows the file header (before the current first release entry). Follow the exact same markdown structure used by existing entries:
@@ -43,16 +53,18 @@ Read the existing `docs/about/changelog.md` to understand the format and convent
 ## [X.Y.Z](https://github.com/IBM/ai4rag/releases/tag/vX.Y.Z)
 
 ### Added
-- ...
+- **Component name** — description of what was added...
 
 ### Changed
-- ...
+- **Component name** — description of what changed...
 
 ### Fixed
-- ...
+- **Component name** — description of what was fixed...
 
 ---
 ```
+
+Each bullet follows the pattern: `**Component label** — concise description`. The component label is a logical area name (e.g. "Search space preparation", "RAG optimization component", "Dependencies"), not a file path.
 
 Do not touch the version numbering explanation or the "Release Process" / "Stay Updated" sections at the bottom.
 

--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.3](https://github.com/IBM/ai4rag/releases/tag/v0.9.3)
 
 ### Added
-- `chunk_overlaps` parameter on `prepare_search_space_report()` for constraining the chunk-overlap dimension of the search space (e.g. `[0, 128]`)
+- **Search space preparation** — `chunk_overlaps` parameter on `prepare_search_space_report()` and `prepare_search_space_with_ogx()` for constraining the chunk-overlap dimension of the search space (e.g. `[0, 128]`), with Pydantic range validation against `ChunkingConstraints` bounds
 
 ### Changed
-- Renamed `max_threads` keyword argument to `inference_max_threads` on `run_rag_optimization()` to align with `prepare_search_space_report()` naming
-- Search space verbose representation now derives values from valid (rule-filtered) combinations instead of raw parameter lists, ensuring the report reflects only reachable configurations
-- Removed automatic deduplication of `chunking_methods` and `chunk_sizes` — duplicates are no longer silently collapsed
-- Removed the `langchain` meta-package dependency; only the needed sub-packages (`langchain-chroma`, `langchain-text-splitters`) are retained
+- **RAG optimization component** — renamed `max_threads` keyword argument to `inference_max_threads` on `run_rag_optimization()` to align with `prepare_search_space_report()` naming
+- **Search space report** — verbose representation in `prepare_search_space_report()` now derives values from valid (rule-filtered) combinations instead of raw parameter lists, ensuring the report reflects only reachable configurations
+- **Search space constraint validation** — removed automatic deduplication of `chunking_methods` and `chunk_sizes` from `AI4RAGConstraints` validators — duplicates are no longer silently collapsed
+- **Dependencies** — removed the `langchain` meta-package; only the needed sub-packages (`langchain-chroma`, `langchain-text-splitters`) are retained
 
 ---
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.3](https://github.com/IBM/ai4rag/releases/tag/v0.9.3)
+
+### Added
+- `chunk_overlaps` parameter on `prepare_search_space_report()` for constraining the chunk-overlap dimension of the search space (e.g. `[0, 128]`)
+
+### Changed
+- Renamed `max_threads` keyword argument to `inference_max_threads` on `run_rag_optimization()` to align with `prepare_search_space_report()` naming
+- Search space verbose representation now derives values from valid (rule-filtered) combinations instead of raw parameter lists, ensuring the report reflects only reachable configurations
+- Removed automatic deduplication of `chunking_methods` and `chunk_sizes` — duplicates are no longer silently collapsed
+- Removed the `langchain` meta-package dependency; only the needed sub-packages (`langchain-chroma`, `langchain-text-splitters`) are retained
+
+---
+
 ## [0.9.2](https://github.com/IBM/ai4rag/releases/tag/v0.9.2)
 
 ### Added

--- a/docs/user-guide/pipeline-components.md
+++ b/docs/user-guide/pipeline-components.md
@@ -124,6 +124,7 @@ report = prepare_search_space_report(
     generation_models=["ibm/granite-3.1-8b-instruct"],
     chunking_methods=["recursive"],   # optional: constrain chunking methods
     chunk_sizes=[256, 512, 1024],     # optional: constrain chunk sizes
+    chunk_overlaps=[0, 128],          # optional: constrain chunk overlaps
 )
 report.save_yaml("/tmp/search_space.yaml")
 ```


### PR DESCRIPTION
## Description
This release adds user-controllable chunk-overlap constraints to the search space, renames the `max_threads` parameter to `inference_max_threads` for consistency across the API, and trims unused dependencies. The search space report now reflects only valid (rule-filtered) parameter combinations, giving users an accurate picture of the configurations that will actually be explored.

## Motivation
Creating new release

## Changes
- patch version increased
- changelog updated 

### Added
- `chunk_overlaps` parameter on `prepare_search_space_report()` for constraining the chunk-overlap dimension of the search space (e.g. `[0, 128]`)

### Changed
- Renamed `max_threads` keyword argument to `inference_max_threads` on `run_rag_optimization()` to align with `prepare_search_space_report()` naming
- Search space verbose representation now derives values from valid (rule-filtered) combinations instead of raw parameter lists, ensuring the report reflects only reachable configurations
- Removed automatic deduplication of `chunking_methods` and `chunk_sizes` — duplicates are no longer silently collapsed
- Removed the `langchain` meta-package dependency; only the needed sub-packages (`langchain-chroma`, `langchain-text-splitters`) are retained 

## Testing
How did you test this?

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
