### PR TITLE
refactor(evaluator): replace untyped score dicts with structured metric types

### DIFF
--- a/ai4rag/components/assets_generator/leaderboard.py
+++ b/ai4rag/components/assets_generator/leaderboard.py
@@ -106,6 +106,27 @@ def _normalize_flat_settings(settings: dict | None) -> dict | None:
     }
 
 
+def _get_aggregate_scores(e: dict) -> dict[str, dict]:
+    """Extract aggregate metric scores as ``{name: {mean, ci_low, ci_high}}`` from either format."""
+    evaluation = e.get("evaluation")
+    if isinstance(evaluation, dict):
+        return {m["name"]: m["scores"] for m in evaluation.get("metrics", []) if isinstance(m, dict)}
+    raw = e.get("scores") or {}
+    if isinstance(raw, list):
+        return {m["name"]: m["scores"] for m in raw if isinstance(m, dict)}
+    aggregate = raw.get("scores") if isinstance(raw.get("scores"), dict) else raw
+    return aggregate or {}
+
+
+def _get_final_score(e: dict) -> float | None:
+    """Extract the mean score of the metric marked with ``optimization_metric: True``."""
+    metrics = e.get("evaluation", {}).get("metrics", [])
+    for m in metrics:
+        if isinstance(m, dict) and m.get("optimization_metric"):
+            return m.get("scores", {}).get("mean")
+    return None
+
+
 def _metric_to_mean_key(metric: str) -> str:
     return "mean_" + metric
 
