### PR TITLE
Release 0.11.0

### DIFF
--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.10.4"
+__version__ = "0.11.0"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.0](https://github.com/IBM/ai4rag/releases/tag/v0.11.0)
+
+### Added
+- **Text extraction** — added support for 9 additional document formats (`.odt`, `.odp`, `.adoc`, `.tex`, `.epub`, `.eml`, `.qmd`, `.rmd`, `.xhtml`) in document discovery and text extraction, alongside existing PDF, DOCX, PPTX, Markdown, HTML, and plain-text support
+
+### Changed
+- **Data component** — `SUPPORTED_EXTENSIONS` extracted into a shared `ai4rag.components.data.constants` module, removing duplication between document discovery and text extraction
+- **Dependencies** — replaced the `docling` meta-package with `docling-slim[standard,feat-chunking,format-opendocument]`, and dropped the standalone `docling-core` dependency, now pulled in transitively via the `feat-chunking` extra
+
+### Fixed
+- **Notebooks** — updated the `ogx_inference_template.ipynb` test-data-loading example to call `ai4rag.components.data.test_data_loader.load_test_data()`, replacing a stale reference to the removed `kfp_components` pipeline API
+
+---
+
 ## [0.10.4](https://github.com/IBM/ai4rag/releases/tag/v0.10.4)
 
 ### Fixed


### PR DESCRIPTION
# Release v0.11.0

## Summary

Minor release that broadens the range of document formats ai4rag can ingest for text extraction, adding support for OpenDocument, AsciiDoc, LaTeX, EPUB, email, and markdown-variant files. This is enabled by a simplified `docling` dependency footprint (moving to `docling-slim` with explicit extras) and comes alongside a notebook fix to keep the OGX inference example aligned with the current test-data-loading API.

## Changes

### Added
- **Text extraction** — added support for 9 additional document formats (`.odt`, `.odp`, `.adoc`, `.tex`, `.epub`, `.eml`, `.qmd`, `.rmd`, `.xhtml`) in document discovery and text extraction, alongside existing PDF, DOCX, PPTX, Markdown, HTML, and plain-text support

### Changed
- **Data component** — `SUPPORTED_EXTENSIONS` extracted into a shared `ai4rag.components.data.constants` module, removing duplication between document discovery and text extraction
- **Dependencies** — replaced the `docling` meta-package with `docling-slim[standard,feat-chunking,format-opendocument]`, and dropped the standalone `docling-core` dependency, now pulled in transitively via the `feat-chunking` extra

### Fixed
- **Notebooks** — updated the `ogx_inference_template.ipynb` test-data-loading example to call `ai4rag.components.data.test_data_loader.load_test_data()`, replacing a stale reference to the removed `kfp_components` pipeline API

## Migration notes

No breaking changes. Environments that pin `docling` or `docling-core` directly (outside of `ai4rag`'s own dependency resolution) should note that ai4rag now depends on `docling-slim` with the `standard`, `feat-chunking`, and `format-opendocument` extras instead; `docling-core` is pulled in transitively rather than as a direct dependency.

## Checklist

- [ ] `__version__` in `ai4rag/__init__.py` updated to `0.11.0`
- [ ] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
