### PR TITLE
Release 0.10.1

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/ai4rag/rag/chunking/chunk.py
+++ b/ai4rag/rag/chunking/chunk.py
@@ -23,6 +23,13 @@ class AI4RAGChunk:
         Chunk metadata. Expected keys include ``document_id`` and
         ``sequence_number``; additional keys (headings, provenance)
         are chunker-dependent.
+
+    Attributes
+    ----------
+    chunk_id : str
+        Deterministic SHA-256 hex digest derived from ``document_id``,
+        ``sequence_number``, and ``text``. Computed automatically on
+        construction; not passed as an ``__init__`` argument.
     """
 
     text: str

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.1](https://github.com/IBM/ai4rag/releases/tag/v0.10.1)
+
+### Added
+- **OGX client** — timeout fallback for embedding and chat requests: on `APITimeoutError`, retries once with a 20-minute timeout and disabled client-level retries to accommodate slow CPU-deployed models
+
+### Changed
+- **Chunking** — `AI4RAGChunk` now carries a deterministic `chunk_id` field (SHA-256 of document ID, sequence number, and text), replacing ad-hoc hash-based ID generation in vector stores
+- **Chunking** — hybrid chunking method now automatically includes document metadata during experiment execution
+- **Vector store** — `ChromaVectorStore` and `OGXVectorStore` deduplication and chunk identification now use the deterministic `AI4RAGChunk.chunk_id` instead of independent hash computations
+
+### Fixed
+- **Prompt templates** — partially reverted default RAG prompt templates for all model families (Granite, Llama, Mistral, OpenAI, default) to use model-native prompting patterns, removing shared instruction boilerplate
+- **Prompt filters** — decoupled `HPO_CITATION_FRAGMENTS` from internal `_RAG_CITATION_INSTRUCTION` constant, using inline string literals for portability
+
+---
+
 ## [0.10.0](https://github.com/IBM/ai4rag/releases/tag/v0.10.0)
 
 ### Added

--- a/docs/architecture/rag-components.md
+++ b/docs/architecture/rag-components.md
@@ -709,7 +709,7 @@ def add_documents(self, documents: list[AI4RAGChunk], batch_size: int = 2048):
         {
             "content": chunk.text,
             "chunk_metadata": chunk.metadata,
-            "chunk_id": chunk.metadata["document_id"],
+            "chunk_id": chunk.chunk_id,
             "embedding_model": self.embedding_model.model_id,
             "embedding_dimension": self.embedding_model.params.embedding_dimension,
             "embedding": embedding_vector,
@@ -770,10 +770,11 @@ Chunkers split `DoclingDocument` objects into `AI4RAGChunk` instances for embedd
 Framework-agnostic chunk representation used across the pipeline:
 
 ```python
-@dataclass(frozen=True)
+@dataclass
 class AI4RAGChunk:
     text: str                                  # Chunk content
     metadata: dict[str, Any] = field(default_factory=dict)  # document_id, sequence_number, etc.
+    chunk_id: str = field(init=False, repr=False)  # Deterministic SHA-256 (auto-computed)
 ```
 
 ### BaseChunker


### PR DESCRIPTION
# Release v0.10.1

## Summary

This patch release improves OGX client resilience with an automatic timeout fallback mechanism, centralizes chunk identification with deterministic SHA-256-based IDs, and reverts RAG prompt templates to model-native patterns for better answer quality across model families.

## Changes

### Added
- **OGX client** — timeout fallback for embedding and chat requests: on `APITimeoutError`, retries once with a 20-minute timeout and disabled client-level retries to accommodate slow CPU-deployed models

### Changed
- **Chunking** — `AI4RAGChunk` now carries a deterministic `chunk_id` field (SHA-256 of document ID, sequence number, and text), replacing ad-hoc hash-based ID generation in vector stores
- **Chunking** — hybrid chunking method now automatically includes document metadata during experiment execution
- **Vector store** — `ChromaVectorStore` and `OGXVectorStore` deduplication and chunk identification now use the deterministic `AI4RAGChunk.chunk_id` instead of independent hash computations

### Fixed
- **Prompt templates** — partially reverted default RAG prompt templates for all model families (Granite, Llama, Mistral, OpenAI, default) to use model-native prompting patterns, removing shared instruction boilerplate
- **Prompt filters** — decoupled `HPO_CITATION_FRAGMENTS` from internal `_RAG_CITATION_INSTRUCTION` constant, using inline string literals for portability

## Migration notes

- `AI4RAGChunk` is no longer a frozen dataclass — it is now mutable to support the auto-computed `chunk_id` field. Code that relied on `AI4RAGChunk` immutability (e.g. using chunks as dict keys or in sets) must be updated.
- Default RAG prompt templates have changed for all model families. If your optimization results depend on specific prompt wording, re-evaluate with the updated templates.
- The `chunk_id` values stored in vector stores will differ from those produced by prior versions. Re-indexing is recommended for consistency.

## Checklist

- [ ] `__version__` in `ai4rag/__init__.py` updated to `0.10.1`
- [ ] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