@@ -360,15 +381,13 @@ def build_leaderboard_html(  # pylint: disable=too-many-locals,too-many-branches
 
     # Sort by optimization metric score descending; missing scores last
     def _optimization_score(e: dict) -> tuple[bool, float]:
-        v = e.get("final_score")
+        v = _get_final_score(e)
         if v is not None:
             try:
                 return (False, -float(v))
             except (TypeError, ValueError):
                 pass
-        raw = e.get("scores") or {}
-        aggregate = raw.get("scores") if isinstance(raw.get("scores"), dict) else raw
-        for _k, info in (aggregate or {}).items():
+        for info in _get_aggregate_scores(e).values():
             if isinstance(info, dict):
                 mean = info.get("mean")
                 if mean is not None:
@@ -383,9 +402,7 @@ def build_leaderboard_html(  # pylint: disable=too-many-locals,too-many-branches
     # Discover metric columns present in data
     all_metric_names: list[str] = []
     for e in evaluations:
-        raw = e.get("scores") or {}
-        aggregate = raw.get("scores") if isinstance(raw.get("scores"), dict) else raw
-        for m in aggregate or {}:
+        for m in _get_aggregate_scores(e):
             if m not in all_metric_names:
                 all_metric_names.append(m)
     metric_columns = [c for c in _LEADERBOARD_METRIC_COLUMNS if c.replace("mean_", "", 1) in all_metric_names]
@@ -409,8 +426,7 @@ def build_leaderboard_html(  # pylint: disable=too-many-locals,too-many-branches
     rows: list[str] = []
     for i, e in enumerate(evaluations):
         pattern_name = e.get("name") or e.get("pattern_name") or (e.get("rag_pattern") or {}).get("name", "—")
-        raw = e.get("scores") or {}
-        scores = raw.get("scores") if isinstance(raw.get("scores"), dict) else raw
+        scores = _get_aggregate_scores(e)
         merged = (
             _settings_from_rag_pattern(e)
             or _normalize_flat_settings(e.get("settings"))

--- a/ai4rag/components/assets_generator/pattern_builder.py
+++ b/ai4rag/components/assets_generator/pattern_builder.py
@@ -237,6 +237,7 @@ def build_responses_system_input(generation: dict) -> str:
 
 def build_pattern_json(
     pattern: dict,
+    indexing_pipeline_params: dict | None = None,
 ) -> dict:
     """Update pattern information with responses template.
 
@@ -245,6 +246,10 @@ def build_pattern_json(
     pattern : dict
         A single evaluation result object carrying ``indexing_params``,
         ``rag_params``, ``pattern_name``, ``collection``, etc.
+
+    indexing_pipeline_params : dict | None, default=None
+        Set of parameter for the indexing pipeline build.
+        If not set, indexing pipeline object is not set.
 
     Notes
     -----
@@ -288,8 +293,6 @@ def build_pattern_json(
     if generation.get("max_completion_tokens") is not None:
         responses_template["max_output_tokens"] = generation["max_completion_tokens"]
 
-    pattern["settings"]["responses_template"] = responses_template
-
     retrieval_settings = pattern["settings"]["retrieval"]
     search_mode = retrieval_settings.get("search_mode")
     ranker_strategy = retrieval_settings.get("ranker_strategy")
@@ -297,20 +300,49 @@ def build_pattern_json(
     ranker_alpha = retrieval_settings.get("ranker_alpha")
 
     if search_mode == "hybrid" and ranker_strategy == "rrf" and ranker_k is not None and ranker_k > 0:
-        pattern["settings"]["responses_template"]["tools"][0]["ranking_options"] = {
+        responses_template["tools"][0]["ranking_options"] = {
             "ranker": "rrf",
             "impact_factor": ranker_k,
         }
     elif search_mode == "hybrid" and ranker_strategy == "weighted" and ranker_alpha is not None and ranker_alpha != 1:
-        # ``ranker_alpha == 1.0`` intentionally falls through to ``else`` (semantic-only default).
-        pattern["settings"]["responses_template"]["tools"][0]["ranking_options"] = {
+        responses_template["tools"][0]["ranking_options"] = {
             "ranker": "weighted",
             "alpha": ranker_alpha,
         }
     else:
-        pattern["settings"]["responses_template"]["tools"][0]["ranking_options"] = {
+        responses_template["tools"][0]["ranking_options"] = {
             "ranker": "weighted",
             "alpha": 1.0,
+        }
+
+    pattern["inference"] = {"responses_template": responses_template}
+
+    if indexing_pipeline_params:
+        pattern["indexing"] = {
+            "pipeline_spec": {
+                "pipeline_name": indexing_pipeline_params.get("pipeline_name", "documents_indexing_pipeline"),
+                "parameters": {
+                    "ogx_secret_name": indexing_pipeline_params.get("ogx_secret_name"),
+                    "vector_io_provider_id": indexing_pipeline_params.get("vector_io_provider_id"),
+                    "input_data_secret_name": indexing_pipeline_params.get("input_data_secret_name"),
+                    "input_data_bucket_name": indexing_pipeline_params.get("input_data_bucket_name"),
+                    "input_data_key": indexing_pipeline_params.get("input_data_key"),
+                    "batch_size": indexing_pipeline_params.get("batch_size"),
+                    "vector_store_id": pattern["settings"]["vector_store_binding"]["vector_store_id"],
+                    "embedding_model_id": pattern["settings"]["embedding"]["model_id"],
+                    "embedding_params": pattern["settings"]["embedding"]["embedding_params"],
+                    "chunking_method": pattern["settings"]["chunking"]["method"],
+                    "chunk_size": pattern["settings"]["chunking"]["chunk_size"],
+                    "chunk_overlap": pattern["settings"]["chunking"]["chunk_overlap"],
+                },
+                "overrides_allowed": [
+                    "input_data_secret_name",
+                    "input_data_bucket_name",
+                    "input_data_key",
+                    "vector_store_id",
+                    "batch_size",
+                ],
+            }
         }
 
     return pattern

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -61,6 +61,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     input_data_key: str = "",
     optimization_settings: dict | None = None,
     inference_max_threads: int = 10,
+    indexing_pipeline_params: dict | None = None,
 ) -> OptimizationResult:
     """Run a full AI4RAG optimization experiment and generate output artefacts.
 
@@ -96,6 +97,9 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         RAG service during benchmark evaluation.  Lower values reduce
         per-request concurrency (useful when each request carries more
         retrieved context).  Defaults to ``10``.
+    indexing_pipeline_params : dict | None, default=None
+        Parameters required to enhance pattern.json with indexing pipeline
+        settings.
 
     Returns
     -------
@@ -181,6 +185,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
 
         pattern_data = build_pattern_json(
             pattern=pattern.get("payload"),
+            indexing_pipeline_params=indexing_pipeline_params,
         )
 
         # Generate notebooks
@@ -252,23 +257,25 @@ def _evaluation_result_fallback(eval_data_list: list, evaluation_result: Any) ->
     This is a safety net for older experiment results that may not contain
     per-question score breakdowns.
     """
+    question_scores = (evaluation_result.scores or {}).get("question_scores") or []
+    scores_by_qid = {q["question_id"]: q["metrics"] for q in question_scores if isinstance(q, dict)}
+
     out: list[dict[str, Any]] = []
     for ev in eval_data_list:
         answer_contexts: list[dict[str, str]] = []
         if getattr(ev, "contexts", None) and getattr(ev, "context_ids", None):
             answer_contexts = [{"text": t, "document_id": doc_id} for t, doc_id in zip(ev.contexts, ev.context_ids)]
-        scores: dict[str, float] = {}
-        q_scores = (evaluation_result.scores or {}).get("question_scores") or {}
-        for key in q_scores:
-            if isinstance(q_scores[key], dict) and getattr(ev, "question_id", None) in q_scores[key]:
-                scores[key] = q_scores[key][ev.question_id]
+        qid = getattr(ev, "question_id", None)
+        metrics = [
+            {"name": m["name"], "evaluator": m["evaluator"], "score": m["value"]} for m in scores_by_qid.get(qid, [])
+        ]
         out.append(
             {
                 "question": getattr(ev, "question", ""),
                 "correct_answers": getattr(ev, "ground_truths", None),
                 "answer": getattr(ev, "answer", ""),
                 "answer_contexts": answer_contexts,
-                "scores": scores,
+                "metrics": metrics,
             }
         )
     return out

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -32,7 +32,9 @@ from ai4rag.core.experiment.utils import (
 from ai4rag.core.hpo.base_optimizer import BaseOptimizer, OptimizationError, OptimizerSettings
 from ai4rag.core.hpo.gam_opt import GAMOptimizer
 from ai4rag.core.hpo.random_opt import FailedIterationError
-from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, MetricType
+from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, EvaluationMetricsResult
+from ai4rag.evaluator.custom_metrics import calculate_overall_score
+from ai4rag.evaluator.metric import Metrics, RAGMetric
 from ai4rag.evaluator.unitxt_evaluator import UnitxtEvaluator
 from ai4rag.rag.chunking import DoclingChunker, LangChainChunker
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
@@ -91,20 +93,18 @@ class AI4RAGExperiment:
         results and intermediate status updates. EventHandler is an entrypoint to configure
         custom logging and assets handling.
 
-    optimization_metric : str, default=MetricType.FAITHFULNESS
-        Metrics that should be used for calculating final score value that will be minimized.
-        This sequence should contain 1 value for first release.
-
+    optimization_metric : RAGMetric | str, default=Metrics.FAITHFULNESS
+        Metric used for calculating the final score that drives optimization.
 
     Other Parameters
     ----------------
     job_id : str, default="ai4rag_job_a0b1c2d3"
         Unique identifier for a job.
 
-    metrics : Sequence[str]
-        Metrics that will be evaluated during AutoRAG experiment. Not all
-        of these metrics will be used to calculate final score, but they will
-        be included in the evaluation results.
+    metrics : Sequence[RAGMetric]
+        Metrics evaluated during the AutoRAG experiment. Not all
+        of these metrics are used to calculate the final score, but they
+        are included in the evaluation results.
 
     evaluator : BaseEvaluator, default=UnitxtEvaluator()
         An implementation of the BaseEvaluator class, that will be used by the AI4RAGExperiment
@@ -138,7 +138,7 @@ class AI4RAGExperiment:
         event_handler: BaseEventHandler,
         client: OgxClient | Any = None,
         ogx_vector_io_provider_id: str | None = None,
-        optimization_metric: str = MetricType.FAITHFULNESS,
+        optimization_metric: RAGMetric | str = Metrics.FAITHFULNESS,
         **kwargs,
     ):
         self.documents = documents
@@ -152,8 +152,9 @@ class AI4RAGExperiment:
         self.optimization_metric = optimization_metric
 
         self.job_id = kwargs.pop("job_id", "ai4rag_job_a0b1c2d3").replace("-", "_")
-        self.metrics: Sequence[str] = kwargs.pop(
-            "metrics", (MetricType.ANSWER_CORRECTNESS, MetricType.FAITHFULNESS, MetricType.CONTEXT_CORRECTNESS)
+        self.metrics: Sequence[RAGMetric] = kwargs.pop(
+            "metrics",
+            (Metrics.ANSWER_CORRECTNESS, Metrics.FAITHFULNESS, Metrics.CONTEXT_CORRECTNESS, Metrics.OVERALL_SCORE),
         )
         self.evaluator: BaseEvaluator = kwargs.pop(
             "evaluator",
@@ -196,20 +197,32 @@ class AI4RAGExperiment:
         self._documents = proper_docs
 
     @property
-    def optimization_metric(self) -> str:
+    def optimization_metric(self) -> RAGMetric:
         """Get optimization metrics used for the experiment."""
         return self._optimization_metric
 
     @optimization_metric.setter
-    def optimization_metric(self, val: str) -> None:
+    def optimization_metric(self, val: RAGMetric | str) -> None:
         """Validate and set optimization metrics"""
-        if val not in MetricType:
+        available_metrics = [m.name for m in Metrics]
+
+        if isinstance(val, str):
+            n_val = next((metric for metric in Metrics if metric.name == val), None)
+            val_name = val
+        elif isinstance(val, RAGMetric):
+            n_val = val if val in Metrics else None
+            val_name = val.name
+        else:
             raise RAGExperimentError(
-                f"Provided optimization metric: '{val}' is not supported. "
-                f"Available metrics: ['answer_correctness', 'faithfulness', 'context_correctness']."
+                f"Incorrect type for optimization metric: {val}. Expected ai4rag.evaluator.metric.RAGMetric or str."
             )
 
-        self._optimization_metric = val
+        if not n_val:
+            raise RAGExperimentError(
+                f"Provided optimization metric: '{val_name}' is not supported. Available metrics: {available_metrics}."
+            )
+
+        self._optimization_metric = n_val
 
     @property
     def benchmark_data(self) -> BenchmarkData:
@@ -458,9 +471,11 @@ class AI4RAGExperiment:
         stop_time = time.time()
         execution_time = stop_time - start_time
 
-        result_score = result_scores["scores"][self.optimization_metric]["mean"]
+        final_score = next(
+            r["scores"]["mean"] for r in result_scores["metrics"] if r["name"] == self.optimization_metric.name
+        )
 
-        logger.info("Calculated optimization score for '%s': %s", pattern_name, result_score)
+        logger.info("Calculated optimization score for '%s': %s", pattern_name, final_score)
 
         evaluation_result = EvaluationResult(
             pattern_name=pattern_name,
@@ -469,7 +484,7 @@ class AI4RAGExperiment:
             rag_params=rag_params,
             scores=result_scores,
             execution_time=execution_time,
-            final_score=result_score,
+            final_score=final_score,
             rag_pattern=rag_pattern,
         )
 
@@ -479,7 +494,7 @@ class AI4RAGExperiment:
 
         logger.info(
             "Evaluation scores: %s",
-            {el.get("question_id"): el.get("scores") for el in evaluation_results_json if isinstance(el, dict)},
+            {el.get("question"): el.get("metrics") for el in evaluation_results_json if isinstance(el, dict)},
         )
 
         try:
@@ -495,7 +510,7 @@ class AI4RAGExperiment:
             evaluation_result=evaluation_result,
         )
 
-        return result_score
+        return final_score
 
     def search(self, **kwargs) -> None:
         """
@@ -630,12 +645,16 @@ class AI4RAGExperiment:
 
         n_known = len(self.known_observations) if self.known_observations else 0
 
+        metrics_payload = [
+            {**m, "optimization_metric": True} if m["name"] == self.optimization_metric.name else m
+            for m in evaluation_result.scores["metrics"]
+        ]
+
         payload = {
             "name": evaluation_result.pattern_name,
             "max_combinations": self.search_space.max_combinations,
-            "scores": evaluation_result.scores["scores"],
+            "evaluation": {"metrics": metrics_payload},
             "duration_seconds": int(evaluation_result.execution_time),
-            "final_score": evaluation_result.final_score,
             "settings": {
                 "vector_store_binding": vector_store_payload,
                 **indexing_payload,
@@ -654,7 +673,7 @@ class AI4RAGExperiment:
         self,
         inference_response: list[dict[str, Any]],
         pattern_name: str,
-    ) -> tuple[dict[str, dict], list[EvaluationData]]:
+    ) -> tuple[EvaluationMetricsResult, list[EvaluationData]]:
         """
         Evaluate response from the model based on the chosen context,
         real questions/answers/ids from the benchmark_data.
@@ -670,15 +689,8 @@ class AI4RAGExperiment:
 
         Returns
         -------
-        tuple[dict[str, dict], list[EvaluationData]]
-            Data from evaluation that is of following structure:
-            data = {
-                "scores": {"answer_correctness": {"mean": 0.5, "ci_low": 0.4, "ci_high": 0.6}, ...},
-                "question_scores": {
-                    "answer_correctness": {"q_id_0": 0.5, "q_id_1": 0.8, ...},
-                    "context_correctness": {"q_id_0": 0.5, "q_id_1": 0.8, ...},
-                },
-            }
+        tuple[EvaluationMetricsResult, list[EvaluationData]]
+            Input and output evaluation data.
         """
 
         logger.info(
@@ -691,7 +703,16 @@ class AI4RAGExperiment:
         )
 
         eval_data = build_evaluation_data(benchmark_data=self.benchmark_data, inference_response=inference_response)
-        result = self.evaluator.evaluate_metrics(evaluation_data=eval_data, metrics=self.metrics)
+
+        unitxt_metrics = [m for m in self.metrics if m.evaluator == "unitxt"]
+        result = self.evaluator.evaluate_metrics(evaluation_data=eval_data, metrics=unitxt_metrics)
+
+        # Add custom metric
+        custom_metrics = [m.name for m in self.metrics if m.name == "overall_score"]
+        for custom_metric in custom_metrics:
+            match custom_metric:
+                case "overall_score":
+                    result = calculate_overall_score(scores=result)
 
         logger.info("Response evaluation results for '%s': %s.", pattern_name, result)
         return result, eval_data

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -33,7 +33,7 @@ from ai4rag.core.hpo.base_optimizer import BaseOptimizer, OptimizationError, Opt
 from ai4rag.core.hpo.gam_opt import GAMOptimizer
 from ai4rag.core.hpo.random_opt import FailedIterationError
 from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, EvaluationMetricsResult
-from ai4rag.evaluator.custom_metrics import calculate_overall_score
+from ai4rag.evaluator.custom_metrics import apply_custom_metrics
 from ai4rag.evaluator.metric import Metrics, RAGMetric
 from ai4rag.evaluator.unitxt_evaluator import UnitxtEvaluator
 from ai4rag.rag.chunking import DoclingChunker, LangChainChunker
@@ -472,8 +472,14 @@ class AI4RAGExperiment:
         execution_time = stop_time - start_time
 
         final_score = next(
-            r["scores"]["mean"] for r in result_scores["metrics"] if r["name"] == self.optimization_metric.name
+            (r["scores"]["mean"] for r in result_scores["metrics"] if r["name"] == self.optimization_metric.name),
+            None,
         )
+        if final_score is None:
+            raise RAGExperimentError(
+                f"Optimization metric '{self.optimization_metric.name}' not found in evaluation results. "
+                f"Available: {[m['name'] for m in result_scores['metrics']]}."
+            )
 
         logger.info("Calculated optimization score for '%s': %s", pattern_name, final_score)
 
@@ -707,12 +713,7 @@ class AI4RAGExperiment:
         unitxt_metrics = [m for m in self.metrics if m.evaluator == "unitxt"]
         result = self.evaluator.evaluate_metrics(evaluation_data=eval_data, metrics=unitxt_metrics)
 
-        # Add custom metric
-        custom_metrics = [m.name for m in self.metrics if m.name == "overall_score"]
-        for custom_metric in custom_metrics:
-            match custom_metric:
-                case "overall_score":
-                    result = calculate_overall_score(scores=result)
+        apply_custom_metrics(scores=result, metrics=self.metrics)
 
         logger.info("Response evaluation results for '%s': %s.", pattern_name, result)
         return result, eval_data

--- a/ai4rag/core/experiment/mps.py
+++ b/ai4rag/core/experiment/mps.py
@@ -16,7 +16,9 @@ from ai4rag.core.experiment.exception_handler import (
 )
 from ai4rag.core.experiment.utils import build_evaluation_data, query_rag
 from ai4rag.evaluator import UnitxtEvaluator
-from ai4rag.evaluator.base_evaluator import BaseEvaluator
+from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationMetricsResult
+from ai4rag.evaluator.custom_metrics import calculate_overall_score
+from ai4rag.evaluator.metric import Metrics, RAGMetric
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.chunking.langchain_chunker import LangChainChunker
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
@@ -39,8 +41,7 @@ class MPSEvaluationResultsTyped(TypedDict):
 
     foundation_model: BaseFoundationModel
     embedding_model: BaseEmbeddingModel
-    scores: dict
-    question_scores: dict
+    evaluation: EvaluationMetricsResult
 
 
 # pylint: disable=too-many-instance-attributes
@@ -58,7 +59,7 @@ class ModelsPreSelector:
 
     Parameters
     ----------
-    metric : str
+    metric : RAGMetric
         Metric used in ranking the models.
 
     foundation_models : list[BaseFoundationModel]
@@ -101,7 +102,7 @@ class ModelsPreSelector:
 
     def __init__(
         self,
-        metric: str,
+        metric: RAGMetric,
         foundation_models: list[BaseFoundationModel],
         embedding_models: list[BaseEmbeddingModel],
         documents: list[DoclingDocument],
@@ -128,6 +129,10 @@ class ModelsPreSelector:
         self.evaluation_results: list[MPSEvaluationResultsTyped] = []
         self._exception_handler = ExperimentExceptionHandler()
         self.max_threads = kwargs.pop("max_threads", 10)
+        self.metrics = kwargs.pop(
+            "metrics",
+            (Metrics.ANSWER_CORRECTNESS, Metrics.FAITHFULNESS, Metrics.CONTEXT_CORRECTNESS, Metrics.OVERALL_SCORE),
+        )
 
     def evaluate_patterns(self):
         """
@@ -203,8 +208,7 @@ class ModelsPreSelector:
                     {
                         "embedding_model": embedding_model,
                         "foundation_model": foundation_model,
-                        "scores": result_scores.get("scores", {}),
-                        "question_scores": result_scores.get("question_scores", {}),
+                        "evaluation": result_scores,
                     }
                 )
 
@@ -269,7 +273,9 @@ class ModelsPreSelector:
 
         return vector_store
 
-    def _evaluate_single_pattern(self, foundation_model: BaseFoundationModel, retriever: Retriever) -> dict[str, dict]:
+    def _evaluate_single_pattern(
+        self, foundation_model: BaseFoundationModel, retriever: Retriever
+    ) -> EvaluationMetricsResult:
         """
         Perform retrieval-augmented generation and evaluate generated response.
 
@@ -283,8 +289,8 @@ class ModelsPreSelector:
 
         Returns
         -------
-        dict[str, dict]
-            Evaluation scores per model.
+        EvaluationMetricsResult
+            Aggregate metrics with confidence intervals and per-question scores.
         """
 
         rag = SimpleRAG(foundation_model=foundation_model, retriever=retriever)
@@ -293,9 +299,16 @@ class ModelsPreSelector:
             rag=rag, questions=list(self.benchmark_data.questions), max_threads=self.max_threads
         )
 
-        result_scores = self._evaluate_response(inference_response=inference_response)
+        result = self._evaluate_response(inference_response=inference_response)
 
-        return result_scores
+        # pylint: disable=duplicate-code
+        custom_metrics = [m.name for m in self.metrics if m.name == "overall_score"]
+        for custom_metric in custom_metrics:
+            match custom_metric:
+                case "overall_score":
+                    result = calculate_overall_score(scores=result)
+
+        return result
 
     def select_models(
         self,
@@ -367,7 +380,11 @@ class ModelsPreSelector:
         _mean_scoring_results = []
 
         for result in self.evaluation_results:
-            mean_score = result.get("scores", {}).get(self.metric, {}).get("mean", {})
+            evaluation = result.get("evaluation", {})
+            mean_score = next(
+                (m["scores"]["mean"] for m in evaluation.get("metrics", []) if m["name"] == self.metric.name),
+                None,
+            )
             _mean_scoring_results.append(
                 {
                     "embedding_model": result.get("embedding_model"),
@@ -380,13 +397,13 @@ class ModelsPreSelector:
 
         models_with_scores = sorted(
             _mean_scoring_results,
-            key=lambda x: x.get("score"),
+            key=lambda x: x.get("score") or 0.0,
             reverse=True,
         )
 
         return models_with_scores
 
-    def _evaluate_response(self, inference_response: list[dict[str, Any]]) -> dict[str, dict]:
+    def _evaluate_response(self, inference_response: list[dict[str, Any]]) -> EvaluationMetricsResult:
         """
         Evaluate response from the model based on the chosen context,
         real questions/answers/ids from the benchmark_data.
@@ -399,15 +416,8 @@ class ModelsPreSelector:
 
         Returns
         -------
-        dict[str, dict]
-            Data from evaluation that is of following structure:
-            data = {
-                "scores": {"answer_correctness": {"mean": 0.5, "ci_low": 0.4, "ci_high": 0.6}, ...},
-                "question_scores": {
-                    "answer_correctness": {"q_id_0": 0.5, "q_id_1": 0.8, ...},
-                    "context_correctness": {"q_id_0": 0.5, "q_id_1": 0.8, ...},
-                },
-            }
+        EvaluationMetricsResult
+            Aggregate metrics with confidence intervals and per-question scores.
         """
         logger.debug("MPS: Evaluating responses...")
 

--- a/ai4rag/core/experiment/mps.py
+++ b/ai4rag/core/experiment/mps.py
@@ -17,7 +17,7 @@ from ai4rag.core.experiment.exception_handler import (
 from ai4rag.core.experiment.utils import build_evaluation_data, query_rag
 from ai4rag.evaluator import UnitxtEvaluator
 from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationMetricsResult
-from ai4rag.evaluator.custom_metrics import calculate_overall_score
+from ai4rag.evaluator.custom_metrics import apply_custom_metrics
 from ai4rag.evaluator.metric import Metrics, RAGMetric
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.chunking.langchain_chunker import LangChainChunker
@@ -301,12 +301,7 @@ class ModelsPreSelector:
 
         result = self._evaluate_response(inference_response=inference_response)
 
-        # pylint: disable=duplicate-code
-        custom_metrics = [m.name for m in self.metrics if m.name == "overall_score"]
-        for custom_metric in custom_metrics:
-            match custom_metric:
-                case "overall_score":
-                    result = calculate_overall_score(scores=result)
+        apply_custom_metrics(scores=result, metrics=self.metrics)
 
         return result
 
@@ -397,7 +392,7 @@ class ModelsPreSelector:
 
         models_with_scores = sorted(
             _mean_scoring_results,
-            key=lambda x: x.get("score") or 0.0,
+            key=lambda x: x["score"] if x["score"] is not None else float("-inf"),
             reverse=True,
         )
 

--- a/ai4rag/core/experiment/results.py
+++ b/ai4rag/core/experiment/results.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 from typing import Any, Generator
 
 from ai4rag import logger
-from ai4rag.evaluator.base_evaluator import EvaluationData
+from ai4rag.evaluator.base_evaluator import EvaluationData, EvaluationMetricsResult
 from ai4rag.rag.template.base_template import BaseRAGTemplate
 
 
@@ -33,15 +33,8 @@ class EvaluationResult:
         Subspace of hyperparameters used during inference stage in the
         Retrieval Augmented Generation.
 
-    scores : dict[str, dict[str, float]]
-        Score data from the evaluation that may look like:
-        data = {
-            "scores": {"answer_correctness": {"mean": 0.5, "ci_low": 0.4, "ci_high": 0.6}, ...},
-            "question_scores": {
-                "answer_correctness": {"q_id_0": 0.5, "q_id_1": 0.8, ...},
-                "context_correctness": {"q_id_0": 0.5, "q_id_1": 0.8, ...},
-            },
-        }
+    scores : EvaluationMetricsResult
+        Evaluation output with aggregate metrics and per-question scores.
 
     execution_time : float
         Time in seconds how long did experiment take to run.
@@ -57,7 +50,7 @@ class EvaluationResult:
     collection: str
     indexing_params: dict[str, Any]
     rag_params: dict[str, Any]
-    scores: dict[str, dict]
+    scores: EvaluationMetricsResult
     execution_time: float
     final_score: float
     rag_pattern: BaseRAGTemplate | None = None
@@ -213,33 +206,21 @@ class ExperimentResults:
         """
         Create json made of evaluation results with proper data.
 
-        Example file content:
-        [
-            {
-                "question_id": "0",
-                "answer": "<model's answer>",
-                "answer_contexts": [
-                    {"text": "<content1_text>", "document_id": "document_1.pdf"},
-                    {"text": "<content2_text>", "document_id": "document_2.pdf"},
-                ]
-                "scores": {
-                    "answer_correctness": 0.79,
-                    "context_correctness": 0.65,
-                }
-            },
-            {
-                "question_id": "1",
-                "answer": "<model's answer>",
-                "answer_contexts": [
-                    {"text": "<content3_text>", "document_id": "document_3.pdf"},
-                    {"text": "<content4_text>", "document_id": "document_4.pdf"},
-                ]
-                "scores": {
-                    "answer_correctness": 0.79,
-                    "context_correctness": 0.65,
-                }
-            },
-        ]
+        Example file content::
+
+            [
+                {
+                    "question_id": "0",
+                    "answer": "<model's answer>",
+                    "answer_contexts": [
+                        {"text": "<content1_text>", "document_id": "document_1.pdf"},
+                    ],
+                    "metrics": [
+                        {"name": "answer_correctness", "evaluator": "unitxt", "score": 0.79},
+                        {"name": "overall_score", "evaluator": "custom", "score": 0.79},
+                    ]
+                },
+            ]
 
         Parameters
         ----------
@@ -254,21 +235,23 @@ class ExperimentResults:
         list[dict[str, Any]]
             json-like object with evaluation results.
         """
+        scores_by_qid = {q["question_id"]: q["metrics"] for q in evaluation_result.scores["question_scores"]}
+
         data = []
-        for local_ev_data in evaluation_data:
-            ret = {
-                "question": local_ev_data.question,
-                "correct_answers": local_ev_data.ground_truths,
-                "answer": local_ev_data.answer,
-                "answer_contexts": [
-                    {"text": text, "document_id": doc_id}
-                    for text, doc_id in zip(local_ev_data.contexts, local_ev_data.context_ids)
-                ],
-                "scores": {
-                    key: evaluation_result.scores["question_scores"][key][local_ev_data.question_id]
-                    for key in evaluation_result.scores["question_scores"]
-                },
-            }
-            data.append(ret)
+        for ev in evaluation_data:
+            data.append(
+                {
+                    "question": ev.question,
+                    "correct_answers": ev.ground_truths,
+                    "answer": ev.answer,
+                    "answer_contexts": [
+                        {"text": text, "document_id": doc_id} for text, doc_id in zip(ev.contexts, ev.context_ids)
+                    ],
+                    "metrics": [
+                        {"name": m["name"], "evaluator": m["evaluator"], "score": m["value"]}
+                        for m in scores_by_qid.get(ev.question_id, [])
+                    ],
+                }
+            )
 
         return data

--- a/ai4rag/evaluator/base_evaluator.py
+++ b/ai4rag/evaluator/base_evaluator.py
@@ -4,9 +4,9 @@
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from typing import Any, Sequence
+from typing import Any, Sequence, TypedDict
 
-from ai4rag.utils.constants import ConstantMeta
+from ai4rag.evaluator.metric import RAGMetric
 
 
 # pylint: disable=too-many-instance-attributes
@@ -61,22 +61,43 @@ class EvaluationData:
         return asdict(self)
 
 
-class MetricType(metaclass=ConstantMeta):
-    """
-    Holder for metric names.
+class ConfidenceInterval(TypedDict):
+    """Aggregate scores with confidence interval bounds."""
 
-    Attributes
-    ----------
-    ANSWER_CORRECTNESS : str, default="answer_correctness"
+    mean: float | None
+    ci_low: float | None
+    ci_high: float | None
 
-    FAITHFULNESS : str, default="faithfulness"
 
-    CONTEXT_CORRECTNESS : str, default="context_correctness"
-    """
+class AggregateMetric(TypedDict):
+    """Single metric with its aggregate scores."""
 
-    ANSWER_CORRECTNESS = "answer_correctness"
-    FAITHFULNESS = "faithfulness"
-    CONTEXT_CORRECTNESS = "context_correctness"
+    name: str
+    evaluator: str
+    description: str
+    scores: ConfidenceInterval
+
+
+class QuestionMetric(TypedDict):
+    """Single metric value for one question."""
+
+    name: str
+    evaluator: str
+    value: float
+
+
+class QuestionScore(TypedDict):
+    """Per-question breakdown of all evaluated metrics."""
+
+    question_id: str
+    metrics: list[QuestionMetric]
+
+
+class EvaluationMetricsResult(TypedDict):
+    """Top-level return type of ``evaluate_metrics``."""
+
+    metrics: list[AggregateMetric]
+    question_scores: list[QuestionScore]
 
 
 class BaseEvaluator(ABC):
@@ -86,7 +107,11 @@ class BaseEvaluator(ABC):
     """
 
     @abstractmethod
-    def evaluate_metrics(self, evaluation_data: list[EvaluationData], metrics: Sequence[str]) -> dict:
+    def evaluate_metrics(
+        self,
+        evaluation_data: list[EvaluationData],
+        metrics: Sequence[RAGMetric],
+    ) -> EvaluationMetricsResult:
         """
         Evaluate the model's responses against list of different metrics.
 
@@ -96,11 +121,11 @@ class BaseEvaluator(ABC):
             List of EvaluationData instances containing all the data needed
             to perform evaluation.
 
-        metrics : Sequence[str]
-            Metrics given as strings. They should be referred to MetricType.
+        metrics : Sequence[RAGMetric]
+            Metric definitions to evaluate.
 
         Returns
         -------
-        dict
-            Evaluation result data.
+        EvaluationMetricsResult
+            Aggregate metrics with confidence intervals and per-question scores.
         """

--- a/ai4rag/evaluator/custom_metrics.py
+++ b/ai4rag/evaluator/custom_metrics.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 import math
+from collections.abc import Sequence
 from statistics import fmean
 
 from ai4rag.evaluator.base_evaluator import EvaluationMetricsResult
-from ai4rag.evaluator.metric import Metrics
+from ai4rag.evaluator.metric import Metrics, RAGMetric
 
-
-def calculate_overall_score(scores: EvaluationMetricsResult) -> EvaluationMetricsResult:
-    """Append an overall-score metric (mean of all other metrics) to *results* in-place.
+def calculate_overall_score(scores: EvaluationMetricsResult) -> None:
+    """Append an overall-score metric (mean of all other metrics) to *scores* in-place.
 
     Aggregate scores average mean/ci_low/ci_high independently across existing
     metrics.  Per-question scores average that question's metric values.
@@ -45,4 +45,11 @@ def calculate_overall_score(scores: EvaluationMetricsResult) -> EvaluationMetric
             }
         )
 
-    return scores
+
+def apply_custom_metrics(scores: EvaluationMetricsResult, metrics: Sequence[RAGMetric]) -> None:
+    """Evaluate and append all requested custom metrics to *scores* in-place."""
+    for metric in metrics:
+        if metric.evaluator != "custom":
+            continue
+        if metric.name == "overall_score":
+            calculate_overall_score(scores)

--- a/ai4rag/evaluator/custom_metrics.py
+++ b/ai4rag/evaluator/custom_metrics.py
@@ -9,6 +9,7 @@ from statistics import fmean
 from ai4rag.evaluator.base_evaluator import EvaluationMetricsResult
 from ai4rag.evaluator.metric import Metrics, RAGMetric
 
+
 def calculate_overall_score(scores: EvaluationMetricsResult) -> None:
     """Append an overall-score metric (mean of all other metrics) to *scores* in-place.
 

--- a/ai4rag/evaluator/custom_metrics.py
+++ b/ai4rag/evaluator/custom_metrics.py
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+import math
+from statistics import fmean
+
+from ai4rag.evaluator.base_evaluator import EvaluationMetricsResult
+from ai4rag.evaluator.metric import Metrics
+
+
+def calculate_overall_score(scores: EvaluationMetricsResult) -> EvaluationMetricsResult:
+    """Append an overall-score metric (mean of all other metrics) to *results* in-place.
+
+    Aggregate scores average mean/ci_low/ci_high independently across existing
+    metrics.  Per-question scores average that question's metric values.
+    """
+    overall = Metrics.OVERALL_SCORE
+
+    def avg(values: list[float | None]) -> float | None:
+        valid = [v for v in values if v is not None and not math.isnan(v)]
+        return round(fmean(valid), 4) if valid else None
+
+    if scores["metrics"]:
+        scores["metrics"].append(
+            {
+                "name": overall.name,
+                "evaluator": overall.evaluator,
+                "description": overall.description,
+                "scores": {
+                    "mean": avg([m["scores"]["mean"] for m in scores["metrics"]]),
+                    "ci_low": avg([m["scores"]["ci_low"] for m in scores["metrics"]]),
+                    "ci_high": avg([m["scores"]["ci_high"] for m in scores["metrics"]]),
+                },
+            }
+        )
+
+    for question in scores["question_scores"]:
+        score = avg([m["value"] for m in question["metrics"]])
+        question["metrics"].append(
+            {
+                "name": overall.name,
+                "evaluator": overall.evaluator,
+                "value": score if score is not None else float("nan"),
+            }
+        )
+
+    return scores

--- a/ai4rag/evaluator/metric.py
+++ b/ai4rag/evaluator/metric.py
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright IBM Corp. 2025
+# Copyright IBM Corp. 2025-2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from dataclasses import dataclass

--- a/ai4rag/evaluator/metric.py
+++ b/ai4rag/evaluator/metric.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from ai4rag.utils.constants import ConstantMeta
+
+
+@dataclass(frozen=True)
+class RAGMetric:
+    """Representation of a single metric that can be used in AI4RAG."""
+
+    name: str
+    evaluator: Literal["unitxt", "judge", "custom"]
+    description: str
+
+
+class Metrics(metaclass=ConstantMeta):
+    """AI4RAG available metrics."""
+
+    ANSWER_CORRECTNESS = RAGMetric(
+        name="answer_correctness",
+        evaluator="unitxt",
+        description="Measures how accurately the generated answer matches the ground-truth reference answers.",
+    )
+    FAITHFULNESS = RAGMetric(
+        name="faithfulness",
+        evaluator="unitxt",
+        description="Measures whether the generated answer is grounded in the retrieved context without hallucination.",
+    )
+    CONTEXT_CORRECTNESS = RAGMetric(
+        name="context_correctness",
+        evaluator="unitxt",
+        description="Measures the relevance and correctness of the retrieved context passages for the given question.",
+    )
+    OVERALL_SCORE = RAGMetric(
+        name="overall_score",
+        evaluator="custom",
+        description="Aggregate score computed as the mean of all other evaluated metrics.",
+    )

--- a/ai4rag/evaluator/metric.py
+++ b/ai4rag/evaluator/metric.py
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright IBM Corp. 2025-2026
+# Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 from dataclasses import dataclass

--- a/ai4rag/evaluator/metric.py
+++ b/ai4rag/evaluator/metric.py
@@ -1,3 +1,7 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2025
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
 from dataclasses import dataclass
 from typing import Literal
 

--- a/ai4rag/evaluator/unitxt_evaluator.py
+++ b/ai4rag/evaluator/unitxt_evaluator.py
@@ -9,26 +9,31 @@ from unitxt.eval_utils import evaluate
 
 from ai4rag.core.experiment.exception_handler import EvaluationError
 from ai4rag.evaluator.base_evaluator import (
+    AggregateMetric,
     BaseEvaluator,
+    ConfidenceInterval,
     EvaluationData,
-    MetricType,
+    EvaluationMetricsResult,
+    QuestionMetric,
+    QuestionScore,
 )
+from ai4rag.evaluator.metric import Metrics, RAGMetric
 
 
 class UnitxtEvaluator(BaseEvaluator):
     """Unitxt wrapper making evaluation of the RAG's usage."""
 
-    METRIC_TYPE_MAP = {
-        MetricType.ANSWER_CORRECTNESS: "metrics.rag.external_rag.answer_correctness",
-        MetricType.FAITHFULNESS: "metrics.rag.external_rag.faithfulness",
-        MetricType.CONTEXT_CORRECTNESS: "metrics.rag.external_rag.context_correctness",
+    METRIC_TYPE_MAP: dict[str, str] = {
+        Metrics.ANSWER_CORRECTNESS.name: "metrics.rag.external_rag.answer_correctness",
+        Metrics.FAITHFULNESS.name: "metrics.rag.external_rag.faithfulness",
+        Metrics.CONTEXT_CORRECTNESS.name: "metrics.rag.external_rag.context_correctness",
     }
 
     def evaluate_metrics(
         self,
         evaluation_data: list[EvaluationData],
-        metrics: Sequence[str],
-    ) -> dict:
+        metrics: Sequence[RAGMetric],
+    ) -> EvaluationMetricsResult:
         """
         Perform evaluation on the given instances with chosen metric types.
 
@@ -37,104 +42,122 @@ class UnitxtEvaluator(BaseEvaluator):
         evaluation_data : list[EvaluationData]
             Instances that hold data needed for the unitxt algorithms to perform evaluation.
 
-        metrics : Sequence[str]
-            Values describing which specific evaluation metrics should be used
-            withing evaluation process.
+        metrics : Sequence[RAGMetric]
+            Metric definitions to evaluate.
 
         Returns
         -------
-        dict
-            Dictionary of scores given for each EvaluationData.
+        EvaluationMetricsResult
+            Aggregate metrics with confidence intervals and per-question scores.
         """
         evaluation_primitives = [prim.to_dict() for prim in evaluation_data]
         df = pd.DataFrame(evaluation_primitives)
-        unitxt_metrics = self.get_metric_types(metric_types=metrics)
+
+        metric_lookup = {self.METRIC_TYPE_MAP[m.name]: m for m in metrics if m.name in self.METRIC_TYPE_MAP}
+        unitxt_metrics = list(metric_lookup)
+
         try:
             scores_df, ci_table = evaluate(df, metric_names=unitxt_metrics, compute_conf_intervals=True)
 
-            returned_ci = self._handle_ci_calculations(ci_table=ci_table)
-            question_scores = self._handle_questions_scores(scores_df=scores_df)
+            aggregate_metrics = self._build_aggregate_metrics(ci_table=ci_table, metric_lookup=metric_lookup)
+            question_scores = self._build_question_scores(scores_df=scores_df, metric_lookup=metric_lookup)
 
-            return {"scores": returned_ci, "question_scores": question_scores}
+            return {"metrics": aggregate_metrics, "question_scores": question_scores}
 
         except Exception as exc:
             raise EvaluationError(exc) from exc
 
-    def _handle_questions_scores(self, scores_df: pd.DataFrame) -> dict:
+    @staticmethod
+    def _build_question_scores(scores_df: pd.DataFrame, metric_lookup: dict[str, RAGMetric]) -> list[QuestionScore]:
         """
-        Handle transformations of questions scores data frame.
+        Pivot per-metric columns into a question-centric list.
 
         Parameters
         ----------
         scores_df : pd.DataFrame
-            Data returned by the unitxt evaluate function containing scores without ids.
+            Data returned by the unitxt evaluate function.
+
+        metric_lookup : dict[str, RAGMetric]
+            Mapping from unitxt metric name to the originating ``RAGMetric``.
 
         Returns
         -------
-        dict
-            Scores calculated for each question in the evaluation data.
+        list[QuestionScore]
+            One entry per question with ``question_id`` and ``metrics``.
         """
-        reversed_metrics_mapping = {v: k for k, v in self.METRIC_TYPE_MAP.items()}
         scores_df = scores_df.mask(scores_df == "")
-        raw_ret_dict = scores_df.round(4).to_dict()
-        without_id = {
-            reversed_metrics_mapping[key]: val for key, val in raw_ret_dict.items() if key in reversed_metrics_mapping
-        }
-        question_scores = {}
-        for key, val in without_id.items():
-            question_scores[key] = {raw_ret_dict["question_id"][k]: v for k, v in val.items()}
+        metric_columns = [col for col in scores_df.columns if col in metric_lookup]
+        records = scores_df.round(4).to_dict(orient="records")
 
-        return question_scores
+        return [
+            QuestionScore(
+                question_id=record["question_id"],
+                metrics=[
+                    QuestionMetric(
+                        name=metric_lookup[col].name,
+                        evaluator=metric_lookup[col].evaluator,
+                        value=record[col],
+                    )
+                    for col in metric_columns
+                ],
+            )
+            for record in records
+        ]
 
-    def _handle_ci_calculations(self, ci_table: pd.DataFrame) -> dict:
+    @staticmethod
+    def _build_aggregate_metrics(ci_table: pd.DataFrame, metric_lookup: dict[str, RAGMetric]) -> list[AggregateMetric]:
         """
-        Handle transformations of confidence interval scores data frame.
+        Transform the confidence-interval table into a list of metric summaries.
 
         Parameters
         ----------
         ci_table : pd.DataFrame
             Data with calculated confidence intervals via unitxt evaluate.
 
+        metric_lookup : dict[str, RAGMetric]
+            Mapping from unitxt metric name to the originating ``RAGMetric``.
+
         Returns
         -------
-        dict
-            Transformed confidence interval data that will be further processed.
+        list[AggregateMetric]
+            One entry per metric with ``name``, ``evaluator``, ``description``, and ``scores``.
         """
-        reversed_metrics_mapping = {v: k for k, v in self.METRIC_TYPE_MAP.items()}
         ci_dict = ci_table.to_dict()
 
         def round_or_none(x: float | None) -> float | None:
             return None if x is None or pd.isna(x) else round(x, 4)
 
-        returned_ci = {}
-        for key, val in ci_dict.items():
-            returned_ci[reversed_metrics_mapping[key]] = {
-                "mean": round_or_none(val["score"]),
-                "ci_low": round_or_none(val.get("score_ci_low")),
-                "ci_high": round_or_none(val.get("score_ci_high")),
-            }
-
-        return returned_ci
+        return [
+            AggregateMetric(
+                name=metric_lookup[key].name,
+                evaluator=metric_lookup[key].evaluator,
+                description=metric_lookup[key].description,
+                scores=ConfidenceInterval(
+                    mean=round_or_none(val["score"]),
+                    ci_low=round_or_none(val.get("score_ci_low")),
+                    ci_high=round_or_none(val.get("score_ci_high")),
+                ),
+            )
+            for key, val in ci_dict.items()
+            if key in metric_lookup
+        ]
 
     @classmethod
-    def get_metric_types(cls, metric_types: Sequence[str]) -> list[str]:
+    def get_metric_types(cls, metrics: Sequence[RAGMetric]) -> list[str]:
         """
-        Perform mapping of general metric names to the specific metric names
-        in the unitxt library.
+        Map ``RAGMetric`` instances to unitxt-specific metric strings.
 
         Parameters
         ----------
-        metric_types : Sequence[str]
-            Metrics defined in the MetricType class.
+        metrics : Sequence[RAGMetric]
+            Metric definitions.
 
         Returns
         -------
         list[str]
-            Specific versions of the metrics that can be used within
-            unitxt evaluation process.
+            Unitxt metric identifiers for the given metrics.
         """
-        mapping = [cls.METRIC_TYPE_MAP.get(metric, None) for metric in metric_types]
-        return [metric for metric in mapping if metric is not None]
+        return [cls.METRIC_TYPE_MAP[m.name] for m in metrics if m.name in cls.METRIC_TYPE_MAP]
 
     @classmethod
     def decode_unitxt_metric(cls, unitxt_metrics: list[str]) -> list[str]:
@@ -149,10 +172,7 @@ class UnitxtEvaluator(BaseEvaluator):
         Returns
         -------
         list[str]
-            Corresponding decoded messages
+            Corresponding decoded names.
         """
-
         reversed_mapping = {v: k for k, v in cls.METRIC_TYPE_MAP.items()}
-        decoded = [reversed_mapping[metric] for metric in unitxt_metrics]
-
-        return decoded
+        return [reversed_mapping[metric] for metric in unitxt_metrics]

--- a/ai4rag/utils/constants.py
+++ b/ai4rag/utils/constants.py
@@ -2,6 +2,7 @@
 # Copyright IBM Corp. 2025-2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+from collections.abc import Hashable
 from typing import Any
 
 __all__ = [
@@ -22,7 +23,7 @@ class ConstantMeta(type):
         _constant_attributes = [
             val
             for key, val in class_dict.items()
-            if not key.startswith("__") and not callable(val) and type(val) in (str, int, float)
+            if not key.startswith("__") and not callable(val) and isinstance(val, Hashable)
         ]
         class_dict["_constant_attributes"] = _constant_attributes
 

--- a/ai4rag/utils/event_handler/base_event_handler.py
+++ b/ai4rag/utils/event_handler/base_event_handler.py
@@ -27,19 +27,22 @@ class LogLevel(StrEnum):
 # ---------------------------------------------------------------------------
 
 
-class MetricCI(TypedDict):
-    """Aggregate score with confidence interval for a single metric."""
+class AggregateMetricScore(TypedDict):
+    """Confidence interval for a single aggregate metric."""
 
-    mean: float
+    mean: float | None
     ci_low: float | None
     ci_high: float | None
 
 
-class PatternScores(TypedDict):
-    """Scores section of :class:`PatternPayload`."""
+class AggregateMetricPayload(TypedDict, total=False):
+    """Single metric entry in the ``metrics`` list of :class:`EvaluationPayload`."""
 
-    scores: dict[str, MetricCI]
-    question_scores: dict[str, dict[str, float]]
+    name: str
+    evaluator: str
+    description: str
+    scores: AggregateMetricScore
+    optimization_metric: bool
 
 
 class VectorStoreSettings(TypedDict, total=False):
@@ -98,14 +101,19 @@ class PatternSettings(TypedDict):
     generation: GenerationSettings
 
 
+class EvaluationPayload(TypedDict):
+    """Evaluation section of :class:`PatternPayload`."""
+
+    metrics: list[AggregateMetricPayload]
+
+
 class PatternPayload(TypedDict):
     """Payload passed to :meth:`BaseEventHandler.on_pattern_creation`."""
 
     name: str
     max_combinations: int
-    scores: PatternScores
+    evaluation: EvaluationPayload
     duration_seconds: int
-    final_score: float
     settings: PatternSettings
     iteration: int
 
@@ -122,6 +130,14 @@ class AnswerContext(TypedDict):
     document_id: str
 
 
+class EvaluationMetricRecord(TypedDict):
+    """Single metric score for a question."""
+
+    name: str
+    evaluator: str
+    score: float
+
+
 class EvaluationRecord(TypedDict):
     """Per-question evaluation entry in the ``evaluation_results`` list."""
 
@@ -129,7 +145,7 @@ class EvaluationRecord(TypedDict):
     correct_answers: list[str]
     answer: str
     answer_contexts: list[AnswerContext]
-    scores: dict[str, float]
+    metrics: list[EvaluationMetricRecord]
 
 
 class BaseEventHandler(ABC):
@@ -173,20 +189,30 @@ class BaseEventHandler(ABC):
             {
                 'name': 'Pattern1',
                 'max_combinations': 24,
-                'scores': {
-                    'scores': {
-                        'answer_correctness': {'mean': 0.0, 'ci_low': None, 'ci_high': None},
-                        'faithfulness': {'mean': 0.0909, 'ci_low': 0.0145, 'ci_high': 0.016},
-                        'context_correctness': {'mean': 0.0, 'ci_low': None, 'ci_high': None},
-                    },
-                    'question_scores': {
-                        'answer_correctness': {'q0': 0, 'q1': 0, 'q2': 0},
-                        'faithfulness': {'q0': 0.0909, 'q1': 0.0909, 'q2': 0.0909},
-                        'context_correctness': {'q0': 0, 'q1': 0, 'q2': 0},
-                    },
+                'evaluation': {
+                    'metrics': [
+                        {
+                            'name': 'answer_correctness',
+                            'evaluator': 'unitxt',
+                            'description': '',
+                            'scores': {'mean': 0.0, 'ci_low': None, 'ci_high': None}
+                        },
+                        {
+                            'name': 'faithfulness',
+                            'evaluator': 'unitxt',
+                            'description': '',
+                            'scores': {'mean': 0.0909, 'ci_low': 0.0145, 'ci_high': 0.016},
+                            'optimization_metric': True
+                        },
+                        {
+                            'name': 'context_correctness',
+                            'evaluator': 'unitxt',
+                            'description': '',
+                            'scores': {'mean': 0.0, 'ci_low': None, 'ci_high': None}
+                        },
+                    ],
                 },
                 'duration_seconds': 42,
-                'final_score': 0.0909,
                 'settings': {
                     'vector_store_binding': {'provider_id': 'local_chroma', 'vector_store_id': 'ai4rag_20260317092550'},
                     'chunking': {'method': 'recursive', 'chunk_size': 1024, 'chunk_overlap': 256},
@@ -213,18 +239,18 @@ class BaseEventHandler(ABC):
 
             [
                 {
-                    "question": "<question_1>"
+                    "question": "<question_1>",
                     "answer": "<model's answer>",
                     "answer_contexts": [
                         {"text": "<content1_text>", "document_id": "document_1.pdf"},
                         {"text": "<content2_text>", "document_id": "document_2.pdf"},
-                    ]
-                    'correct_answers': ['correct_answer_for_question_1'],
-                    "scores": {
-                        "answer_correctness": 0.79,
-                        "faithfulness": 0.55,
-                        "context_correctness": 0.65,
-                    }
+                    ],
+                    "correct_answers": ["correct_answer_for_question_1"],
+                    "metrics": [
+                        {"name": "answer_correctness", "evaluator": "unitxt", "score": 0.79},
+                        {"name": "faithfulness", "evaluator": "unitxt", "score": 0.55},
+                        {"name": "context_correctness", "evaluator": "unitxt", "score": 0.65},
+                    ],
                 },
                 {
                     "question": "<question_2>",
@@ -232,13 +258,13 @@ class BaseEventHandler(ABC):
                     "answer_contexts": [
                         {"text": "<content3_text>", "document_id": "document_3.pdf"},
                         {"text": "<content4_text>", "document_id": "document_4.pdf"},
-                    ]
+                    ],
                     "correct_answers": ["correct_answer_1_for_question_2", "correct_answer_2_for_question_3"],
-                    "scores": {
-                        "answer_correctness": 0.79,
-                        "faithfulness": 0.55,
-                        "context_correctness": 0.65,
-                    },
+                    "metrics": [
+                        {"name": "answer_correctness", "evaluator": "unitxt", "score": 0.79},
+                        {"name": "faithfulness", "evaluator": "unitxt", "score": 0.55},
+                        {"name": "context_correctness", "evaluator": "unitxt", "score": 0.65},
+                    ],
                 },
             ]
         """

--- a/ai4rag/utils/event_handler/base_event_handler.py
+++ b/ai4rag/utils/event_handler/base_event_handler.py
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 __all__ = [
     "BaseEventHandler",
@@ -35,14 +35,14 @@ class AggregateMetricScore(TypedDict):
     ci_high: float | None
 
 
-class AggregateMetricPayload(TypedDict, total=False):
+class AggregateMetricPayload(TypedDict):
     """Single metric entry in the ``metrics`` list of :class:`EvaluationPayload`."""
 
     name: str
     evaluator: str
     description: str
     scores: AggregateMetricScore
-    optimization_metric: bool
+    optimization_metric: NotRequired[bool]
 
 
 class VectorStoreSettings(TypedDict, total=False):

--- a/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
+++ b/tests/unit/ai4rag/assets_generator/test_pattern_builder.py
@@ -89,11 +89,11 @@ class TestBuildPatternJson:
     """Verify that build_pattern_json populates responses_template correctly."""
 
     def test_adds_responses_template(self):
-        """A responses_template section must be added to settings."""
+        """A responses_template section must be added under inference."""
         pattern = _make_pattern()
         result = build_pattern_json(pattern)
 
-        rt = result["settings"]["responses_template"]
+        rt = result["inference"]["responses_template"]
         generation = result["settings"]["generation"]
         expected_system = build_responses_system_input(generation)
 
@@ -131,9 +131,9 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
+        ro = pattern["inference"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "rrf", "impact_factor": 60}
-        assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
+        assert pattern["inference"]["responses_template"]["tools"][0]["max_num_results"] == 5
 
     def test_hybrid_weighted_ranking_options(self):
         """Hybrid search with weighted ranker must set ranker and alpha in ranking_options."""
@@ -144,18 +144,18 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
+        ro = pattern["inference"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "weighted", "alpha": 0.7}
-        assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
+        assert pattern["inference"]["responses_template"]["tools"][0]["max_num_results"] == 5
 
     def test_simple_retrieval_default_ranking_options(self):
         """Vector-only search simulates semantic retrieval via weighted ranker alpha=1.0."""
         pattern = _make_pattern()
         build_pattern_json(pattern)
 
-        ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
+        ro = pattern["inference"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "weighted", "alpha": 1.0}
-        assert pattern["settings"]["responses_template"]["tools"][0]["max_num_results"] == 5
+        assert pattern["inference"]["responses_template"]["tools"][0]["max_num_results"] == 5
 
     def test_hybrid_weighted_alpha_one_uses_default_ranking(self):
         """Hybrid weighted with alpha=1.0 uses the default semantic-only simulation branch."""
@@ -166,7 +166,7 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        ro = pattern["settings"]["responses_template"]["tools"][0]["ranking_options"]
+        ro = pattern["inference"]["responses_template"]["tools"][0]["ranking_options"]
         assert ro == {"ranker": "weighted", "alpha": 1.0}
 
     def test_export_system_input_merges_non_redundant_user_rules(self):
@@ -187,7 +187,7 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        system_text = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
+        system_text = pattern["inference"]["responses_template"]["input"][0]["content"][0]["text"]
         assert "retrieval-augmented assistant" in system_text
         assert "retrieved via file search" not in system_text
         assert "provided documents" not in system_text.lower()
@@ -216,7 +216,7 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        system_text = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
+        system_text = pattern["inference"]["responses_template"]["input"][0]["content"][0]["text"]
         assert "must cite sources" not in system_text.lower()
         assert "max 150 words" in system_text
         assert "English only" in system_text
@@ -255,7 +255,7 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        actual = pattern["settings"]["responses_template"]["input"][0]["content"][0]["text"]
+        actual = pattern["inference"]["responses_template"]["input"][0]["content"][0]["text"]
         assert actual == expected
         assert actual != pattern["settings"]["generation"]["system_message_text"]
         assert "Granite Chat" in actual
@@ -466,9 +466,9 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        assert "temperature" not in pattern["settings"]["responses_template"]
+        assert "temperature" not in pattern["inference"]["responses_template"]
         # max_output_tokens should still be present
-        assert "max_output_tokens" in pattern["settings"]["responses_template"]
+        assert "max_output_tokens" in pattern["inference"]["responses_template"]
 
     def test_omits_max_output_tokens_when_none(self):
         """max_output_tokens field must be omitted when None to avoid sending null to API."""
@@ -477,9 +477,9 @@ class TestBuildPatternJson:
 
         build_pattern_json(pattern)
 
-        assert "max_output_tokens" not in pattern["settings"]["responses_template"]
+        assert "max_output_tokens" not in pattern["inference"]["responses_template"]
         # temperature should still be present
-        assert "temperature" in pattern["settings"]["responses_template"]
+        assert "temperature" in pattern["inference"]["responses_template"]
 
     def test_system_grounding_detection_no_false_positive_on_embedded_substring(self):
         """Grounding detection must not match embedded substrings, only sentence prefixes."""
@@ -493,3 +493,34 @@ class TestBuildPatternJson:
         # Should NOT suppress user grounding since system doesn't start with a grounding prefix
         assert "Use only relevant information" in result
         assert "All documents do not contain PII" in result
+
+    def test_indexing_pipeline_params_populates_indexing(self):
+        """When indexing_pipeline_params is supplied, pattern["indexing"] is populated."""
+        pattern = _make_pattern()
+        params = {
+            "pipeline_name": "custom_pipeline",
+            "ogx_secret_name": "secret_a",
+            "vector_io_provider_id": "milvus",
+            "input_data_secret_name": "data_secret",
+            "input_data_bucket_name": "bucket_x",
+            "input_data_key": "key_y",
+            "batch_size": 50,
+        }
+        result = build_pattern_json(pattern, indexing_pipeline_params=params)
+
+        spec = result["indexing"]["pipeline_spec"]
+        assert spec["pipeline_name"] == "custom_pipeline"
+        assert spec["parameters"]["ogx_secret_name"] == "secret_a"
+        assert spec["parameters"]["vector_store_id"] == "test_collection_001"
+        assert spec["parameters"]["embedding_model_id"] == "ibm/slate-125m-english-rtrvr"
+        assert spec["parameters"]["chunking_method"] == "recursive"
+        assert spec["parameters"]["chunk_size"] == 512
+        assert spec["parameters"]["chunk_overlap"] == 50
+        assert spec["parameters"]["batch_size"] == 50
+        assert "vector_store_id" in spec["overrides_allowed"]
+
+    def test_indexing_omitted_without_params(self):
+        """Without indexing_pipeline_params, no indexing key is added."""
+        pattern = _make_pattern()
+        result = build_pattern_json(pattern)
+        assert "indexing" not in result

--- a/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
+++ b/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
@@ -233,4 +233,3 @@ class TestPrepareSearchSpaceReportFiltering:
         assert result.search_space["chunk_size"] == []
         assert result.search_space["chunk_overlap"] == []
         assert result.search_space["chunking_method"] == []
-

--- a/tests/unit/ai4rag/core/experiment/test_mps.py
+++ b/tests/unit/ai4rag/core/experiment/test_mps.py
@@ -17,6 +17,7 @@ from ai4rag.core.experiment.mps import (
     ModelsPreSelector,
     PreSelectorError,
 )
+from ai4rag.evaluator.metric import Metrics
 
 
 @pytest.fixture
@@ -72,15 +73,22 @@ def pre_selector_evaluation_results(embedding_models, foundation_models) -> list
                 {
                     "embedding_model": em,
                     "foundation_model": fm,
-                    "scores": {"answer_correctness": {"mean": score}},
-                    "question_scores": {
-                        "answer_correctness": {
-                            "q0": score,
-                            "q1": score,
-                            "q2": score,
-                            "q3": score,
-                            "q4": score,
-                        }
+                    "evaluation": {
+                        "metrics": [
+                            {
+                                "name": "answer_correctness",
+                                "evaluator": "unitxt",
+                                "description": "",
+                                "scores": {"mean": score, "ci_low": None, "ci_high": None},
+                            },
+                        ],
+                        "question_scores": [
+                            {
+                                "question_id": f"q{i}",
+                                "metrics": [{"name": "answer_correctness", "evaluator": "unitxt", "value": score}],
+                            }
+                            for i in range(5)
+                        ],
                     },
                 }
             )
@@ -100,7 +108,7 @@ def pre_selector(
         benchmark_data=benchmark_data,
         foundation_models=foundation_models,
         embedding_models=embedding_models,
-        metric="answer_correctness",
+        metric=Metrics.ANSWER_CORRECTNESS,
     )
     pre_selector.evaluation_results = pre_selector_evaluation_results
 
@@ -125,7 +133,7 @@ def fully_mocked_selector(mocker, documents, benchmark_data, embedding_models, f
         documents=documents,
         foundation_models=foundation_models,
         embedding_models=embedding_models,
-        metric="answer_correctness",
+        metric=Metrics.ANSWER_CORRECTNESS,
     )
 
     return selector
@@ -139,7 +147,7 @@ class TestModelsPreSelectorInit:
             documents=documents,
             foundation_models=foundation_models,
             embedding_models=embedding_models,
-            metric="answer_correctness",
+            metric=Metrics.ANSWER_CORRECTNESS,
         )
 
         assert selector.retrieval_params["search_mode"] == "vector"
@@ -151,7 +159,7 @@ class TestModelsPreSelectorInit:
             documents=documents,
             foundation_models=foundation_models,
             embedding_models=embedding_models,
-            metric="answer_correctness",
+            metric=Metrics.ANSWER_CORRECTNESS,
             search_mode="hybrid",
         )
 
@@ -166,7 +174,7 @@ class TestModelsPreSelectorInit:
             documents=documents,
             foundation_models=foundation_models,
             embedding_models=embedding_models,
-            metric="answer_correctness",
+            metric=Metrics.ANSWER_CORRECTNESS,
             retrieval_method="window",
         )
 

--- a/tests/unit/ai4rag/core/experiment/test_results.py
+++ b/tests/unit/ai4rag/core/experiment/test_results.py
@@ -529,14 +529,36 @@ class TestExperimentResultsCreateEvaluationResultsJson:
             indexing_params={"chunk_size": 512},
             rag_params={"retrieval_method": "simple"},
             scores={
-                "scores": {
-                    "answer_correctness": {"mean": 0.75},
-                    "context_correctness": {"mean": 0.80},
-                },
-                "question_scores": {
-                    "answer_correctness": {"q0": 0.70, "q1": 0.80},
-                    "context_correctness": {"q0": 0.85, "q1": 0.75},
-                },
+                "metrics": [
+                    {
+                        "name": "answer_correctness",
+                        "evaluator": "unitxt",
+                        "description": "",
+                        "scores": {"mean": 0.75, "ci_low": None, "ci_high": None},
+                    },
+                    {
+                        "name": "context_correctness",
+                        "evaluator": "unitxt",
+                        "description": "",
+                        "scores": {"mean": 0.80, "ci_low": None, "ci_high": None},
+                    },
+                ],
+                "question_scores": [
+                    {
+                        "question_id": "q0",
+                        "metrics": [
+                            {"name": "answer_correctness", "evaluator": "unitxt", "value": 0.70},
+                            {"name": "context_correctness", "evaluator": "unitxt", "value": 0.85},
+                        ],
+                    },
+                    {
+                        "question_id": "q1",
+                        "metrics": [
+                            {"name": "answer_correctness", "evaluator": "unitxt", "value": 0.80},
+                            {"name": "context_correctness", "evaluator": "unitxt", "value": 0.75},
+                        ],
+                    },
+                ],
             },
             execution_time=10.0,
             final_score=0.77,
@@ -567,23 +589,31 @@ class TestExperimentResultsCreateEvaluationResultsJson:
         assert first_entry["answer_contexts"][0] == {"text": "Context about AI", "document_id": "doc1"}
         assert first_entry["answer_contexts"][1] == {"text": "More AI context", "document_id": "doc2"}
 
-    def test_create_evaluation_results_json_scores(self, evaluation_data_list, evaluation_result):
-        """Test scores structure in results json."""
+    def test_create_evaluation_results_json_metrics(self, evaluation_data_list, evaluation_result):
+        """Test metrics structure in results json."""
         result = ExperimentResults.create_evaluation_results_json(evaluation_data_list, evaluation_result)
 
-        first_entry = result[0]
-        assert first_entry["scores"]["answer_correctness"] == 0.70
-        assert first_entry["scores"]["context_correctness"] == 0.85
+        q0_metrics = {m["name"]: m for m in result[0]["metrics"]}
+        assert q0_metrics["answer_correctness"] == {"name": "answer_correctness", "evaluator": "unitxt", "score": 0.70}
+        assert q0_metrics["context_correctness"] == {
+            "name": "context_correctness",
+            "evaluator": "unitxt",
+            "score": 0.85,
+        }
 
-        second_entry = result[1]
-        assert second_entry["scores"]["answer_correctness"] == 0.80
-        assert second_entry["scores"]["context_correctness"] == 0.75
+        q1_metrics = {m["name"]: m for m in result[1]["metrics"]}
+        assert q1_metrics["answer_correctness"] == {"name": "answer_correctness", "evaluator": "unitxt", "score": 0.80}
+        assert q1_metrics["context_correctness"] == {
+            "name": "context_correctness",
+            "evaluator": "unitxt",
+            "score": 0.75,
+        }
 
     def test_create_evaluation_results_json_all_fields(self, evaluation_data_list, evaluation_result):
         """Test that all expected fields are present."""
         result = ExperimentResults.create_evaluation_results_json(evaluation_data_list, evaluation_result)
 
-        expected_fields = {"question", "correct_answers", "answer", "answer_contexts", "scores"}
+        expected_fields = {"question", "correct_answers", "answer", "answer_contexts", "metrics"}
         for entry in result:
             assert set(entry.keys()) == expected_fields
 

--- a/tests/unit/ai4rag/evaluator/test_base_evaluator.py
+++ b/tests/unit/ai4rag/evaluator/test_base_evaluator.py
@@ -4,7 +4,8 @@
 # -----------------------------------------------------------------------------
 import pytest
 
-from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData, MetricType
+from ai4rag.evaluator.base_evaluator import BaseEvaluator, EvaluationData
+from ai4rag.evaluator.metric import Metrics
 
 
 @pytest.fixture
@@ -124,35 +125,35 @@ class TestEvaluationDataToDict:
         assert set(result.keys()) == expected_keys
 
 
-class TestMetricType:
-    """Test suite for MetricType constants."""
+class TestMetrics:
+    """Test suite for Metrics constants."""
 
-    def test_answer_correctness_constant(self):
-        """Test ANSWER_CORRECTNESS constant value."""
-        assert MetricType.ANSWER_CORRECTNESS == "answer_correctness"
+    def test_answer_correctness_name(self):
+        assert Metrics.ANSWER_CORRECTNESS.name == "answer_correctness"
 
-    def test_faithfulness_constant(self):
-        """Test FAITHFULNESS constant value."""
-        assert MetricType.FAITHFULNESS == "faithfulness"
+    def test_faithfulness_name(self):
+        assert Metrics.FAITHFULNESS.name == "faithfulness"
 
-    def test_context_correctness_constant(self):
-        """Test CONTEXT_CORRECTNESS constant value."""
-        assert MetricType.CONTEXT_CORRECTNESS == "context_correctness"
+    def test_context_correctness_name(self):
+        assert Metrics.CONTEXT_CORRECTNESS.name == "context_correctness"
 
-    def test_all_metrics_are_strings(self):
-        """Test that all metric constants are strings."""
-        assert isinstance(MetricType.ANSWER_CORRECTNESS, str)
-        assert isinstance(MetricType.FAITHFULNESS, str)
-        assert isinstance(MetricType.CONTEXT_CORRECTNESS, str)
+    def test_overall_score_name(self):
+        assert Metrics.OVERALL_SCORE.name == "overall_score"
 
-    def test_metrics_are_unique(self):
-        """Test that all metric constants have unique values."""
-        metrics = [
-            MetricType.ANSWER_CORRECTNESS,
-            MetricType.FAITHFULNESS,
-            MetricType.CONTEXT_CORRECTNESS,
+    def test_all_metrics_have_evaluator(self):
+        assert Metrics.ANSWER_CORRECTNESS.evaluator == "unitxt"
+        assert Metrics.FAITHFULNESS.evaluator == "unitxt"
+        assert Metrics.CONTEXT_CORRECTNESS.evaluator == "unitxt"
+        assert Metrics.OVERALL_SCORE.evaluator == "custom"
+
+    def test_metrics_names_are_unique(self):
+        names = [
+            Metrics.ANSWER_CORRECTNESS.name,
+            Metrics.FAITHFULNESS.name,
+            Metrics.CONTEXT_CORRECTNESS.name,
+            Metrics.OVERALL_SCORE.name,
         ]
-        assert len(metrics) == len(set(metrics))
+        assert len(names) == len(set(names))
 
 
 class TestBaseEvaluator:

--- a/tests/unit/ai4rag/evaluator/test_custom_metrics.py
+++ b/tests/unit/ai4rag/evaluator/test_custom_metrics.py
@@ -1,0 +1,159 @@
+# -----------------------------------------------------------------------------
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: Apache-2.0
+# -----------------------------------------------------------------------------
+import math
+
+import pytest
+
+from ai4rag.evaluator.custom_metrics import calculate_overall_score
+from ai4rag.evaluator.metric import Metrics
+
+
+@pytest.fixture
+def two_metric_result():
+    return {
+        "metrics": [
+            {
+                "name": "answer_correctness",
+                "evaluator": "unitxt",
+                "description": "",
+                "scores": {"mean": 0.8, "ci_low": 0.7, "ci_high": 0.9},
+            },
+            {
+                "name": "faithfulness",
+                "evaluator": "unitxt",
+                "description": "",
+                "scores": {"mean": 0.6, "ci_low": 0.5, "ci_high": 0.7},
+            },
+        ],
+        "question_scores": [
+            {
+                "question_id": "q1",
+                "metrics": [
+                    {"name": "answer_correctness", "evaluator": "unitxt", "value": 0.9},
+                    {"name": "faithfulness", "evaluator": "unitxt", "value": 0.7},
+                ],
+            },
+            {
+                "question_id": "q2",
+                "metrics": [
+                    {"name": "answer_correctness", "evaluator": "unitxt", "value": 0.7},
+                    {"name": "faithfulness", "evaluator": "unitxt", "value": 0.5},
+                ],
+            },
+        ],
+    }
+
+
+class TestCalculateOverallScore:
+
+    def test_aggregate_mean(self, two_metric_result):
+        calculate_overall_score(two_metric_result)
+
+        overall = next(m for m in two_metric_result["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert overall["scores"]["mean"] == 0.7
+
+    def test_aggregate_ci(self, two_metric_result):
+        calculate_overall_score(two_metric_result)
+
+        overall = next(m for m in two_metric_result["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert overall["scores"]["ci_low"] == 0.6
+        assert overall["scores"]["ci_high"] == 0.8
+
+    def test_aggregate_evaluator_and_description(self, two_metric_result):
+        calculate_overall_score(two_metric_result)
+
+        overall = next(m for m in two_metric_result["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert overall["evaluator"] == "custom"
+
+    def test_per_question_values(self, two_metric_result):
+        calculate_overall_score(two_metric_result)
+
+        q1 = next(q for q in two_metric_result["question_scores"] if q["question_id"] == "q1")
+        q2 = next(q for q in two_metric_result["question_scores"] if q["question_id"] == "q2")
+
+        q1_overall = next(m for m in q1["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        q2_overall = next(m for m in q2["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+
+        assert q1_overall["value"] == 0.8
+        assert q2_overall["value"] == 0.6
+
+    def test_per_question_evaluator(self, two_metric_result):
+        calculate_overall_score(two_metric_result)
+
+        q1 = two_metric_result["question_scores"][0]
+        q1_overall = next(m for m in q1["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert q1_overall["evaluator"] == "custom"
+
+    def test_mutates_in_place(self, two_metric_result):
+        returned = calculate_overall_score(two_metric_result)
+        assert returned is two_metric_result
+
+    def test_with_none_ci(self):
+        result = {
+            "metrics": [
+                {
+                    "name": "answer_correctness",
+                    "evaluator": "unitxt",
+                    "description": "",
+                    "scores": {"mean": 0.9, "ci_low": None, "ci_high": None},
+                },
+            ],
+            "question_scores": [],
+        }
+        calculate_overall_score(result)
+
+        overall = next(m for m in result["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert overall["scores"]["mean"] == 0.9
+        assert overall["scores"]["ci_low"] is None
+        assert overall["scores"]["ci_high"] is None
+
+    def test_with_nan_question_value(self):
+        result = {
+            "metrics": [
+                {
+                    "name": "answer_correctness",
+                    "evaluator": "unitxt",
+                    "description": "",
+                    "scores": {"mean": 0.8, "ci_low": 0.7, "ci_high": 0.9},
+                },
+            ],
+            "question_scores": [
+                {
+                    "question_id": "q1",
+                    "metrics": [
+                        {"name": "answer_correctness", "evaluator": "unitxt", "value": float("nan")},
+                        {"name": "faithfulness", "evaluator": "unitxt", "value": 0.6},
+                    ],
+                },
+            ],
+        }
+        calculate_overall_score(result)
+
+        q1_overall = next(m for m in result["question_scores"][0]["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert q1_overall["value"] == 0.6
+
+    def test_all_nan_question_values(self):
+        result = {
+            "metrics": [],
+            "question_scores": [
+                {
+                    "question_id": "q1",
+                    "metrics": [
+                        {"name": "answer_correctness", "evaluator": "unitxt", "value": float("nan")},
+                    ],
+                },
+            ],
+        }
+        calculate_overall_score(result)
+
+        q1_overall = next(m for m in result["question_scores"][0]["metrics"] if m["name"] == Metrics.OVERALL_SCORE.name)
+        assert math.isnan(q1_overall["value"])
+
+    def test_empty_metrics(self):
+        result = {"metrics": [], "question_scores": []}
+        calculate_overall_score(result)
+
+        assert len(result["metrics"]) == 0
+        assert len(result["question_scores"]) == 0

--- a/tests/unit/ai4rag/evaluator/test_custom_metrics.py
+++ b/tests/unit/ai4rag/evaluator/test_custom_metrics.py
@@ -87,8 +87,10 @@ class TestCalculateOverallScore:
         assert q1_overall["evaluator"] == "custom"
 
     def test_mutates_in_place(self, two_metric_result):
-        returned = calculate_overall_score(two_metric_result)
-        assert returned is two_metric_result
+        original_metrics = two_metric_result["metrics"]
+        calculate_overall_score(two_metric_result)
+        assert two_metric_result["metrics"] is original_metrics
+        assert any(m["name"] == Metrics.OVERALL_SCORE.name for m in original_metrics)
 
     def test_with_none_ci(self):
         result = {

--- a/tests/unit/ai4rag/evaluator/test_unitxt_evaluator.py
+++ b/tests/unit/ai4rag/evaluator/test_unitxt_evaluator.py
@@ -7,7 +7,8 @@ import pandas as pd
 import pytest
 
 from ai4rag.core.experiment.exception_handler import EvaluationError
-from ai4rag.evaluator.base_evaluator import EvaluationData, MetricType
+from ai4rag.evaluator.base_evaluator import EvaluationData
+from ai4rag.evaluator.metric import Metrics, RAGMetric
 from ai4rag.evaluator.unitxt_evaluator import UnitxtEvaluator
 
 
@@ -65,18 +66,25 @@ def sample_ci_table() -> pd.DataFrame:
     )
 
 
+@pytest.fixture
+def sample_metric_lookup() -> dict[str, RAGMetric]:
+    """Fixture providing a unitxt-name → RAGMetric lookup for the three standard metrics."""
+    return {
+        UnitxtEvaluator.METRIC_TYPE_MAP[m.name]: m
+        for m in (Metrics.ANSWER_CORRECTNESS, Metrics.FAITHFULNESS, Metrics.CONTEXT_CORRECTNESS)
+    }
+
+
 class TestUnitxtEvaluatorMetricMapping:
     """Test suite for UnitxtEvaluator metric type mapping."""
 
     def test_get_metric_types_single_metric(self):
-        """Test get_metric_types with a single metric."""
-        result = UnitxtEvaluator.get_metric_types([MetricType.ANSWER_CORRECTNESS])
+        result = UnitxtEvaluator.get_metric_types([Metrics.ANSWER_CORRECTNESS])
         assert result == ["metrics.rag.external_rag.answer_correctness"]
 
     def test_get_metric_types_multiple_metrics(self):
-        """Test get_metric_types with multiple metrics."""
         result = UnitxtEvaluator.get_metric_types(
-            [MetricType.ANSWER_CORRECTNESS, MetricType.FAITHFULNESS, MetricType.CONTEXT_CORRECTNESS]
+            [Metrics.ANSWER_CORRECTNESS, Metrics.FAITHFULNESS, Metrics.CONTEXT_CORRECTNESS]
         )
         assert len(result) == 3
         assert "metrics.rag.external_rag.answer_correctness" in result
@@ -84,25 +92,23 @@ class TestUnitxtEvaluatorMetricMapping:
         assert "metrics.rag.external_rag.context_correctness" in result
 
     def test_get_metric_types_empty_list(self):
-        """Test get_metric_types with empty list."""
         result = UnitxtEvaluator.get_metric_types([])
         assert result == []
 
-    def test_get_metric_types_invalid_metric(self):
-        """Test get_metric_types with invalid metric type."""
-        result = UnitxtEvaluator.get_metric_types(["invalid_metric", MetricType.FAITHFULNESS])
-        assert len(result) == 1
+    def test_get_metric_types_unknown_metric_skipped(self):
+        unknown = RAGMetric(name="not_in_map", evaluator="unitxt", description="")
+        result = UnitxtEvaluator.get_metric_types([unknown, Metrics.FAITHFULNESS])
         assert result == ["metrics.rag.external_rag.faithfulness"]
 
-    def test_get_metric_types_all_invalid(self):
-        """Test get_metric_types with all invalid metrics."""
-        result = UnitxtEvaluator.get_metric_types(["invalid1", "invalid2"])
+    def test_get_metric_types_all_unknown(self):
+        unknown = RAGMetric(name="nope", evaluator="unitxt", description="")
+        result = UnitxtEvaluator.get_metric_types([unknown])
         assert result == []
 
     def test_decode_unitxt_metric_single(self):
         """Test decode_unitxt_metric with a single metric."""
         result = UnitxtEvaluator.decode_unitxt_metric(["metrics.rag.external_rag.answer_correctness"])
-        assert result == [MetricType.ANSWER_CORRECTNESS]
+        assert result == [Metrics.ANSWER_CORRECTNESS.name]
 
     def test_decode_unitxt_metric_multiple(self):
         """Test decode_unitxt_metric with multiple metrics."""
@@ -113,9 +119,9 @@ class TestUnitxtEvaluatorMetricMapping:
         ]
         result = UnitxtEvaluator.decode_unitxt_metric(unitxt_metrics)
         assert len(result) == 3
-        assert MetricType.ANSWER_CORRECTNESS in result
-        assert MetricType.FAITHFULNESS in result
-        assert MetricType.CONTEXT_CORRECTNESS in result
+        assert Metrics.ANSWER_CORRECTNESS.name in result
+        assert Metrics.FAITHFULNESS.name in result
+        assert Metrics.CONTEXT_CORRECTNESS.name in result
 
     def test_decode_unitxt_metric_empty_list(self):
         """Test decode_unitxt_metric with empty list."""
@@ -123,42 +129,49 @@ class TestUnitxtEvaluatorMetricMapping:
         assert result == []
 
 
-class TestUnitxtEvaluatorHandleCICalculations:
-    """Test suite for _handle_ci_calculations method."""
+class TestBuildAggregateMetrics:
+    """Test suite for _build_aggregate_metrics method."""
 
-    def test_handle_ci_calculations_basic(self, sample_ci_table):
-        """Test _handle_ci_calculations with basic input."""
+    def test_basic(self, sample_ci_table, sample_metric_lookup):
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_ci_calculations(sample_ci_table)
+        result = evaluator._build_aggregate_metrics(sample_ci_table, sample_metric_lookup)
 
-        assert isinstance(result, dict)
+        assert isinstance(result, list)
         assert len(result) == 3
-        assert MetricType.ANSWER_CORRECTNESS in result
-        assert MetricType.FAITHFULNESS in result
-        assert MetricType.CONTEXT_CORRECTNESS in result
+        names = {entry["name"] for entry in result}
+        assert names == {Metrics.ANSWER_CORRECTNESS.name, Metrics.FAITHFULNESS.name, Metrics.CONTEXT_CORRECTNESS.name}
 
-    def test_handle_ci_calculations_structure(self, sample_ci_table):
-        """Test that _handle_ci_calculations returns correct structure."""
+    def test_structure(self, sample_ci_table, sample_metric_lookup):
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_ci_calculations(sample_ci_table)
+        result = evaluator._build_aggregate_metrics(sample_ci_table, sample_metric_lookup)
 
-        for metric_key in result:
-            assert "mean" in result[metric_key]
-            assert "ci_low" in result[metric_key]
-            assert "ci_high" in result[metric_key]
+        for entry in result:
+            assert "name" in entry
+            assert "evaluator" in entry
+            assert "description" in entry
+            assert "scores" in entry
+            assert "mean" in entry["scores"]
+            assert "ci_low" in entry["scores"]
+            assert "ci_high" in entry["scores"]
 
-    def test_handle_ci_calculations_rounding(self, sample_ci_table):
-        """Test that _handle_ci_calculations rounds values correctly."""
+    def test_evaluator_and_description_populated(self, sample_ci_table, sample_metric_lookup):
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_ci_calculations(sample_ci_table)
+        result = evaluator._build_aggregate_metrics(sample_ci_table, sample_metric_lookup)
 
-        answer_correctness = result[MetricType.ANSWER_CORRECTNESS]
-        assert answer_correctness["mean"] == 0.91
-        assert answer_correctness["ci_low"] == 0.85
-        assert answer_correctness["ci_high"] == 0.97
+        for entry in result:
+            assert entry["evaluator"] == "unitxt"
+            assert isinstance(entry["description"], str)
 
-    def test_handle_ci_calculations_with_nan(self):
-        """Test _handle_ci_calculations with NaN values."""
+    def test_rounding(self, sample_ci_table, sample_metric_lookup):
+        evaluator = UnitxtEvaluator()
+        result = evaluator._build_aggregate_metrics(sample_ci_table, sample_metric_lookup)
+
+        ac = next(e for e in result if e["name"] == Metrics.ANSWER_CORRECTNESS.name)
+        assert ac["scores"]["mean"] == 0.91
+        assert ac["scores"]["ci_low"] == 0.85
+        assert ac["scores"]["ci_high"] == 0.97
+
+    def test_with_nan(self, sample_metric_lookup):
         ci_table = pd.DataFrame(
             {
                 "metrics.rag.external_rag.answer_correctness": {
@@ -175,15 +188,16 @@ class TestUnitxtEvaluatorHandleCICalculations:
         )
 
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_ci_calculations(ci_table)
+        result = evaluator._build_aggregate_metrics(ci_table, sample_metric_lookup)
 
-        assert result[MetricType.ANSWER_CORRECTNESS]["mean"] == 0.91
-        assert result[MetricType.FAITHFULNESS]["mean"] is None
-        assert result[MetricType.FAITHFULNESS]["ci_low"] is None
-        assert result[MetricType.FAITHFULNESS]["ci_high"] is None
+        ac = next(e for e in result if e["name"] == Metrics.ANSWER_CORRECTNESS.name)
+        faith = next(e for e in result if e["name"] == Metrics.FAITHFULNESS.name)
+        assert ac["scores"]["mean"] == 0.91
+        assert faith["scores"]["mean"] is None
+        assert faith["scores"]["ci_low"] is None
+        assert faith["scores"]["ci_high"] is None
 
-    def test_handle_ci_calculations_missing_ci_columns(self):
-        """Test _handle_ci_calculations when CI columns are missing."""
+    def test_missing_ci_columns(self, sample_metric_lookup):
         ci_table = pd.DataFrame(
             {
                 "metrics.rag.external_rag.answer_correctness": {"score": 0.91},
@@ -191,14 +205,14 @@ class TestUnitxtEvaluatorHandleCICalculations:
         )
 
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_ci_calculations(ci_table)
+        result = evaluator._build_aggregate_metrics(ci_table, sample_metric_lookup)
 
-        assert result[MetricType.ANSWER_CORRECTNESS]["mean"] == 0.91
-        assert result[MetricType.ANSWER_CORRECTNESS]["ci_low"] is None
-        assert result[MetricType.ANSWER_CORRECTNESS]["ci_high"] is None
+        ac = result[0]
+        assert ac["scores"]["mean"] == 0.91
+        assert ac["scores"]["ci_low"] is None
+        assert ac["scores"]["ci_high"] is None
 
-    def test_handle_ci_calculations_precision(self):
-        """Test that _handle_ci_calculations rounds to 4 decimal places."""
+    def test_precision(self, sample_metric_lookup):
         ci_table = pd.DataFrame(
             {
                 "metrics.rag.external_rag.answer_correctness": {
@@ -210,49 +224,63 @@ class TestUnitxtEvaluatorHandleCICalculations:
         )
 
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_ci_calculations(ci_table)
+        result = evaluator._build_aggregate_metrics(ci_table, sample_metric_lookup)
 
-        assert result[MetricType.ANSWER_CORRECTNESS]["mean"] == 0.1235
-        assert result[MetricType.ANSWER_CORRECTNESS]["ci_low"] == 0.9877
-        assert result[MetricType.ANSWER_CORRECTNESS]["ci_high"] == 0.5556
+        ac = result[0]
+        assert ac["scores"]["mean"] == 0.1235
+        assert ac["scores"]["ci_low"] == 0.9877
+        assert ac["scores"]["ci_high"] == 0.5556
 
 
-class TestUnitxtEvaluatorHandleQuestionsScores:
-    """Test suite for _handle_questions_scores method."""
+class TestBuildQuestionScores:
+    """Test suite for _build_question_scores method."""
 
-    def test_handle_questions_scores_basic(self, sample_scores_df):
-        """Test _handle_questions_scores with basic input."""
+    def test_basic(self, sample_scores_df, sample_metric_lookup):
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_questions_scores(sample_scores_df)
+        result = evaluator._build_question_scores(sample_scores_df, sample_metric_lookup)
 
-        assert isinstance(result, dict)
-        assert len(result) == 3
-        assert MetricType.ANSWER_CORRECTNESS in result
-        assert MetricType.FAITHFULNESS in result
-        assert MetricType.CONTEXT_CORRECTNESS in result
+        assert isinstance(result, list)
+        assert len(result) == 2
+        question_ids = {entry["question_id"] for entry in result}
+        assert question_ids == {"q1", "q2"}
 
-    def test_handle_questions_scores_structure(self, sample_scores_df):
-        """Test that _handle_questions_scores returns correct structure."""
+    def test_structure(self, sample_scores_df, sample_metric_lookup):
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_questions_scores(sample_scores_df)
+        result = evaluator._build_question_scores(sample_scores_df, sample_metric_lookup)
 
-        for metric_key in result:
-            assert isinstance(result[metric_key], dict)
-            assert "q1" in result[metric_key]
-            assert "q2" in result[metric_key]
+        for entry in result:
+            assert "question_id" in entry
+            assert "metrics" in entry
+            assert isinstance(entry["metrics"], list)
+            for m in entry["metrics"]:
+                assert "name" in m
+                assert "evaluator" in m
+                assert "value" in m
 
-    def test_handle_questions_scores_values(self, sample_scores_df):
-        """Test that _handle_questions_scores returns correct values."""
+    def test_values(self, sample_scores_df, sample_metric_lookup):
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_questions_scores(sample_scores_df)
+        result = evaluator._build_question_scores(sample_scores_df, sample_metric_lookup)
 
-        assert result[MetricType.ANSWER_CORRECTNESS]["q1"] == 0.95
-        assert result[MetricType.ANSWER_CORRECTNESS]["q2"] == 0.87
-        assert result[MetricType.FAITHFULNESS]["q1"] == 0.92
-        assert result[MetricType.FAITHFULNESS]["q2"] == 0.88
+        q1 = next(e for e in result if e["question_id"] == "q1")
+        q2 = next(e for e in result if e["question_id"] == "q2")
 
-    def test_handle_questions_scores_rounding(self):
-        """Test that _handle_questions_scores rounds to 4 decimal places."""
+        q1_metrics = {m["name"]: m["value"] for m in q1["metrics"]}
+        q2_metrics = {m["name"]: m["value"] for m in q2["metrics"]}
+
+        assert q1_metrics[Metrics.ANSWER_CORRECTNESS.name] == 0.95
+        assert q2_metrics[Metrics.ANSWER_CORRECTNESS.name] == 0.87
+        assert q1_metrics[Metrics.FAITHFULNESS.name] == 0.92
+        assert q2_metrics[Metrics.FAITHFULNESS.name] == 0.88
+
+    def test_evaluator_populated(self, sample_scores_df, sample_metric_lookup):
+        evaluator = UnitxtEvaluator()
+        result = evaluator._build_question_scores(sample_scores_df, sample_metric_lookup)
+
+        for entry in result:
+            for m in entry["metrics"]:
+                assert m["evaluator"] == "unitxt"
+
+    def test_rounding(self, sample_metric_lookup):
         scores_df = pd.DataFrame(
             {
                 "question_id": ["q1"],
@@ -261,12 +289,11 @@ class TestUnitxtEvaluatorHandleQuestionsScores:
         )
 
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_questions_scores(scores_df)
+        result = evaluator._build_question_scores(scores_df, sample_metric_lookup)
 
-        assert result[MetricType.ANSWER_CORRECTNESS]["q1"] == 0.1235
+        assert result[0]["metrics"][0]["value"] == 0.1235
 
-    def test_handle_questions_scores_with_empty_strings(self):
-        """Test _handle_questions_scores replaces empty strings with NaN."""
+    def test_with_empty_strings(self, sample_metric_lookup):
         scores_df = pd.DataFrame(
             {
                 "question_id": ["q1", "q2"],
@@ -275,13 +302,14 @@ class TestUnitxtEvaluatorHandleQuestionsScores:
         )
 
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_questions_scores(scores_df)
+        result = evaluator._build_question_scores(scores_df, sample_metric_lookup)
 
-        assert result[MetricType.ANSWER_CORRECTNESS]["q1"] == 0.95
-        assert pd.isna(result[MetricType.ANSWER_CORRECTNESS]["q2"])
+        q1 = next(e for e in result if e["question_id"] == "q1")
+        q2 = next(e for e in result if e["question_id"] == "q2")
+        assert q1["metrics"][0]["value"] == 0.95
+        assert pd.isna(q2["metrics"][0]["value"])
 
-    def test_handle_questions_scores_filters_irrelevant_columns(self):
-        """Test that _handle_questions_scores only includes relevant metrics."""
+    def test_filters_irrelevant_columns(self, sample_metric_lookup):
         scores_df = pd.DataFrame(
             {
                 "question_id": ["q1"],
@@ -292,11 +320,11 @@ class TestUnitxtEvaluatorHandleQuestionsScores:
         )
 
         evaluator = UnitxtEvaluator()
-        result = evaluator._handle_questions_scores(scores_df)
+        result = evaluator._build_question_scores(scores_df, sample_metric_lookup)
 
         assert len(result) == 1
-        assert MetricType.ANSWER_CORRECTNESS in result
-        assert "some_other_column" not in str(result)
+        assert len(result[0]["metrics"]) == 1
+        assert result[0]["metrics"][0]["name"] == Metrics.ANSWER_CORRECTNESS.name
 
 
 class TestUnitxtEvaluatorEvaluateMetrics:
@@ -328,13 +356,13 @@ class TestUnitxtEvaluatorEvaluateMetrics:
         evaluator = UnitxtEvaluator()
         result = evaluator.evaluate_metrics(
             sample_evaluation_data_list,
-            [MetricType.ANSWER_CORRECTNESS, MetricType.FAITHFULNESS],
+            [Metrics.ANSWER_CORRECTNESS, Metrics.FAITHFULNESS],
         )
 
-        assert "scores" in result
+        assert "metrics" in result
         assert "question_scores" in result
-        assert isinstance(result["scores"], dict)
-        assert isinstance(result["question_scores"], dict)
+        assert isinstance(result["metrics"], list)
+        assert isinstance(result["question_scores"], list)
 
         mock_evaluate.assert_called_once()
         call_args = mock_evaluate.call_args
@@ -353,7 +381,7 @@ class TestUnitxtEvaluatorEvaluateMetrics:
         mock_evaluate.return_value = (mock_scores_df, mock_ci_table)
 
         evaluator = UnitxtEvaluator()
-        evaluator.evaluate_metrics(sample_evaluation_data_list, [MetricType.ANSWER_CORRECTNESS])
+        evaluator.evaluate_metrics(sample_evaluation_data_list, [Metrics.ANSWER_CORRECTNESS])
 
         call_args = mock_evaluate.call_args
         df_arg = call_args[0][0]
@@ -369,7 +397,7 @@ class TestUnitxtEvaluatorEvaluateMetrics:
         evaluator = UnitxtEvaluator()
 
         with pytest.raises(EvaluationError):
-            evaluator.evaluate_metrics(sample_evaluation_data_list, [MetricType.ANSWER_CORRECTNESS])
+            evaluator.evaluate_metrics(sample_evaluation_data_list, [Metrics.ANSWER_CORRECTNESS])
 
     def test_evaluate_metrics_with_single_metric(self, mocker, sample_evaluation_data_list):
         """Test evaluate_metrics with a single metric."""
@@ -389,10 +417,12 @@ class TestUnitxtEvaluatorEvaluateMetrics:
         mock_evaluate.return_value = (mock_scores_df, mock_ci_table)
 
         evaluator = UnitxtEvaluator()
-        result = evaluator.evaluate_metrics(sample_evaluation_data_list, [MetricType.FAITHFULNESS])
+        result = evaluator.evaluate_metrics(sample_evaluation_data_list, [Metrics.FAITHFULNESS])
 
-        assert MetricType.FAITHFULNESS in result["scores"]
-        assert MetricType.FAITHFULNESS in result["question_scores"]
+        names = {m["name"] for m in result["metrics"]}
+        assert Metrics.FAITHFULNESS.name in names
+        q_names = {m["name"] for q in result["question_scores"] for m in q["metrics"]}
+        assert Metrics.FAITHFULNESS.name in q_names
 
     def test_evaluate_metrics_with_all_metrics(self, mocker, sample_evaluation_data_list):
         """Test evaluate_metrics with all three metrics."""
@@ -426,11 +456,11 @@ class TestUnitxtEvaluatorEvaluateMetrics:
         evaluator = UnitxtEvaluator()
         result = evaluator.evaluate_metrics(
             sample_evaluation_data_list,
-            [MetricType.ANSWER_CORRECTNESS, MetricType.FAITHFULNESS, MetricType.CONTEXT_CORRECTNESS],
+            [Metrics.ANSWER_CORRECTNESS, Metrics.FAITHFULNESS, Metrics.CONTEXT_CORRECTNESS],
         )
 
-        assert len(result["scores"]) == 3
-        assert len(result["question_scores"]) == 3
+        assert len(result["metrics"]) == 3
+        assert len(result["question_scores"]) == 2
 
 
 class TestUnitxtEvaluatorIntegration:
@@ -477,12 +507,17 @@ class TestUnitxtEvaluatorIntegration:
         mock_evaluate.return_value = (mock_scores_df, mock_ci_table)
 
         evaluator = UnitxtEvaluator()
-        result = evaluator.evaluate_metrics(evaluation_data, [MetricType.ANSWER_CORRECTNESS])
+        result = evaluator.evaluate_metrics(evaluation_data, [Metrics.ANSWER_CORRECTNESS])
 
-        assert result["scores"][MetricType.ANSWER_CORRECTNESS]["mean"] == 0.98
-        assert result["scores"][MetricType.ANSWER_CORRECTNESS]["ci_low"] == 0.95
-        assert result["scores"][MetricType.ANSWER_CORRECTNESS]["ci_high"] == 1.0
-        assert result["question_scores"][MetricType.ANSWER_CORRECTNESS]["q1"] == 0.98
+        ac_metric = result["metrics"][0]
+        assert ac_metric["name"] == Metrics.ANSWER_CORRECTNESS.name
+        assert ac_metric["scores"]["mean"] == 0.98
+        assert ac_metric["scores"]["ci_low"] == 0.95
+        assert ac_metric["scores"]["ci_high"] == 1.0
+
+        q1 = result["question_scores"][0]
+        assert q1["question_id"] == "q1"
+        assert q1["metrics"][0]["value"] == 0.98
 
 
 class TestUnitxtEvaluatorEdgeCases:
@@ -497,15 +532,18 @@ class TestUnitxtEvaluatorEdgeCases:
         mock_evaluate.return_value = (mock_scores_df, mock_ci_table)
 
         evaluator = UnitxtEvaluator()
-        result = evaluator.evaluate_metrics([], [MetricType.ANSWER_CORRECTNESS])
+        result = evaluator.evaluate_metrics([], [Metrics.ANSWER_CORRECTNESS])
 
-        assert "scores" in result
+        assert "metrics" in result
         assert "question_scores" in result
+        assert result["metrics"] == []
+        assert result["question_scores"] == []
 
-    def test_metric_name_case_sensitivity(self):
-        """Test that metric names are case-sensitive."""
-        evaluator = UnitxtEvaluator()
-        result = evaluator.get_metric_types(["ANSWER_CORRECTNESS", "answer_correctness"])
+    def test_name_case_sensitivity(self):
+        """Test that metric names are case-sensitive in METRIC_TYPE_MAP lookup."""
+        upper = RAGMetric(name="ANSWER_CORRECTNESS", evaluator="unitxt", description="")
+        lower = Metrics.ANSWER_CORRECTNESS
+        result = UnitxtEvaluator.get_metric_types([upper, lower])
         assert result == ["metrics.rag.external_rag.answer_correctness"]
 
     def test_decode_with_invalid_unitxt_metric(self):

--- a/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
+++ b/tests/unit/ai4rag/search_space/prepare/test_prepare_search_space.py
@@ -432,7 +432,6 @@ class TestPrepareSearchSpaceWithOgx:
         with pytest.raises(ValidationError):
             prepare_search_space_with_ogx({"chunk_sizes": [99999]}, MagicMock())
 
-
     def test_custom_chunk_overlaps_override_defaults(self, mocker):
         """chunk_overlaps in payload overrides the default chunk_overlap dimension."""
         mock_client = self._setup_mock_client(mocker)
@@ -450,4 +449,3 @@ class TestPrepareSearchSpaceWithOgx:
         """A chunk overlap above MAX_CHUNK_OVERLAP raises ValidationError before any I/O."""
         with pytest.raises(ValidationError):
             prepare_search_space_with_ogx({"chunk_overlaps": [99999]}, MagicMock())
-


### PR DESCRIPTION
Introduce RAGMetric dataclass and Metrics registry to replace MetricType string constants. Evaluation results now use EvaluationMetricsResult (list-based) instead of nested dict-of-dicts, with typed QuestionScore and AggregateMetric entries.

## Motivation
The previous evaluation result format used deeply nested untyped dicts (`dict[str, dict]`) for scores, making it error-prone to access metrics and impossible for type checkers to validate. This refactoring introduces structured types that are self-documenting, IDE-friendly, and consistent across the experiment engine, MPS, event handler, and leaderboard.

## Changes
- Add `ai4rag/evaluator/metric.py` with `RAGMetric` dataclass and `Metrics` registry
- Add `ai4rag/evaluator/custom_metrics.py` with `overall_score` computation and shared `apply_custom_metrics` dispatcher
- Replace `dict[str, dict]` returns with `EvaluationMetricsResult` TypedDicts (`AggregateMetric`, `QuestionScore`, `ConfidenceInterval`)
- Move `responses_template` under `pattern["inference"]` in `pattern_builder`
- Add optional indexing pipeline spec to `build_pattern_json`
- Update event handler payload: `evaluation.metrics` replaces `scores`/`final_score`
- Widen `ConstantMeta` to accept any `Hashable` (not just `str`/`int`/`float`)

## Testing
- Updated all existing unit tests for evaluator, experiment, MPS, results, and pattern builder
- Added new test suite for `calculate_overall_score` covering aggregation, NaN handling, empty inputs, and CI propagation
- Added new tests for indexing pipeline params in `build_pattern_json`

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Code follows style guide
- [ ] All checks passing