### PR TITLE
feat(chunking): enable metadata inclusion for hybrid method

### DIFF
--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -397,6 +397,8 @@ class AI4RAGExperiment:
         start_time = time.time()
 
         chunking_params = get_chunking_params(rag_params)
+        chunking_params["include_metadata"] = chunking_params.get("method") == "hybrid"
+
         retrieval_params = get_retrieval_params(rag_params)
 
         foundation_model = rag_params.get(AI4RAGParamNames.FOUNDATION_MODEL)


### PR DESCRIPTION
## Description
Very simple change: when chunking method is set to hybrid and we include metadata in the chunk content, enrich the payload with `include_metadata: True`.
