### PR TITLE
Release 0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It accepts a variety of RAG Templates and a search space definition, then return
 
 ai4RAG can run experiments using an [OGX](https://github.com/ogx-ai/ogx) server for embeddings, vector storage, and text generation. Use the official client and API docs to connect and extend:
 
-- **Client:** [ogx-client](https://pypi.org/project/ogx-client/) >= 1.1.0 (Python package used by ai4RAG; installs with this project).
+- **Client:** [ogx-client](https://pypi.org/project/ogx-client/) >= 1.2.0 (Python package used by ai4RAG; installs with this project).
 - **Server:** [OGX](https://github.com/ogx-ai/ogx) >= 1.1.0.
 - **API reference:** [OGX API docs](https://ogx-ai.github.io/docs/) — HTTP API used by the client.
 

--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.2](https://github.com/IBM/ai4rag/releases/tag/v0.10.2)
+
+### Changed
+- **Dependencies** — updated `ogx-client` dependency from `~=1.1.0` to `~=1.2.0`
+- **Data component** — `ChunkingConstraints.METHODS` changed from mutable list to immutable tuple for correctness
+
+### Fixed
+- **Evaluator** — hardened LLM-as-a-Judge JSON response parsing with lightweight repair for common malformed outputs (single-quoted JSON, markdown-fenced blocks, JSON embedded in surrounding prose); added explicit output format instructions to the judge prompt; separated LLM call failures from JSON parse failures with distinct warning messages and raw response logging
+- **Evaluator** — `calculate_overall_score()` now propagates `None` directly for unevaluated metrics instead of converting to `float("nan")`
+- **Experiment** — streamed pattern now includes the `include_metadata` chunking field, ensuring metadata-aware chunking configurations are fully captured in pattern output
+
+### Removed
+- **Data component** — removed `index_documents()` function and `documents_indexing` module from `ai4rag.components.data`; the component was unused
+
+---
+
 ## [0.10.1](https://github.com/IBM/ai4rag/releases/tag/v0.10.1)
 
 ### Added

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -155,7 +155,7 @@ graph TB
 
 **Data Components** (`ai4rag/components/data/`)
 
-- Reusable functions for pipeline data stages: document discovery, text extraction, indexing, and test data loading
+- Reusable functions for pipeline data stages: document discovery, text extraction, and test data loading
 - Extracted from Kubeflow Pipeline components for standalone use
 - Provider-agnostic — accepts injected S3 clients and OGX clients
 

--- a/docs/user-guide/pipeline-components.md
+++ b/docs/user-guide/pipeline-components.md
@@ -73,25 +73,6 @@ result = extract_text(
 print(f"Processed {result.processed_count}/{result.total_documents}")
 ```
 
-### Document Indexing
-
-Chunk, embed, and index documents into a vector store:
-
-```python
-from ai4rag.components.data import index_documents
-from ai4rag.components import create_ogx_client
-
-client = create_ogx_client(base_url="http://localhost:8321", api_key="key")
-total_chunks = index_documents(
-    extracted_text_dir="/tmp/extracted",
-    embedding_model_id="ibm/slate-125m-english-rtrvr",
-    vector_io_provider_id="milvus",
-    ogx_client=client,
-    chunking_method="hybrid",
-    chunk_size=1024,
-)
-```
-
 ### Test Data Loading
 
 Load benchmark test data from S3:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "langchain_chroma~=1.1.0",
   "langchain-text-splitters~=1.1.0",
   "multiprocess>=0.70",
-  "ogx-client~=1.2.0",
+  "ogx-client>=1.1.0,<=1.1.3",
   "pandas==2.2.*",
   "pydantic==2.11.*",
   "pygam~=0.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,46 +5,41 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ai4rag"
 description = "Automatic and optimized RAG Pattern generator"
-authors = [{ name = "IBM"}]
+authors = [{ name = "IBM" }]
 maintainers = [
-    { name = "Jakub Walaszczyk", email = "jwalaszc@redhat.com" },
-    { name = "Lukasz Cmielowski", email = "lcmielow@redhat.com" },
-    { name = "Michal Steczko", email = "msteczko@redhat.com" },
-    { name = "Filip Komarzyniec", email = "fkomarzy@redhat.com"}
+  { name = "Jakub Walaszczyk", email = "jwalaszc@redhat.com" },
+  { name = "Lukasz Cmielowski", email = "lcmielow@redhat.com" },
+  { name = "Michal Steczko", email = "msteczko@redhat.com" },
+  { name = "Filip Komarzyniec", email = "fkomarzy@redhat.com" },
 ]
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.12,<3.14"
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: Apache Software License",
-    "Natural Language :: English",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: POSIX :: Linux",
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: Apache Software License",
+  "Natural Language :: English",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: POSIX :: Linux",
 ]
-keywords = [
-    "AI",
-    "RAG",
-    "LLM",
-    "GenAI"
-]
+keywords = ["AI", "RAG", "LLM", "GenAI"]
 dynamic = ["version"]
 
 dependencies = [
-    "boto3>=1.28",
-    "docling~=2.107.0",
-    "docling-core[chunking]~=2.84.0",
-    "langchain_chroma~=1.1.0",
-    "langchain-text-splitters~=1.1.0",
-    "multiprocess>=0.70",
-    "ogx-client~=1.1.0",
-    "pandas==2.2.*",
-    "pydantic==2.11.*",
-    "pygam~=0.12.0",
-    "scikit-learn==1.8.*",
-    "unitxt~=1.26.1",
+  "boto3>=1.28",
+  "docling~=2.107.0",
+  "docling-core[chunking]~=2.84.0",
+  "langchain_chroma~=1.1.0",
+  "langchain-text-splitters~=1.1.0",
+  "multiprocess>=0.70",
+  "ogx-client~=1.2.0",
+  "pandas==2.2.*",
+  "pydantic==2.11.*",
+  "pygam~=0.12.0",
+  "scikit-learn==1.8.*",
+  "unitxt~=1.26.1",
 ]
 
 
@@ -57,13 +52,13 @@ Documentation = "https://ibm.github.io/ai4rag/"
 
 [project.optional-dependencies]
 dev = [
-    "ai4rag[test]",
-    "ai4rag[code_check]",
-    "ai4rag[docs]",
-    "ai4rag[llm-judge]",
-    "beautifulsoup4",      # reading data from html
-    "dotenv",
-    "ipykernel",
+  "ai4rag[test]",
+  "ai4rag[code_check]",
+  "ai4rag[docs]",
+  "ai4rag[llm-judge]",
+  "beautifulsoup4",     # reading data from html
+  "dotenv",
+  "ipykernel",
 ]
 
 test = ["pytest", "pytest-cov", "pytest-mock", "psutil", "nbformat"]
@@ -71,20 +66,18 @@ test = ["pytest", "pytest-cov", "pytest-mock", "psutil", "nbformat"]
 code_check = ["pylint", "black", "isort"]
 
 docs = [
-    "mkdocs~=1.6.0",
-    "mkdocs-material~=9.5",
-    "mkdocstrings[python]>=0.25.0",
-    "mkdocs-git-revision-date-localized-plugin>=1.2.0",
-    "mkdocs-minify-plugin>=0.8.0",
+  "mkdocs~=1.6.0",
+  "mkdocs-material~=9.5",
+  "mkdocstrings[python]>=0.25.0",
+  "mkdocs-git-revision-date-localized-plugin>=1.2.0",
+  "mkdocs-minify-plugin>=0.8.0",
 ]
 
 [tool.setuptools.dynamic]
 version = { attr = "ai4rag.__version__" }
 
 [tool.setuptools.package-data]
-"ai4rag.components.assets_generator" = [
-    "notebook_templates/*.ipynb",
-]
+"ai4rag.components.assets_generator" = ["notebook_templates/*.ipynb"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests*", "dev_utils*"]
@@ -99,9 +92,9 @@ log_level = "INFO"
 [tool.coverage.run]
 # Skipping orchestration modules that require integration tests (S3, multiprocessing, full experiment runs)
 omit = [
-    "ai4rag/core/experiment/experiment.py",
-    "ai4rag/components/data/text_extraction.py",
-    "ai4rag/components/optimization/rag_templates_optimization.py",
+  "ai4rag/core/experiment/experiment.py",
+  "ai4rag/components/data/text_extraction.py",
+  "ai4rag/components/optimization/rag_templates_optimization.py",
 ]
 
 [tool.black]
@@ -115,7 +108,13 @@ skip = ["scripts/"]
 
 
 [tool.pylint]
-disable = ["missing-module-docstring", "too-few-public-methods", "arguments-differ", "import-outside-toplevel", "broad-exception-caught"]
+disable = [
+  "missing-module-docstring",
+  "too-few-public-methods",
+  "arguments-differ",
+  "import-outside-toplevel",
+  "broad-exception-caught",
+]
 max-line-length = 120
 max-args = 8
 max-positional-arguments = 8

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },
     { name = "multiprocess", specifier = ">=0.70" },
     { name = "nbformat", marker = "extra == 'test'" },
-    { name = "ogx-client", specifier = "~=1.1.0" },
+    { name = "ogx-client", specifier = "~=1.2.0" },
     { name = "pandas", specifier = "==2.2.*" },
     { name = "psutil", marker = "extra == 'test'" },
     { name = "pydantic", specifier = "==2.11.*" },
@@ -2375,28 +2375,19 @@ wheels = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.3"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "distro" },
     { name = "fire" },
     { name = "httpx" },
-    { name = "pandas" },
-    { name = "prompt-toolkit" },
-    { name = "pyaml" },
     { name = "pydantic" },
+    { name = "python-dateutil" },
     { name = "requests" },
-    { name = "rich" },
-    { name = "sniffio" },
-    { name = "termcolor" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ac/2fd77ab57ef26b8689d29d3f0a2e9020966282797b715ecf537806ca3486/ogx_client-1.1.3.tar.gz", hash = "sha256:d61a6f4cd996a5ce5cd6eb1389215f520cc1ca49d485b454d00faa021d4f4f0a", size = 440850, upload-time = "2026-06-24T15:07:27.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/6b/5a22ea5b1193219cc6760acdd4085676c251096780dacbfbe3bd7d3381e1/ogx_client-1.2.1.tar.gz", hash = "sha256:1e22c29fff211c8f135da8f594407f01350ec00e9d0491d917b2fdd117d8b8c1", size = 588070, upload-time = "2026-07-14T19:20:43.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/f0/be21078666dc51b30a92dcd83e7711f923230b2cdd4a274994c36059233d/ogx_client-1.1.3-py3-none-any.whl", hash = "sha256:56390f857807f99c1927ab2de46d3427d63970d55533945c92e575fbe51d2252", size = 314011, upload-time = "2026-06-24T15:07:25.85Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1b/d912fcec167ec4d0b03b39579e2c0e4f8d712025f5bcb1e837b83a4e0ccc/ogx_client-1.2.1-py3-none-any.whl", hash = "sha256:b23c94e2ec5be59b359280ff58574d426662c22e0a6cbd51fc6357deb045e3ca", size = 1544659, upload-time = "2026-07-14T19:20:42.053Z" },
 ]
 
 [[package]]
@@ -2875,18 +2866,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
-]
-
-[[package]]
-name = "pyaml"
-version = "26.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/6a/acfdf17de0d6947b419da8696e02b781b18de2cf49e0472298b50e1f0711/pyaml-26.7.0.tar.gz", hash = "sha256:11cda3a796efc6dbce0d56836be56cfd26289dad07bcd78e9904086729929c93", size = 30669, upload-time = "2026-07-04T00:34:38.532Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/26/3f05f9e3692853dff663913d5d62fb8df3f5640c8d70b06588c0b51ed953/pyaml-26.7.0-py3-none-any.whl", hash = "sha256:cfa382780c43ae660669b87d394d550a41856ef175f5749f51f753e12d7077ac", size = 27226, upload-time = "2026-07-04T00:34:37.198Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25.0" },
     { name = "multiprocess", specifier = ">=0.70" },
     { name = "nbformat", marker = "extra == 'test'" },
-    { name = "ogx-client", specifier = "~=1.2.0" },
+    { name = "ogx-client", specifier = ">=1.1.0,<=1.1.3" },
     { name = "pandas", specifier = "==2.2.*" },
     { name = "psutil", marker = "extra == 'test'" },
     { name = "pydantic", specifier = "==2.11.*" },
@@ -2375,19 +2375,28 @@ wheels = [
 
 [[package]]
 name = "ogx-client"
-version = "1.2.1"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "distro" },
     { name = "fire" },
     { name = "httpx" },
+    { name = "pandas" },
+    { name = "prompt-toolkit" },
+    { name = "pyaml" },
     { name = "pydantic" },
-    { name = "python-dateutil" },
     { name = "requests" },
+    { name = "rich" },
+    { name = "sniffio" },
+    { name = "termcolor" },
+    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/6b/5a22ea5b1193219cc6760acdd4085676c251096780dacbfbe3bd7d3381e1/ogx_client-1.2.1.tar.gz", hash = "sha256:1e22c29fff211c8f135da8f594407f01350ec00e9d0491d917b2fdd117d8b8c1", size = 588070, upload-time = "2026-07-14T19:20:43.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ac/2fd77ab57ef26b8689d29d3f0a2e9020966282797b715ecf537806ca3486/ogx_client-1.1.3.tar.gz", hash = "sha256:d61a6f4cd996a5ce5cd6eb1389215f520cc1ca49d485b454d00faa021d4f4f0a", size = 440850, upload-time = "2026-06-24T15:07:27.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/1b/d912fcec167ec4d0b03b39579e2c0e4f8d712025f5bcb1e837b83a4e0ccc/ogx_client-1.2.1-py3-none-any.whl", hash = "sha256:b23c94e2ec5be59b359280ff58574d426662c22e0a6cbd51fc6357deb045e3ca", size = 1544659, upload-time = "2026-07-14T19:20:42.053Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f0/be21078666dc51b30a92dcd83e7711f923230b2cdd4a274994c36059233d/ogx_client-1.1.3-py3-none-any.whl", hash = "sha256:56390f857807f99c1927ab2de46d3427d63970d55533945c92e575fbe51d2252", size = 314011, upload-time = "2026-06-24T15:07:25.85Z" },
 ]
 
 [[package]]
@@ -2866,6 +2875,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyaml"
+version = "26.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/6a/acfdf17de0d6947b419da8696e02b781b18de2cf49e0472298b50e1f0711/pyaml-26.7.0.tar.gz", hash = "sha256:11cda3a796efc6dbce0d56836be56cfd26289dad07bcd78e9904086729929c93", size = 30669, upload-time = "2026-07-04T00:34:38.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/26/3f05f9e3692853dff663913d5d62fb8df3f5640c8d70b06588c0b51ed953/pyaml-26.7.0-py3-none-any.whl", hash = "sha256:cfa382780c43ae660669b87d394d550a41856ef175f5749f51f753e12d7077ac", size = 27226, upload-time = "2026-07-04T00:34:37.198Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Release v0.10.2

## Summary

This patch release hardens the LLM-as-a-Judge evaluation pipeline with robust JSON response parsing that recovers from common model output malformations, fixes a missing field in streamed pattern output, removes the unused `documents_indexing` component, and bumps `ogx-client` to `~=1.2.0`.

## Changes

### Changed
- **Dependencies** — updated `ogx-client` dependency from `~=1.1.0` to `~=1.2.0`
- **Data component** — `ChunkingConstraints.METHODS` changed from mutable list to immutable tuple for correctness

### Fixed
- **Evaluator** — hardened LLM-as-a-Judge JSON response parsing with lightweight repair for common malformed outputs (single-quoted JSON, markdown-fenced blocks, JSON embedded in surrounding prose); added explicit output format instructions to the judge prompt; separated LLM call failures from JSON parse failures with distinct warning messages and raw response logging
- **Evaluator** — `calculate_overall_score()` now propagates `None` directly for unevaluated metrics instead of converting to `float("nan")`
- **Experiment** — streamed pattern now includes the `include_metadata` chunking field, ensuring metadata-aware chunking configurations are fully captured in pattern output

### Removed
- **Data component** — removed `index_documents()` function and `documents_indexing` module from `ai4rag.components.data`; the component was unused

## Migration notes

The `index_documents()` function has been removed from `ai4rag.components.data`. If you were importing it, remove the import — the function was unused and had no supported downstream consumers. No other breaking changes.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.10.2`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
