### PR TITLE
Release 0.10.4

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.4](https://github.com/IBM/ai4rag/releases/tag/v0.10.4)
+
+### Fixed
+- **Experiment** — fixed incorrect dictionary key `"method"` used to check the chunking method when determining whether to include metadata; now uses the canonical `AI4RAGParamNames.CHUNKING_METHOD` constant, ensuring `include_metadata` is correctly set for hybrid chunking during experiment execution
+
+---
+
 ## [0.10.3](https://github.com/IBM/ai4rag/releases/tag/v0.10.3)
 
 ### Fixed


### PR DESCRIPTION
# Release v0.10.4

## Summary

Patch release fixing a bug where the chunking method check during experiment execution used a raw string key instead of the canonical `AI4RAGParamNames.CHUNKING_METHOD` constant. This caused `include_metadata` to never be set to `True` for hybrid chunking, preventing metadata-aware chunking configurations from working correctly.

## Changes

### Fixed
- **Experiment** — fixed incorrect dictionary key `"method"` used to check the chunking method when determining whether to include metadata; now uses the canonical `AI4RAGParamNames.CHUNKING_METHOD` constant, ensuring `include_metadata` is correctly set for hybrid chunking during experiment execution

## Migration notes

No breaking changes.

## Checklist

- [ ] `__version__` in `ai4rag/__init__.py` updated to `0.10.4`
- [ ] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
