### PR TITLE
Release 0.10.0

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.9.3"
+__version__ = "0.10.0"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -74,6 +74,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     optimization_settings: dict | None = None,
     inference_max_threads: int = 10,
     indexing_pipeline_params: dict | None = None,
+    judge_enabled: bool = True,
 ) -> OptimizationResult:
     """Run a full AI4RAG optimization experiment and generate output artefacts.
 
@@ -112,6 +113,8 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     indexing_pipeline_params : dict | None, default=None
         Parameters required to enhance pattern.json with indexing pipeline
         settings.
+    judge_enabled : bool, default=True
+        Whether LLM as a Judge metrics should be calculated.
 
     Returns
     -------
@@ -155,6 +158,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     foundation_models: list[OGXFoundationModel] = []
     embedding_models: list[OGXEmbeddingModel] = []
     params: list[Parameter] = []
+
     for param_name, values in search_space_raw.items():
         if param_name == "foundation_model":
             values = [_deserialize_model(m, ogx_client) for m in values]
@@ -166,17 +170,20 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
 
     search_space = AI4RAGSearchSpace(params=params)
 
-    # --- Select judge model and build evaluators ---
-    judge_model = select_judge_model(
-        generation_models=foundation_models,
-        embedding_models=embedding_models,
-        benchmark_data=benchmark_data_obj,
-        documents=documents,
-        max_threads=inference_max_threads,
-    )
-    _logger.info("Judge model selected: %s", judge_model.model_id)
+    if judge_enabled:
+        # --- Select judge model and build evaluators ---
+        judge_model = select_judge_model(
+            generation_models=foundation_models,
+            embedding_models=embedding_models,
+            benchmark_data=benchmark_data_obj,
+            documents=documents,
+            max_threads=inference_max_threads,
+        )
+        _logger.info("Judge model selected: %s", judge_model.model_id)
 
-    evaluators = [UnitxtEvaluator(), LLMaJEvaluator(model=judge_model)]
+        evaluators = [UnitxtEvaluator(), LLMaJEvaluator(model=judge_model)]
+    else:
+        evaluators = [UnitxtEvaluator()]
 
     # --- Configure experiment ---
     max_rag_patterns = settings.get("max_number_of_rag_patterns", DEFAULT_MAX_RAG_PATTERNS)

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.0](https://github.com/IBM/ai4rag/releases/tag/v0.10.0)
+
+### Added
+- **Evaluator** — `LLMaJEvaluator` for LLM-as-a-Judge evaluation, scoring `answer_relevance` on a 1–5 rubric with structured JSON output and bootstrap confidence intervals; scores are normalized to [0.0, 1.0]
+- **Evaluator** — automatic judge model selection via `select_judge_model()` — when multiple generation models are available, a calibration round scores each candidate on a benchmark subset and picks the one with the highest spread-and-stability score
+- **Evaluator** — `RAGMetric` frozen dataclass and `Metrics` registry replacing raw metric-name strings throughout the evaluator and experiment APIs
+- **Evaluator** — `custom_metrics` module with `calculate_overall_score()` — computes a cross-metric mean as a built-in custom metric (`overall_score`)
+- **Experiment** — multi-evaluator dispatch: `AI4RAGExperiment` now accepts an `evaluators` list and routes each metric to the evaluator matching its `EVALUATOR_TYPE`
+- **Experiment** — `metrics` parameter on `AI4RAGExperiment` for explicit control over which metrics are evaluated; defaults are derived from configured evaluators when omitted
+- **RAG optimization component** — `indexing_pipeline_params` parameter on `run_rag_optimization()` for enriching `pattern.json` with indexing pipeline settings
+- **OGX client utilities** — `ogx_inference_base_url()` helper for building `/v1`-suffixed inference endpoint URLs
+
+### Changed
+- **Evaluator** — `BaseEvaluator.evaluate_metrics()` signature now accepts `Sequence[RAGMetric]` and returns a structured `EvaluationMetricsResult` TypedDict (was `list[str]` → `dict`)
+- **Evaluator** — `UnitxtEvaluator` updated to work with the new `RAGMetric`-based metric dispatch and return `EvaluationMetricsResult`
+- **Event handler** — `BaseEventHandler.on_pattern_creation()` payload and evaluation results now fully typed via `PatternPayload` and `EvaluationRecord` TypedDicts with nested structured types (`AggregateMetricPayload`, `VectorStoreSettings`, `ChunkingSettings`, `RetrievalSettings`, `GenerationSettings`)
+- **Experiment** — `optimization_metric` parameter accepts `RAGMetric | str` (was `str` only); default changed from `faithfulness` to `overall_score`
+- **Experiment** — evaluation results internally use structured `EvaluationMetricsResult` throughout the scoring, streaming, and caching pipeline
+- **RAG optimization component** — default optimization metric changed from `faithfulness` to `overall_score`; supported metrics now include `overall_score`
+- **RAG optimization component** — judge model selection and LLM-as-a-Judge evaluation are now automatically enabled during `run_rag_optimization()`
+- **RAG optimization component** — artefact generation extracted into `_generate_output_artifacts()` for clearer separation of concerns
+- **Dependencies** — refreshed `uv.lock` and sorted dependency declarations in `pyproject.toml`
+
+---
+
 ## [0.9.3](https://github.com/IBM/ai4rag/releases/tag/v0.9.3)
 
 ### Added

--- a/docs/api-reference/evaluator/evaluator.md
+++ b/docs/api-reference/evaluator/evaluator.md
@@ -1,6 +1,58 @@
 # Evaluator API
 
+## Metrics
+
+::: ai4rag.evaluator.metric.RAGMetric
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: ai4rag.evaluator.metric.Metrics
+    options:
+      show_root_heading: true
+      show_source: true
+
+## Base Evaluator
+
+::: ai4rag.evaluator.base_evaluator.BaseEvaluator
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: ai4rag.evaluator.base_evaluator.EvaluationData
+    options:
+      show_root_heading: true
+      show_source: true
+
+::: ai4rag.evaluator.base_evaluator.EvaluationMetricsResult
+    options:
+      show_root_heading: true
+      show_source: true
+
+## Unitxt Evaluator
+
 ::: ai4rag.evaluator.unitxt_evaluator.UnitxtEvaluator
+    options:
+      show_root_heading: true
+      show_source: true
+
+## LLM-as-a-Judge Evaluator
+
+::: ai4rag.evaluator.llmaj_evaluator.LLMaJEvaluator
+    options:
+      show_root_heading: true
+      show_source: true
+
+## Judge Model Selection
+
+::: ai4rag.evaluator.judge_selection.select_judge_model
+    options:
+      show_root_heading: true
+      show_source: true
+
+## Custom Metrics
+
+::: ai4rag.evaluator.custom_metrics.calculate_overall_score
     options:
       show_root_heading: true
       show_source: true

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -17,7 +17,7 @@ graph TB
     D[Documents]
     E[Benchmark Data]
     F[RAG Components]
-    G[Evaluator]
+    G[Evaluators<br/>Unitxt + LLM Judge]
 
     D --> A
     E --> A
@@ -122,9 +122,10 @@ sequenceDiagram
         RAG-->>Exp: inference responses
         deactivate RAG
 
-        Exp->>Eval: evaluate responses
+        Note over Exp: Multi-evaluator dispatch
+        Exp->>Eval: evaluate responses (Unitxt + LLM Judge)
         activate Eval
-        Eval-->>Exp: metric scores
+        Eval-->>Exp: EvaluationMetricsResult
         deactivate Eval
 
         Exp->>EH: stream finished pattern

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -465,14 +465,15 @@ answer = response.choices[0].message.content
 
 ## Evaluation Phase
 
-The evaluation phase compares generated answers against ground truth using unitxt metrics.
+The evaluation phase compares generated answers against ground truth using multiple evaluator types and merges results.
 
 ```mermaid
 sequenceDiagram
     participant Exp as AI4RAGExperiment
     participant Builder as build_evaluation_data()
     participant UE as UnitxtEvaluator
-    participant Unitxt as unitxt.evaluate()
+    participant JE as LLMaJEvaluator
+    participant CM as custom_metrics
 
     Exp->>Builder: build_evaluation_data(benchmark_data, inference_response)
     activate Builder
@@ -484,20 +485,24 @@ sequenceDiagram
     Builder-->>Exp: evaluation_data: list[EvaluationData]
     deactivate Builder
 
-    Exp->>UE: evaluate_metrics(evaluation_data, metrics)
+    Note over Exp: Route metrics to matching evaluators
+
+    Exp->>UE: evaluate_metrics(eval_data, unitxt_metrics)
     activate UE
-    UE->>UE: convert to DataFrame
-    UE->>Unitxt: evaluate(df, metric_names, compute_conf_intervals=True)
-    Unitxt-->>UE: scores_df, ci_table
-
-    UE->>UE: _handle_ci_calculations(ci_table)
-    Note over UE: Extract mean, ci_low, ci_high<br/>for each metric
-
-    UE->>UE: _handle_questions_scores(scores_df)
-    Note over UE: Extract per-question scores<br/>for each metric
-
-    UE-->>Exp: {"scores": {...}, "question_scores": {...}}
+    UE-->>Exp: EvaluationMetricsResult (faithfulness, answer_correctness, ...)
     deactivate UE
+
+    Exp->>JE: evaluate_metrics(eval_data, judge_metrics)
+    activate JE
+    JE-->>Exp: EvaluationMetricsResult (answer_relevance)
+    deactivate JE
+
+    Exp->>Exp: merge_evaluation_results(partial_results)
+
+    Exp->>CM: apply_custom_metrics(merged, metrics)
+    activate CM
+    CM-->>Exp: overall_score appended
+    deactivate CM
 ```
 
 ### EvaluationData Assembly
@@ -627,9 +632,12 @@ scores_df, ci_table = evaluate(
 The final optimization score is extracted from the aggregate results:
 
 ```python
-optimization_metric = "faithfulness"  # User-configured
-optimization_score = result_scores["scores"][optimization_metric]["mean"]
-# Example: 0.72
+optimization_metric = "overall_score"  # Default; user-configurable
+final_score = next(
+    m["scores"]["mean"] for m in result_scores["metrics"]
+    if m["name"] == optimization_metric
+)
+# Example: 0.75
 ```
 
 This single scalar value is returned to the optimizer.
@@ -791,22 +799,32 @@ After each evaluation completes:
 ```python
 event_handler.on_pattern_creation(
     payload={
-        "pattern_name": "Pattern5",
+        "name": "Pattern5",
         "iteration": 4,
-        "final_score": 0.72,
-        "execution_time": 134,
-        "scores": {...},
+        "max_combinations": 24,
+        "duration_seconds": 134,
+        "evaluation": {
+            "metrics": [
+                {"name": "faithfulness", "evaluator": "unitxt", "description": "...",
+                 "scores": {"mean": 0.72, "ci_low": 0.61, "ci_high": 0.83}},
+                {"name": "overall_score", "evaluator": "custom", "description": "...",
+                 "scores": {"mean": 0.75, ...}, "optimization_metric": True},
+            ],
+        },
         "settings": {
             "chunking": {...},
             "embedding": {...},
             "retrieval": {...},
-            "generation": {...}
-        }
+            "generation": {...},
+            "vector_store_binding": {...},
+        },
     },
     evaluation_results=[
-        {"question": ..., "answer": ..., "scores": {...}},
+        {"question": ..., "answer": ..., "metrics": [
+            {"name": "faithfulness", "evaluator": "unitxt", "score": 0.71}, ...
+        ]},
         ...
-    ]
+    ],
 )
 ```
 
@@ -952,11 +970,17 @@ question = "What is the capital of France?"
     "contexts": [...],
     "ground_truths_context_ids": [...]
 }
-↓ (UnitxtEvaluator)
+↓ (Multi-Evaluator Dispatch → merge → custom metrics)
 {
-    "faithfulness": {"mean": 0.95, "ci_low": 0.90, "ci_high": 1.0},
-    "answer_correctness": {"mean": 0.88, "ci_low": 0.75, "ci_high": 1.0},
-    ...
+    "metrics": [
+        {"name": "faithfulness", "evaluator": "unitxt", ...,
+         "scores": {"mean": 0.95, "ci_low": 0.90, "ci_high": 1.0}},
+        {"name": "answer_relevance", "evaluator": "judge", ...,
+         "scores": {"mean": 0.92, "ci_low": 0.85, "ci_high": 0.98}},
+        {"name": "overall_score", "evaluator": "custom", ...,
+         "scores": {"mean": 0.91, ...}},
+    ],
+    "question_scores": [...]
 }
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -143,10 +143,13 @@ graph TB
 
 **Evaluator** (`ai4rag/evaluator/`)
 
-- Wraps `unitxt` evaluation library
-- Computes metrics: `faithfulness`, `answer_correctness` and `context_correctness`
-- Compares generated answers to ground truth
-- Returns scores for optimization
+- Multi-evaluator architecture with dispatch by metric type
+- `UnitxtEvaluator` — wraps the `unitxt` library for reference-based metrics (`faithfulness`, `answer_correctness`, `context_correctness`)
+- `LLMaJEvaluator` — LLM-as-a-Judge for `answer_relevance` scoring with structured output
+- `custom_metrics` — derived metrics such as `overall_score` (mean of all other metrics)
+- `RAGMetric` dataclass and `Metrics` registry for typed metric definitions
+- Automatic judge model selection via calibration when multiple generation models are available
+- Returns structured `EvaluationMetricsResult` with confidence intervals and per-question breakdowns
 
 ### 5. Pipeline Components Layer
 
@@ -223,11 +226,13 @@ Ground Truth Answer
 Retrieved Documents
 Ground Truth Documents
     ↓
-Unitxt Evaluator
+Multi-Evaluator Dispatch
+  ├─ UnitxtEvaluator → faithfulness, answer_correctness, context_correctness
+  └─ LLMaJEvaluator  → answer_relevance
     ↓
-Metrics (faithfulness, answer_correctness, context_correctness)
+Custom Metrics (overall_score = mean of all)
     ↓
-Aggregated Score
+Optimization Score
     ↓
 HPO Optimizer (feedback for next configuration)
 ```

--- a/docs/user-guide/evaluation.md
+++ b/docs/user-guide/evaluation.md
@@ -12,13 +12,13 @@ RAG systems can fail in subtle ways:
 - Retrieve irrelevant documents that don't help answer the question
 - Produce incorrect answers even when the right information is available
 
-ai4rag uses **unitxt-based metrics** to detect these failures and guide optimization toward configurations that produce accurate, grounded, and relevant responses.
+ai4rag uses **multiple evaluator types** to detect these failures and guide optimization toward configurations that produce accurate, grounded, and relevant responses.
 
 ---
 
 ## Available Metrics
 
-ai4rag evaluates three complementary aspects of RAG performance:
+ai4rag evaluates four complementary aspects of RAG performance using two evaluator types — **Unitxt** (reference-based) and **LLM-as-a-Judge**:
 
 ### Faithfulness
 
@@ -86,26 +86,46 @@ Retrieved document IDs: ["hybrid_search_guide.md", "installation.md"]
 Context Correctness: Medium (1 of 2 correct documents retrieved)
 ```
 
+### Answer Relevance (LLM Judge)
+
+**What it measures**: Whether the generated response directly and helpfully addresses the user's question, as judged by an LLM.
+
+**Why it matters**: This metric provides an independent quality signal that does not require ground-truth answers. It detects off-topic, unhelpful, or incoherent responses that reference-based metrics might miss.
+
+**Score range**: 0.0 to 1.0 (higher is better)
+
+**How it works**: An LLM judge scores the response on a 1–5 rubric using structured JSON output. The raw score is normalized to [0.0, 1.0]. Confidence intervals are computed via bootstrapping.
+
+---
+
+### Overall Score
+
+**What it measures**: The mean of all other evaluated metrics.
+
+**Why it matters**: A single aggregate score for optimization that balances all quality dimensions. This is the **default optimization metric** in ai4rag.
+
+**Score range**: 0.0 to 1.0 (higher is better)
+
 ---
 
 ## How Evaluation Works
 
-### The UnitxtEvaluator
+### Multi-Evaluator Architecture
 
-ai4rag uses the `UnitxtEvaluator` class, which wraps the [unitxt](https://github.com/IBM/unitxt) library for RAG evaluation.
+ai4rag supports multiple evaluator types working together. Each evaluator handles the metrics matching its type:
+
+- **`UnitxtEvaluator`** — wraps the [unitxt](https://github.com/IBM/unitxt) library for reference-based RAG metrics (`faithfulness`, `answer_correctness`, `context_correctness`)
+- **`LLMaJEvaluator`** — uses an LLM as a judge for `answer_relevance`
+- **Custom metrics** — computed from the results of other evaluators (e.g. `overall_score` is the mean of all other metrics)
 
 For each RAG configuration being tested:
 
 1. **Generate answers** for all benchmark questions using the current configuration
-2. **Collect evaluation data**:
-   - Question
-   - Generated answer
-   - Retrieved contexts (chunks)
-   - Context IDs (document IDs)
-   - Ground truth answers
-   - Ground truth document IDs
-3. **Compute metrics** using unitxt's RAG evaluation algorithms
-4. **Return scores** with confidence intervals
+2. **Collect evaluation data** (question, answer, contexts, ground truths)
+3. **Route metrics to evaluators** — each evaluator receives only its own metrics
+4. **Merge results** into a single `EvaluationMetricsResult`
+5. **Compute custom metrics** (e.g. `overall_score`) on top of the merged results
+6. **Return scores** with confidence intervals
 
 ### EvaluationData Structure
 
@@ -135,40 +155,52 @@ evaluation_data = EvaluationData(
 
 ## Result Structure
 
-Evaluation results include both aggregate scores and per-question breakdowns.
+Evaluation results are returned as an `EvaluationMetricsResult` TypedDict with two sections: aggregate metrics and per-question breakdowns.
 
-### Aggregate Scores
+### Aggregate Metrics
 
 For each metric, you get:
 
-- **`mean`**: Average score across all questions
-- **`ci_low`**: Lower bound of 95% confidence interval
-- **`ci_high`**: Upper bound of 95% confidence interval
+- **`name`**: Metric identifier
+- **`evaluator`**: Which evaluator produced it (`"unitxt"`, `"judge"`, or `"custom"`)
+- **`scores.mean`**: Average score across all questions
+- **`scores.ci_low`**: Lower bound of 95% confidence interval
+- **`scores.ci_high`**: Upper bound of 95% confidence interval
 
 **Example**:
 
 ```python
 {
-    "scores": {
-        "faithfulness": {
-            "mean": 0.72,
-            "ci_low": 0.61,
-            "ci_high": 0.83
+    "metrics": [
+        {
+            "name": "faithfulness",
+            "evaluator": "unitxt",
+            "description": "Measures whether the generated answer is grounded in the retrieved context.",
+            "scores": {"mean": 0.72, "ci_low": 0.61, "ci_high": 0.83},
         },
-        "answer_correctness": {
-            "mean": 0.68,
-            "ci_low": 0.55,
-            "ci_high": 0.81
+        {
+            "name": "answer_correctness",
+            "evaluator": "unitxt",
+            "description": "Measures how accurately the generated answer matches the ground-truth.",
+            "scores": {"mean": 0.68, "ci_low": 0.55, "ci_high": 0.81},
         },
-        "context_correctness": {
-            "mean": 0.80,
-            "ci_low": 0.70,
-            "ci_high": 0.90
-        }
-    },
-    "question_scores": {
+        {
+            "name": "answer_relevance",
+            "evaluator": "judge",
+            "description": "LLM judge score for how directly the response addresses the question.",
+            "scores": {"mean": 0.85, "ci_low": 0.78, "ci_high": 0.92},
+            "model_id": "ollama/llama3.2:3b",
+        },
+        {
+            "name": "overall_score",
+            "evaluator": "custom",
+            "description": "Aggregate score computed as the mean of all other evaluated metrics.",
+            "scores": {"mean": 0.75, "ci_low": 0.65, "ci_high": 0.85},
+        },
+    ],
+    "question_scores": [
         # Per-question breakdown (see below)
-    }
+    ],
 }
 ```
 
@@ -183,23 +215,26 @@ Detailed breakdown showing how each question performed:
 
 ```python
 {
-    "question_scores": {
-        "faithfulness": {
-            "q0": 0.71,
-            "q1": 0.73,
-            "q2": 0.68
+    "question_scores": [
+        {
+            "question_id": "q0",
+            "metrics": [
+                {"name": "faithfulness", "evaluator": "unitxt", "value": 0.71},
+                {"name": "answer_correctness", "evaluator": "unitxt", "value": 0.65},
+                {"name": "answer_relevance", "evaluator": "judge", "value": 0.90},
+                {"name": "overall_score", "evaluator": "custom", "value": 0.75},
+            ],
         },
-        "answer_correctness": {
-            "q0": 0.65,
-            "q1": 0.70,
-            "q2": 0.69
+        {
+            "question_id": "q1",
+            "metrics": [
+                {"name": "faithfulness", "evaluator": "unitxt", "value": 0.73},
+                {"name": "answer_correctness", "evaluator": "unitxt", "value": 0.70},
+                {"name": "answer_relevance", "evaluator": "judge", "value": 0.80},
+                {"name": "overall_score", "evaluator": "custom", "value": 0.74},
+            ],
         },
-        "context_correctness": {
-            "q0": 0.80,
-            "q1": 0.85,
-            "q2": 0.75
-        }
-    }
+    ]
 }
 ```
 
@@ -213,56 +248,45 @@ This granular data helps you identify:
 
 ## Choosing the Optimization Metric
 
-ai4rag optimizes for a **single objective metric**. By default, this is **`FAITHFULNESS`**, but you can change it when creating your experiment.
+ai4rag optimizes for a **single objective metric**. By default, this is **`overall_score`** (the mean of all other metrics), but you can change it when creating your experiment.
 
-### Default: Faithfulness
+The `optimization_metric` parameter accepts either a `RAGMetric` instance from the `Metrics` registry or a metric name string:
+
+### Default: Overall Score
 
 ```python
 from ai4rag.core.experiment.experiment import AI4RAGExperiment
 
 experiment = AI4RAGExperiment(
     # ... other parameters
-    # objective_metric defaults to MetricType.FAITHFULNESS
+    # optimization_metric defaults to Metrics.OVERALL_SCORE
 )
 ```
 
-**Why faithfulness is the default**: Hallucination is the most critical failure mode. A system that invents information is worse than one that gives incomplete but accurate answers.
+**Why overall_score is the default**: It balances all quality dimensions — grounding, accuracy, retrieval precision, and response relevance — into a single aggregate score, preventing optimization from over-fitting to one aspect at the expense of others.
 
 ---
 
-### Optimizing for Answer Correctness
+### Optimizing for a Specific Metric
 
-If your priority is maximizing accuracy:
-
-```python
-from ai4rag.core.experiment.experiment import AI4RAGExperiment
-from ai4rag.evaluator.base_evaluator import MetricType
-
-experiment = AI4RAGExperiment(
-    # ... other parameters
-    objective_metric=MetricType.ANSWER_CORRECTNESS
-)
-```
-
-**When to use this**: When you have high-quality ground truth answers and want to maximize end-to-end accuracy, even if it means occasionally including less relevant context.
-
----
-
-### Optimizing for Context Correctness
-
-If your priority is retrieval quality:
+You can target any metric from the `Metrics` registry:
 
 ```python
 from ai4rag.core.experiment.experiment import AI4RAGExperiment
-from ai4rag.evaluator.base_evaluator import MetricType
+from ai4rag.evaluator.metric import Metrics
 
+# Using a RAGMetric instance
 experiment = AI4RAGExperiment(
     # ... other parameters
-    objective_metric=MetricType.CONTEXT_CORRECTNESS
+    optimization_metric=Metrics.FAITHFULNESS,
+)
+
+# Or using a metric name string
+experiment = AI4RAGExperiment(
+    # ... other parameters
+    optimization_metric="answer_correctness",
 )
 ```
-
-**When to use this**: When you're primarily optimizing retrieval (chunking, embedding, retrieval method) and your generation model is already well-tuned.
 
 ---
 
@@ -270,12 +294,14 @@ experiment = AI4RAGExperiment(
 
 | Metric | Optimizes For | Risk |
 |--------|--------------|------|
+| **Overall Score** | Balanced quality across all dimensions | May not maximize any single aspect |
 | **Faithfulness** | Grounded, trustworthy answers | May retrieve more context than necessary |
 | **Answer Correctness** | Accurate final answers | May prioritize accuracy over explainability |
 | **Context Correctness** | Retrieval precision | May not account for generation quality |
+| **Answer Relevance** | Direct, helpful responses (LLM judge) | Requires a judge model; adds inference cost |
 
 !!! tip "Multi-Objective Optimization"
-    While ai4rag optimizes a single metric, all three are computed for every evaluation. Review all metrics when analyzing results to ensure your best configuration doesn't sacrifice one quality for another.
+    While ai4rag optimizes a single metric, all configured metrics are computed for every evaluation. Review all metrics when analyzing results to ensure your best configuration doesn't sacrifice one quality for another.
 
 ---
 
@@ -393,6 +419,39 @@ Manually verify that:
 
 ---
 
+## Configuring Evaluators
+
+By default, `AI4RAGExperiment` uses only the `UnitxtEvaluator`. To enable LLM-as-a-Judge evaluation alongside Unitxt, pass both evaluators:
+
+```python
+from ai4rag.evaluator.unitxt_evaluator import UnitxtEvaluator
+from ai4rag.evaluator.llmaj_evaluator import LLMaJEvaluator
+from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
+
+judge_model = OGXFoundationModel(model_id="ollama/llama3.2:3b", client=client)
+
+experiment = AI4RAGExperiment(
+    # ... other parameters
+    evaluators=[UnitxtEvaluator(), LLMaJEvaluator(model=judge_model)],
+)
+```
+
+When both evaluators are configured, the experiment automatically evaluates `answer_relevance` via the LLM judge alongside the Unitxt reference-based metrics. The default metrics list adjusts to include `answer_relevance` when a judge evaluator is present.
+
+You can also explicitly control which metrics to evaluate:
+
+```python
+from ai4rag.evaluator.metric import Metrics
+
+experiment = AI4RAGExperiment(
+    # ... other parameters
+    evaluators=[UnitxtEvaluator(), LLMaJEvaluator(model=judge_model)],
+    metrics=[Metrics.FAITHFULNESS, Metrics.JUDGE_ANSWER_RELEVANCE, Metrics.OVERALL_SCORE],
+)
+```
+
+---
+
 ## Code Example
 
 Here's a complete example showing how evaluation is used in the experiment loop:
@@ -409,7 +468,9 @@ from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
 from ai4rag.rag.foundation_models.ogx import OGXFoundationModel
 from ai4rag.rag.embedding.ogx import OGXEmbeddingModel
 from ai4rag.core.hpo.gam_opt import GAMOptSettings
-from ai4rag.evaluator.base_evaluator import MetricType
+from ai4rag.evaluator.metric import Metrics
+from ai4rag.evaluator.unitxt_evaluator import UnitxtEvaluator
+from ai4rag.evaluator.llmaj_evaluator import LLMaJEvaluator
 from ai4rag.utils.event_handler import LocalEventHandler
 
 from dev_utils.file_store import FileStore
@@ -447,7 +508,10 @@ search_space = AI4RAGSearchSpace(
     ]
 )
 
-# Run optimization (optimizes for faithfulness by default)
+# Configure evaluators — Unitxt for reference-based metrics, LLMaJ for judge-based
+judge_model = OGXFoundationModel(model_id="ollama/llama3.2:3b", client=client)
+
+# Run optimization (optimizes for overall_score by default)
 experiment = AI4RAGExperiment(
     client=client,
     documents=documents,
@@ -456,16 +520,17 @@ experiment = AI4RAGExperiment(
     vector_store_type="ogx",
     ogx_vector_io_provider_id="milvus",
     optimizer_settings=GAMOptSettings(max_evals=8, n_random_nodes=3),
-    objective_metric=MetricType.FAITHFULNESS,  # Can change to ANSWER_CORRECTNESS or CONTEXT_CORRECTNESS
+    evaluators=[UnitxtEvaluator(), LLMaJEvaluator(model=judge_model)],
+    optimization_metric=Metrics.OVERALL_SCORE,
     event_handler=LocalEventHandler(output_path="./results"),
 )
 
-best_pattern = experiment.search()
+experiment.search()
 
-# Results are automatically saved to ./results with all three metrics
-print(f"Best pattern achieved faithfulness: {best_pattern.scores['scores']['faithfulness']['mean']:.2f}")
-print(f"Answer correctness: {best_pattern.scores['scores']['answer_correctness']['mean']:.2f}")
-print(f"Context correctness: {best_pattern.scores['scores']['context_correctness']['mean']:.2f}")
+# Access results
+best = experiment.results.get_best_evaluations(k=1)[0]
+for m in best.scores["metrics"]:
+    print(f"{m['name']}: {m['scores']['mean']:.2f}")
 ```
 
 ---
@@ -541,9 +606,10 @@ print(f"Context correctness: {best_pattern.scores['scores']['context_correctness
 
 Evaluation in ai4rag:
 
-- **Three metrics**: Faithfulness (grounding), Answer Correctness (accuracy), Context Correctness (retrieval quality)
-- **Powered by unitxt**: Industry-standard RAG evaluation library
-- **Single objective**: Optimizes for one metric, but computes all three
+- **Four metrics**: Faithfulness (grounding), Answer Correctness (accuracy), Context Correctness (retrieval quality), Answer Relevance (LLM judge)
+- **Multi-evaluator architecture**: Unitxt for reference-based metrics, LLM-as-a-Judge for response quality
+- **Overall score**: Cross-metric mean used as the default optimization target
+- **Single objective**: Optimizes for one metric, but computes all configured metrics
 - **Benchmark-driven**: Quality depends on your benchmark data
 - **Confidence intervals**: Statistical rigor built-in
 - **Per-question breakdown**: Detailed diagnostics for analysis

--- a/docs/user-guide/event-handlers.md
+++ b/docs/user-guide/event-handlers.md
@@ -60,18 +60,29 @@ def on_pattern_creation(
     "name": "Pattern1",
     "iteration": 0,
     "max_combinations": 24,
-    "final_score": 0.72,
     "duration_seconds": 134,
-    "scores": {
-        "scores": {
-            "faithfulness":        {"mean": 0.72, "ci_low": 0.61, "ci_high": 0.83},
-            "answer_correctness":  {"mean": 0.68, "ci_low": 0.55, "ci_high": 0.81},
-            "context_correctness": {"mean": 0.80, "ci_low": 0.70, "ci_high": 0.90},
-        },
-        "question_scores": {
-            "faithfulness": {"q0": 0.71, "q1": 0.73, ...},
-            ...
-        },
+    "evaluation": {
+        "metrics": [
+            {
+                "name": "faithfulness",
+                "evaluator": "unitxt",
+                "description": "...",
+                "scores": {"mean": 0.72, "ci_low": 0.61, "ci_high": 0.83},
+            },
+            {
+                "name": "answer_relevance",
+                "evaluator": "judge",
+                "description": "...",
+                "scores": {"mean": 0.85, "ci_low": 0.78, "ci_high": 0.92},
+            },
+            {
+                "name": "overall_score",
+                "evaluator": "custom",
+                "description": "...",
+                "scores": {"mean": 0.75, "ci_low": 0.65, "ci_high": 0.85},
+                "optimization_metric": True,
+            },
+        ],
     },
     "settings": {
         "chunking":    {"method": "recursive", "chunk_size": 512, "chunk_overlap": 64},
@@ -94,11 +105,11 @@ def on_pattern_creation(
         "answer_contexts": [
             {"text": "Retrieved chunk text ...", "document_id": "doc1.pdf"},
         ],
-        "scores": {
-            "faithfulness": 0.71,
-            "answer_correctness": 0.65,
-            "context_correctness": 0.80,
-        },
+        "metrics": [
+            {"name": "faithfulness", "evaluator": "unitxt", "score": 0.71},
+            {"name": "answer_relevance", "evaluator": "judge", "score": 0.85},
+            {"name": "overall_score", "evaluator": "custom", "score": 0.78},
+        ],
     },
     ...
 ]
@@ -149,7 +160,7 @@ class MyEventHandler(BaseEventHandler):
     ) -> None:
         requests.post("https://my-service/patterns", json={
             "name": payload["name"],
-            "score": payload["final_score"],
+            "metrics": payload["evaluation"]["metrics"],
             "settings": payload["settings"],
         })
 ```

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -51,11 +51,13 @@ The **HPO engine** explores the search space intelligently:
 
 ### Evaluation Metrics
 
-ai4rag uses **unitxt-based metrics**:
+ai4rag uses **multiple evaluator types** for comprehensive quality assessment:
 
-- **Faithfulness**: Answer grounded in retrieved context
-- **Answer Correctness**: Answer matches ground truth
-- **Context Correctness**: Retrieved documents are relevant
+- **Faithfulness** (Unitxt): Answer grounded in retrieved context
+- **Answer Correctness** (Unitxt): Answer matches ground truth
+- **Context Correctness** (Unitxt): Retrieved documents are relevant
+- **Answer Relevance** (LLM Judge): Response directly addresses the question
+- **Overall Score** (Custom): Mean of all other metrics (default optimization target)
 
 ---
 


### PR DESCRIPTION
# Release v0.10.0

## Summary

This release introduces LLM-as-a-Judge evaluation and multi-evaluator dispatch to ai4rag. Experiments can now score RAG patterns with both reference-based Unitxt metrics and an LLM judge simultaneously, producing an `answer_relevance` score alongside existing `faithfulness`, `answer_correctness`, and `context_correctness` metrics. A calibration-based judge model selection algorithm automatically picks the best-performing judge from the available generation models. The evaluator API has been refactored around structured `RAGMetric` types and `EvaluationMetricsResult` TypedDicts, replacing untyped dictionaries with fully typed contracts across the experiment, scoring, and event-handler layers.

## Changes

### Added
- **Evaluator** — `LLMaJEvaluator` for LLM-as-a-Judge evaluation, scoring `answer_relevance` on a 1-5 rubric with structured JSON output and bootstrap confidence intervals; scores are normalized to [0.0, 1.0]
- **Evaluator** — automatic judge model selection via `select_judge_model()` — when multiple generation models are available, a calibration round scores each candidate on a benchmark subset and picks the one with the highest spread-and-stability score
- **Evaluator** — `RAGMetric` frozen dataclass and `Metrics` registry replacing raw metric-name strings throughout the evaluator and experiment APIs
- **Evaluator** — `custom_metrics` module with `calculate_overall_score()` — computes a cross-metric mean as a built-in custom metric (`overall_score`)
- **Experiment** — multi-evaluator dispatch: `AI4RAGExperiment` now accepts an `evaluators` list and routes each metric to the evaluator matching its `EVALUATOR_TYPE`
- **Experiment** — `metrics` parameter on `AI4RAGExperiment` for explicit control over which metrics are evaluated; defaults are derived from configured evaluators when omitted
- **RAG optimization component** — `indexing_pipeline_params` parameter on `run_rag_optimization()` for enriching `pattern.json` with indexing pipeline settings
- **OGX client utilities** — `ogx_inference_base_url()` helper for building `/v1`-suffixed inference endpoint URLs

### Changed
- **Evaluator** — `BaseEvaluator.evaluate_metrics()` signature now accepts `Sequence[RAGMetric]` and returns a structured `EvaluationMetricsResult` TypedDict (was `list[str]` -> `dict`)
- **Evaluator** — `UnitxtEvaluator` updated to work with the new `RAGMetric`-based metric dispatch and return `EvaluationMetricsResult`
- **Event handler** — `BaseEventHandler.on_pattern_creation()` payload and evaluation results now fully typed via `PatternPayload` and `EvaluationRecord` TypedDicts with nested structured types
- **Experiment** — `optimization_metric` parameter accepts `RAGMetric | str` (was `str` only); default changed from `faithfulness` to `overall_score`
- **Experiment** — evaluation results internally use structured `EvaluationMetricsResult` throughout the scoring, streaming, and caching pipeline
- **RAG optimization component** — default optimization metric changed from `faithfulness` to `overall_score`; supported metrics now include `overall_score`
- **RAG optimization component** — judge model selection and LLM-as-a-Judge evaluation are now automatically enabled during `run_rag_optimization()`
- **RAG optimization component** — artefact generation extracted into `_generate_output_artifacts()` for clearer separation of concerns
- **Dependencies** — refreshed `uv.lock` and sorted dependency declarations in `pyproject.toml`

## Migration notes

**Breaking changes for custom evaluator implementations:**

- `BaseEvaluator.evaluate_metrics()` now accepts `Sequence[RAGMetric]` instead of `list[str]` for the `metrics` parameter and must return an `EvaluationMetricsResult` TypedDict. Custom evaluator subclasses must update their signatures and return types accordingly.

**Breaking changes for custom event handlers:**

- `BaseEventHandler.on_pattern_creation()` parameter types are now `PatternPayload` and `list[EvaluationRecord]`. Both are TypedDicts, so dict-style access (`payload["name"]`, `record["metrics"]`) continues to work — but the per-question scores key changed from `"scores"` (flat dict) to `"metrics"` (list of `{"name", "evaluator", "score"}` dicts).

**Default optimization metric change:**

- The default optimization metric changed from `faithfulness` to `overall_score`. Pass `optimization_metric="faithfulness"` explicitly if you relied on the old default.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.10.0`
- [x] `docs/about/changelog.md` updated
- [x] All tests pass (`pytest`)
- [x] Docs build successfully
