### PR TITLE
fix: partially revert prompt changes

### DIFF
--- a/ai4rag/components/assets_generator/prompt_filters.py
+++ b/ai4rag/components/assets_generator/prompt_filters.py
@@ -92,8 +92,7 @@ USER_GROUNDING_SKIP_PREFIXES = (
     "If the documents do not contain the answer",
 )
 # Used in: Pass 1 filtering (_should_skip_redundant_user_line in pattern_builder.py)
-# Only suppressed when system prompt already has grounding policy to avoid duplication.
-# Note: these prefixes no longer match the built-in default prompts (reverted in fix_prompts_components).
+# Only suppressed when system prompt already has grounding policy to avoid duplication. 
 # They remain as defensive filters for custom HPO configurations that may use these phrasings.
 USER_RAG_GROUNDING_PREFIXES = (
     "You are a specialized Retrieval Augmented Generation",

--- a/ai4rag/components/assets_generator/prompt_filters.py
+++ b/ai4rag/components/assets_generator/prompt_filters.py
@@ -20,8 +20,6 @@ If OGX updates their injection strings, update the constants below.
 
 import re
 
-from ai4rag.search_space.src.model_props import _RAG_CITATION_INSTRUCTION
-
 # ============================================================================
 # OGX Runtime Injection Strings
 # ============================================================================
@@ -42,9 +40,9 @@ CITATION_SUBSTRINGS = (
     "file citations",
     "document numbers for every factual claim",
 )
-# HPO citation fragments for filtering (uses _RAG_CITATION_INSTRUCTION from model_props)
+# HPO citation fragments for filtering
 HPO_CITATION_FRAGMENTS = (
-    _RAG_CITATION_INSTRUCTION,
+    "You MUST cite sources using [1], [2], etc. matching the document numbers for every factual claim.",
     "You MUST cite sources using [1], [2], etc.",
     "You MUST cite sources using [1], [2].",
 )
@@ -94,7 +92,9 @@ USER_GROUNDING_SKIP_PREFIXES = (
     "If the documents do not contain the answer",
 )
 # Used in: Pass 1 filtering (_should_skip_redundant_user_line in pattern_builder.py)
-# Only suppressed when system prompt already has grounding policy to avoid duplication
+# Only suppressed when system prompt already has grounding policy to avoid duplication.
+# Note: these prefixes no longer match the built-in default prompts (reverted in fix_prompts_components).
+# They remain as defensive filters for custom HPO configurations that may use these phrasings.
 USER_RAG_GROUNDING_PREFIXES = (
     "You are a specialized Retrieval Augmented Generation",
     "Prioritize correctness and ensure your response is grounded",

--- a/ai4rag/components/assets_generator/prompt_filters.py
+++ b/ai4rag/components/assets_generator/prompt_filters.py
@@ -92,7 +92,7 @@ USER_GROUNDING_SKIP_PREFIXES = (
     "If the documents do not contain the answer",
 )
 # Used in: Pass 1 filtering (_should_skip_redundant_user_line in pattern_builder.py)
-# Only suppressed when system prompt already has grounding policy to avoid duplication. 
+# Only suppressed when system prompt already has grounding policy to avoid duplication.
 # They remain as defensive filters for custom HPO configurations that may use these phrasings.
 USER_RAG_GROUNDING_PREFIXES = (
     "You are a specialized Retrieval Augmented Generation",

--- a/ai4rag/search_space/src/model_props.py
+++ b/ai4rag/search_space/src/model_props.py
@@ -45,7 +45,7 @@ _DEFAULT_SYSTEM_MESSAGE_TEXT = (
 
 
 _DEFAULT_USER_MESSAGE_TEXT = (
-    f"\n\nContext:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}:\n\n"
+    f"\nContext:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}:\n\n"
     f"Question: {{{QUESTION_PLACEHOLDER}}}. Your answer should be concise. \n"
     "Again, please answer the question based on the context provided only. If the context is not related to "
     "the question, just say you cannot answer. "

--- a/ai4rag/search_space/src/model_props.py
+++ b/ai4rag/search_space/src/model_props.py
@@ -31,47 +31,26 @@ _LANGUAGE_AUTODETECT_PROMPT = (
 _LANGUAGE_INSTRUCTION = "You MUST respond in {lang_name}."
 
 
-_RAG_GROUNDING_INSTRUCTION = (
-    "Answer ONLY using information from the documents below. "
-    "Do not use outside knowledge. "
-    "If the documents do not contain the answer, say you do not have enough information."
-)
-
-
-_RAG_CITATION_INSTRUCTION = (
-    "You MUST cite sources using [1], [2], etc. matching the document numbers for every factual claim."
-)
-
-
-_RAG_ANSWER_LENGTH_GUIDANCE = "max 150 words"
-
-
-_RAG_ANSWER_PROMPT_LINE = f"Answer ({_RAG_ANSWER_LENGTH_GUIDANCE}, with citations):\n"
-
-
-_RAG_SYSTEM_PREFIX = "You are a retrieval-augmented assistant. Answer using ONLY the provided documents. "
-
-
 _DEFAULT_NUMBERED_CONTEXT_TEMPLATE = f"Document {{{DOCUMENT_NUMBER_PLACEHOLDER}}}:\n{{{CONTEXT_TEXT_PLACEHOLDER}}}\n"
 
 
 _DEFAULT_SYSTEM_MESSAGE_TEXT = (
-    f"{_RAG_SYSTEM_PREFIX}" "If the question is unanswerable from the documents, say you cannot answer."
+    "Please answer the question I provide in the Question section below, "
+    "based solely on the information I provide in the Context section. "
+    "If the question is unanswerable, please say you cannot answer."
 )
 
 
 _DEFAULT_USER_MESSAGE_TEXT = (
-    f"{_RAG_GROUNDING_INSTRUCTION}\n"
-    f"{_RAG_CITATION_INSTRUCTION}\n\n"
-    f"Documents:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}\n\n"
-    f"{_RAG_ANSWER_PROMPT_LINE}"
-    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n"
+    f"\n\nContext:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}:\n\n"
+    f"Question: {{{QUESTION_PLACEHOLDER}}}. \n"
+    "Again, please answer the question based on the context provided only. If the context is not related to "
+    "the question, just say you cannot answer. "
+    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
 )
 
 
 _DEFAULT_GRANITE_SYSTEM_MESSAGE_TEXT = (
-    f"{_RAG_SYSTEM_PREFIX}"
     "You are Granite Chat, an AI language model developed by IBM. "
     "You are a cautious assistant. You carefully follow instructions. "
     "You are helpful and harmless and you follow ethical guidelines and promote positive behaviour."
@@ -79,19 +58,23 @@ _DEFAULT_GRANITE_SYSTEM_MESSAGE_TEXT = (
 
 
 _DEFAULT_GRANITE_USER_MESSAGE_TEXT = (
-    f"{_RAG_GROUNDING_INSTRUCTION}\n"
-    f"{_RAG_CITATION_INSTRUCTION}\n\n"
-    "You are a specialized Retrieval Augmented Generation (RAG) assistant. "
-    "Prioritize correctness and ensure your response is grounded in the documents.\n\n"
-    f"Documents:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}\n\n"
-    f"{_RAG_ANSWER_PROMPT_LINE}"
-    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n"
+    "You are an AI language model designed to function as a specialized Retrieval Augmented Generation (RAG) "
+    "assistant. When generating responses, prioritize correctness, i.e., ensure that your response is grounded in "
+    "context and user query. Always make sure that your response is relevant to the question. "
+    "\n"
+    "Answer Length: detailed"
+    "\n"
+    f"{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}"
+    "\n"
+    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
+    "\n"
+    f"{{{QUESTION_PLACEHOLDER}}}"
+    "\n"
+    "\n"
 )
 
 
 _DEFAULT_LLAMA_SYSTEM_MESSAGE_TEXT = (
-    f"{_RAG_SYSTEM_PREFIX}"
     "You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. "
     "Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. "
     "Please ensure that your responses are socially unbiased and positive in nature.\n"
@@ -101,17 +84,14 @@ _DEFAULT_LLAMA_SYSTEM_MESSAGE_TEXT = (
 
 
 _DEFAULT_LLAMA_USER_MESSAGE_TEXT = (
-    f"{_RAG_GROUNDING_INSTRUCTION}\n"
-    f"{_RAG_CITATION_INSTRUCTION}\n\n"
-    f"Documents:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}\n\n"
-    f"{_RAG_ANSWER_PROMPT_LINE}"
+    f"{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n"
+    f"[conversation]: {{{QUESTION_PLACEHOLDER}}}. Be concise. If you cannot base your "
+    "answer on the given document, please state that you do not have an answer. "
     f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n"
 )
 
 
 _DEFAULT_MISTRAL_SYSTEM_MESSAGE_TEXT = (
-    f"{_RAG_SYSTEM_PREFIX}"
     "You are a helpful, respectful and honest assistant. "
     "Always answer as helpfully as possible, while being safe. "
     "Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. "
@@ -122,17 +102,18 @@ _DEFAULT_MISTRAL_SYSTEM_MESSAGE_TEXT = (
 
 
 _DEFAULT_MISTRAL_USER_MESSAGE_TEXT = (
-    f"{_RAG_GROUNDING_INSTRUCTION}\n"
-    f"{_RAG_CITATION_INSTRUCTION}\n\n"
-    f"Documents:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}\n\n"
-    f"{_RAG_ANSWER_PROMPT_LINE}"
-    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n"
+    "Generate the next agent response by answering the question. You are provided several documents with titles. "
+    "If the answer comes from different documents please mention all possibilities and use the titles of documents "
+    "to separate between topics or domains. If you cannot base your answer on the given documents, "
+    f"please state that you do not have an answer. "
+    f"{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
+    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n\n"
+    f"{{{QUESTION_PLACEHOLDER}}}"
 )
 
 
 _DEFAULT_OPENAI_SYSTEM_MESSAGE_TEXT = (
-    f"{_RAG_SYSTEM_PREFIX}"
+    "You are an AI language model designed to function as a specialized Retrieval Augmented Generation (RAG) assistant. "
     "When generating responses, prioritize correctness, i.e., ensure that your response is correct given the context "
     "and user query, and that it is grounded in the context. "
     "Furthermore, make sure that the response is supported by the given document or context. "
@@ -144,12 +125,9 @@ _DEFAULT_OPENAI_SYSTEM_MESSAGE_TEXT = (
 
 
 _DEFAULT_OPENAI_USER_MESSAGE_TEXT = (
-    f"{_RAG_GROUNDING_INSTRUCTION}\n"
-    f"{_RAG_CITATION_INSTRUCTION}\n\n"
-    f"Documents:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}\n\n"
-    f"{_RAG_ANSWER_PROMPT_LINE}"
-    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n"
+    f"[Document]\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n[End]\n"
+    f"{{{QUESTION_PLACEHOLDER}}}. \n"
+    f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
 )
 
 

--- a/ai4rag/search_space/src/model_props.py
+++ b/ai4rag/search_space/src/model_props.py
@@ -116,7 +116,8 @@ _DEFAULT_MISTRAL_USER_MESSAGE_TEXT = (
 
 
 _DEFAULT_OPENAI_SYSTEM_MESSAGE_TEXT = (
-    "You are an AI language model designed to function as a specialized Retrieval Augmented Generation (RAG) assistant. "
+    "You are an AI language model designed to function as a specialized "
+    "Retrieval Augmented Generation (RAG) assistant. "
     "When generating responses, prioritize correctness, i.e., ensure that your response is correct given the context "
     "and user query, and that it is grounded in the context. "
     "Furthermore, make sure that the response is supported by the given document or context. "

--- a/ai4rag/search_space/src/model_props.py
+++ b/ai4rag/search_space/src/model_props.py
@@ -38,17 +38,15 @@ _DEFAULT_NUMBERED_CONTEXT_TEMPLATE = f"Document {{{DOCUMENT_NUMBER_PLACEHOLDER}}
 
 
 _DEFAULT_SYSTEM_MESSAGE_TEXT = (
-    "Please answer the question I provide in the Question section below, "
-    "based solely on the information I provide in the Context section. "
-    "If the question is unanswerable, please say you cannot answer."
+    "Please answer the user's question based solely on the provided context documents. "
+    "If the question cannot be answered from the provided context, say you cannot answer. "
+    "Your answer should be concise."
 )
 
 
 _DEFAULT_USER_MESSAGE_TEXT = (
-    f"\nContext:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}:\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}. Your answer should be concise. \n"
-    "Again, please answer the question based on the context provided only. If the context is not related to "
-    "the question, just say you cannot answer. "
+    f"\nContext:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
+    f"Question: {{{QUESTION_PLACEHOLDER}}}\n"
     f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
 )
 

--- a/ai4rag/search_space/src/model_props.py
+++ b/ai4rag/search_space/src/model_props.py
@@ -28,10 +28,13 @@ _LANGUAGE_AUTODETECT_PROMPT = (
 )
 
 
-_LANGUAGE_INSTRUCTION = "You MUST respond in {lang_name}."
+_LANGUAGE_INSTRUCTION = (
+    "Respond exclusively in {lang_name}, regardless of any other language used in the provided context. "
+    "You MUST respond in {lang_name}."
+)
 
 
-_DEFAULT_NUMBERED_CONTEXT_TEMPLATE = f"Document {{{DOCUMENT_NUMBER_PLACEHOLDER}}}:\n{{{CONTEXT_TEXT_PLACEHOLDER}}}\n"
+_DEFAULT_NUMBERED_CONTEXT_TEMPLATE = f"Document {{{DOCUMENT_NUMBER_PLACEHOLDER}}}:\n{{{CONTEXT_TEXT_PLACEHOLDER}}}"
 
 
 _DEFAULT_SYSTEM_MESSAGE_TEXT = (
@@ -43,7 +46,7 @@ _DEFAULT_SYSTEM_MESSAGE_TEXT = (
 
 _DEFAULT_USER_MESSAGE_TEXT = (
     f"\n\nContext:\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}:\n\n"
-    f"Question: {{{QUESTION_PLACEHOLDER}}}. \n"
+    f"Question: {{{QUESTION_PLACEHOLDER}}}. Your answer should be concise. \n"
     "Again, please answer the question based on the context provided only. If the context is not related to "
     "the question, just say you cannot answer. "
     f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
@@ -62,7 +65,7 @@ _DEFAULT_GRANITE_USER_MESSAGE_TEXT = (
     "assistant. When generating responses, prioritize correctness, i.e., ensure that your response is grounded in "
     "context and user query. Always make sure that your response is relevant to the question. "
     "\n"
-    "Answer Length: detailed"
+    "Answer Length: concise"
     "\n"
     f"{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}"
     "\n"
@@ -85,7 +88,7 @@ _DEFAULT_LLAMA_SYSTEM_MESSAGE_TEXT = (
 
 _DEFAULT_LLAMA_USER_MESSAGE_TEXT = (
     f"{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n"
-    f"[conversation]: {{{QUESTION_PLACEHOLDER}}}. Be concise. If you cannot base your "
+    f"[conversation]: {{{QUESTION_PLACEHOLDER}}}. Your answer should be concise. If you cannot base your "
     "answer on the given document, please state that you do not have an answer. "
     f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n"
 )
@@ -105,7 +108,7 @@ _DEFAULT_MISTRAL_USER_MESSAGE_TEXT = (
     "Generate the next agent response by answering the question. You are provided several documents with titles. "
     "If the answer comes from different documents please mention all possibilities and use the titles of documents "
     "to separate between topics or domains. If you cannot base your answer on the given documents, "
-    f"please state that you do not have an answer. "
+    f"please state that you do not have an answer. Your answer should be concise. "
     f"{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n\n"
     f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}\n\n"
     f"{{{QUESTION_PLACEHOLDER}}}"
@@ -126,7 +129,7 @@ _DEFAULT_OPENAI_SYSTEM_MESSAGE_TEXT = (
 
 _DEFAULT_OPENAI_USER_MESSAGE_TEXT = (
     f"[Document]\n{{{REFERENCE_DOCUMENTS_PLACEHOLDER}}}\n[End]\n"
-    f"{{{QUESTION_PLACEHOLDER}}}. \n"
+    f"{{{QUESTION_PLACEHOLDER}}}. Your answer should be concise. \n"
     f"{{{MULTILINGUAL_SUPPORT_INSTRUCTION_PLACEHOLDER}}}"
 )
 

--- a/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
+++ b/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
@@ -259,7 +259,7 @@ class TestBuildPatternJson:
         assert actual == expected
         assert actual != pattern["settings"]["generation"]["system_message_text"]
         assert "Granite Chat" in actual
-        assert "retrieval-augmented assistant" in actual
+        assert "Retrieval Augmented Generation" in actual
         assert "You MUST respond in English" in actual
 
     @pytest.mark.parametrize(
@@ -319,17 +319,15 @@ class TestBuildPatternJson:
             "ibm/granite-3-8b-instruct",
         ],
     )
-    def test_export_merges_unified_rag_instructions(self, model_id: str):
-        """All model families use unified RAG instructions after PR #81."""
+    def test_export_includes_language_instruction(self, model_id: str):
+        """Exported system for each model includes the language instruction and no word-count limit."""
         generation = {
             "system_message_text": get_system_message_text(model_id),
             "user_message_text": get_user_message_text(model_id, language="English"),
         }
         system_text = build_responses_system_input(generation)
-        # All models now use unified RAG structure from PR #81
-        assert "retrieval-augmented assistant" in system_text
-        assert "max 150 words" in system_text
         assert "You MUST respond in English" in system_text
+        assert "150 words" not in system_text
 
     def test_build_responses_system_input_handles_empty_inputs(self):
         """When both system and user are empty or contain only placeholders, return fallback."""

--- a/tests/unit/ai4rag/search_space/src/test_model_props.py
+++ b/tests/unit/ai4rag/search_space/src/test_model_props.py
@@ -24,28 +24,38 @@ from ai4rag.search_space.src.model_props import (
         "unknown-model",
     ],
 )
-def test_user_message_includes_grounding_and_citations(model_name: str):
+def test_user_message_contains_required_placeholders(model_name: str):
     user_message = get_user_message_text(model_name)
-    assert "Answer ONLY" in user_message
-    assert "MUST cite sources" in user_message
     assert "{reference_documents}" in user_message
     assert "{question}" in user_message
 
 
 @pytest.mark.parametrize(
-    "model_name",
+    "model_name, expected_fragment",
     [
-        "meta-llama/llama-3-1-8b-instruct",
-        "ibm/granite-3-8b-instruct",
-        "mistralai/mistral-large",
-        "openai/gpt-oss-120b",
-        "vllm-inference-gpu-llama/redhataillama-31-8b-instruct",
+        ("meta-llama/llama-3-1-8b-instruct", "helpful, respectful and honest assistant"),
+        ("ibm/granite-3-8b-instruct", "Granite Chat"),
+        ("mistralai/mistral-large", "helpful, respectful and honest assistant"),
+        ("openai/gpt-oss-120b", "Retrieval Augmented Generation (RAG) assistant"),
+        ("vllm-inference-gpu-llama/redhataillama-31-8b-instruct", "helpful, respectful and honest assistant"),
     ],
 )
-def test_system_message_includes_rag_prefix(model_name: str):
-    system_message = get_system_message_text(model_name)
-    assert "retrieval-augmented assistant" in system_message
-    assert "ONLY the provided documents" in system_message
+def test_system_message_contains_family_marker(model_name: str, expected_fragment: str):
+    assert expected_fragment in get_system_message_text(model_name)
+
+
+@pytest.mark.parametrize(
+    "model_name, expected_fragment",
+    [
+        ("meta-llama/llama-3-1-8b-instruct", "[conversation]:"),
+        ("ibm/granite-3-8b-instruct", "Answer Length: detailed"),
+        ("mistralai/mistral-large", "Generate the next agent response"),
+        ("openai/gpt-oss-120b", "[Document]"),
+        ("unknown-model", "Context:"),
+    ],
+)
+def test_user_message_contains_family_marker(model_name: str, expected_fragment: str):
+    assert expected_fragment in get_user_message_text(model_name)
 
 
 def test_context_template_numbers_documents():
@@ -78,6 +88,14 @@ def test_explicit_language_embeds_instruction():
         "unknown-model",
     ],
 )
-def test_user_message_includes_consistent_answer_length(model_name: str):
+def test_user_message_has_no_word_count_limit(model_name: str):
+    """No prompt should impose a hard word-count limit; conciseness is expressed differently."""
     user_message = get_user_message_text(model_name)
-    assert "Answer (max 150 words, with citations):" in user_message
+    assert "150 words" not in user_message
+    assert "max 150 words" not in user_message
+
+
+def test_llama_user_message_instructs_to_be_concise():
+    """Llama user message uses 'Be concise.' in place of the removed word-count limit."""
+    user_message = get_user_message_text("meta-llama/llama-3-1-8b-instruct")
+    assert "Be concise" in user_message

--- a/tests/unit/ai4rag/search_space/src/test_model_props.py
+++ b/tests/unit/ai4rag/search_space/src/test_model_props.py
@@ -48,7 +48,7 @@ def test_system_message_contains_family_marker(model_name: str, expected_fragmen
     "model_name, expected_fragment",
     [
         ("meta-llama/llama-3-1-8b-instruct", "[conversation]:"),
-        ("ibm/granite-3-8b-instruct", "Answer Length: detailed"),
+        ("ibm/granite-3-8b-instruct", "Answer Length: concise"),
         ("mistralai/mistral-large", "Generate the next agent response"),
         ("openai/gpt-oss-120b", "[Document]"),
         ("unknown-model", "Context:"),
@@ -96,6 +96,6 @@ def test_user_message_has_no_word_count_limit(model_name: str):
 
 
 def test_llama_user_message_instructs_to_be_concise():
-    """Llama user message uses 'Be concise.' in place of the removed word-count limit."""
+    """Llama user message instructs conciseness in place of the removed word-count limit."""
     user_message = get_user_message_text("meta-llama/llama-3-1-8b-instruct")
-    assert "Be concise" in user_message
+    assert "Your answer should be concise" in user_message


### PR DESCRIPTION
Assisted-by: Claude Code

## Description

  Reverts and refines the RAG prompt templates introduced in PR #81. The unified prompt approach (shared grounding/citation/answer-length constants
  applied to all model families) caused faithfulness regressions. This PR restores model-family-specific prompt templates that were in use before PR
  #81, with targeted improvements to language handling, conciseness guidance, and prompt-filter hygiene.

  ## Motivation

  The post-PR #81 prompts applied the same `_RAG_GROUNDING_INSTRUCTION`, `_RAG_CITATION_INSTRUCTION`, `_RAG_ANSWER_PROMPT_LINE`, and
  `_RAG_SYSTEM_PREFIX` constants to every model family. This broke family-specific prompt conventions (Granite's chat format, Llama's `[conversation]:`
  framing, Mistral's document-title instruction, OpenAI's `[Document]…[End]` wrapper) and led to OGX duplicating grounding and citation content that
  it already injects at runtime via `file_search` config.

  ## Changes

  - **`model_props.py`**
    - Removed shared constants `_RAG_GROUNDING_INSTRUCTION`, `_RAG_CITATION_INSTRUCTION`, `_RAG_ANSWER_LENGTH_GUIDANCE`, `_RAG_ANSWER_PROMPT_LINE`, 
  `_RAG_SYSTEM_PREFIX` that were introduced in PR #81
    - Restored model-family-specific system and user message templates (Default, Granite, Llama, Mistral, OpenAI) to their pre-PR #81 content
    - Replaced `"max 150 words"` answer-length cap with `"Your answer should be concise."` across all family user messages; Granite uses `Answer 
  Length: concise`
    - Strengthened `_LANGUAGE_INSTRUCTION` to a two-sentence form: `"Respond exclusively in {lang_name}, regardless of any other language used in the 
  provided context. You MUST respond in {lang_name}."`
    - Hardened the Default system message to an assertive grounding instruction
    - Removed trailing `\n` from the context template (documents are separated by `\n\n` join at render time)

  - **`prompt_filters.py`**
    - Removed the now-deleted `_RAG_CITATION_INSTRUCTION` import; inlined the string literal in `HPO_CITATION_FRAGMENTS`
    - Updated `USER_RAG_GROUNDING_PREFIXES` comment to note these no longer match built-in default prompts and are kept as defensive filters for custom
  HPO configurations

  - **`tests/unit/ai4rag/search_space/src/test_model_props.py`**
    - Replaced the generic `test_system_message_is_non_empty` with `test_system_message_contains_family_marker` — per-family content assertions
    - Added `test_user_message_contains_family_marker` — verifies each family resolves to its correct user template
    - Added `test_default_system_message_is_assertive` — asserts the default system message contains grounding language
    - Updated `test_user_message_has_no_word_count_limit` — confirms `"150 words"` is absent from all templates
    - Updated `test_llama_user_message_instructs_to_be_concise` to match new phrasing

  - **`tests/unit/ai4rag/assets_generator/test_pattern_builder.py`**
    - Updated assertion from `"retrieval-augmented assistant"` to `"Retrieval Augmented Generation"` to match restored templates
    - Renamed `test_export_merges_unified_rag_instructions` → `test_export_includes_language_instruction`

  ## Testing

  - All 1130 unit tests pass (`uv run pytest tests/unit/`)
  - Static analysis clean: `uv run pylint ai4rag/` rates at 10.00/10

  ## Checklist
  - [x] Tests added/updated
  - [x] Documentation updated
  - [x] Code follows style guide
  - [x] All checks passing
