### PR TITLE
fix: Non-ascii characters rendered as Unicode escapes in experiment output

### DIFF
--- a/ai4rag/components/assets_generator/leaderboard.py
+++ b/ai4rag/components/assets_generator/leaderboard.py
@@ -447,7 +447,7 @@ def build_leaderboard_html(  # pylint: disable=too-many-locals,too-many-branches
             val = _get_config_value(merged, col) if merged else None
             if val is not None and (val != "" or col != "retrieval.ranker_strategy"):
                 if isinstance(val, dict):
-                    cells.append(json.dumps(val, sort_keys=True))
+                    cells.append(json.dumps(val, sort_keys=True, ensure_ascii=False))
                 else:
                     cells.append(str(val))
             elif col == "retrieval.ranker_strategy":

--- a/ai4rag/components/assets_generator/notebook.py
+++ b/ai4rag/components/assets_generator/notebook.py
@@ -184,7 +184,7 @@ class Notebook:
         path.parent.mkdir(parents=True, exist_ok=True)
 
         with path.open("w+", encoding="utf-8") as f:
-            json_dump(self.to_dict(), f, indent=indent)
+            json_dump(self.to_dict(), f, indent=indent, ensure_ascii=False)
 
         return self
 

--- a/ai4rag/components/data/documents_discovery.py
+++ b/ai4rag/components/data/documents_discovery.py
@@ -86,7 +86,7 @@ class DiscoveryResult:
         out_dir.mkdir(parents=True, exist_ok=True)
         descriptor_path = out_dir / filename
         with open(descriptor_path, "w", encoding="utf-8") as fh:
-            json.dump(self.to_dict(), fh, indent=2)
+            json.dump(self.to_dict(), fh, indent=2, ensure_ascii=False)
         _logger.info("Documents descriptor written to %s", descriptor_path)
 
 

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -287,10 +287,10 @@ def _generate_output_artifacts(
         )
 
         with (patt_dir / "pattern.json").open("w", encoding="utf-8") as f:
-            json_dump(pattern_data, f, indent=2)
+            json_dump(pattern_data, f, indent=2, ensure_ascii=False)
 
         with (patt_dir / "evaluation_results.json").open("w", encoding="utf-8") as f:
-            json_dump(pattern.get("evaluation_results", []), f, indent=2)
+            json_dump(pattern.get("evaluation_results", []), f, indent=2, ensure_ascii=False)
 
         patterns.append(pattern_data)
 

--- a/ai4rag/components/optimization/search_space_preparation.py
+++ b/ai4rag/components/optimization/search_space_preparation.py
@@ -96,7 +96,7 @@ class SearchSpaceReport:
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.search_space, f, indent=2)
+            json.dump(self.search_space, f, indent=2, ensure_ascii=False)
 
 
 def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments

--- a/ai4rag/utils/event_handler/event_handler.py
+++ b/ai4rag/utils/event_handler/event_handler.py
@@ -38,10 +38,10 @@ class LocalEventHandler(BaseEventHandler):
 
             evaluation_results_path = dir_path / "evaluation_results.json"
             with open(evaluation_results_path, encoding="utf-8", mode="w") as file:
-                json.dump(evaluation_results, file)
+                json.dump(evaluation_results, file, ensure_ascii=False)
 
             with open(dir_path / "pattern.json", encoding="utf-8", mode="w") as file2:
-                json.dump(payload, file2)
+                json.dump(payload, file2, ensure_ascii=False)
 
 
 class KFPEventHandler(BaseEventHandler):


### PR DESCRIPTION

fixes: https://redhat.atlassian.net/browse/RHOAIENG-78562

## Description
All json files generated throughout the experiment that might face the end user should be dumped as-is, i.e. any non-ASCII characters should not be escaped. 

## Motivation
Readability of experiment's artifacts. 

## Changes
- added `ensure_ascii=False` keywords argument to the `json.dump[s]?` invocations


## Additional information
Please note that:
    - json artifacts from text_extraction component (serialised `docling.Document` objects) will still escape any non-ASCII characters due to: https://github.com/docling-project/docling/issues/3939. 
        I believe this is acceptable as the serialised docling documents are an intermediary form of storing data and are not of much interest to the end users. The existing workaround (described in the linked issue) brings too much overhead to be accepted. 

## Testing
How did you test this?

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [x] All checks passing
