### PR TITLE
feat: add preparation space check step to fail fast

### DIFF
--- a/ai4rag/components/assets_generator/notebook_templates/ogx_inference_template.ipynb
+++ b/ai4rag/components/assets_generator/notebook_templates/ogx_inference_template.ipynb
@@ -160,7 +160,29 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "from ai4rag.rag.retrieval.retriever import Retriever\n\nmethod = \"{RETRIEVAL_METHOD}\"\nnumber_of_chunks = {NUMBER_OF_CHUNKS}\nsearch_mode = \"{SEARCH_MODE}\"\nranker_strategy = \"{RANKER_STRATEGY}\"\nranker_k = {RANKER_K}\nranker_alpha = {RANKER_ALPHA}\n\n# Build retriever kwargs, only including non-None hybrid search parameters\nretriever_kwargs = dict(\n    ((\"vector_store\", vector_store),\n    (\"method\", method),\n    (\"number_of_chunks\", number_of_chunks))\n)\nif search_mode is not None:\n    retriever_kwargs[\"search_mode\"] = search_mode\nif ranker_strategy != \"None\":\n    retriever_kwargs[\"ranker_strategy\"] = ranker_strategy\nif ranker_k is not None:\n    retriever_kwargs[\"ranker_k\"] = ranker_k\nif ranker_alpha is not None:\n    retriever_kwargs[\"ranker_alpha\"] = ranker_alpha\n\nretriever = Retriever(**retriever_kwargs)"
+   "source": [
+    "from ai4rag.rag.retrieval.retriever import Retriever\n",
+    "\n",
+    "method = \"{RETRIEVAL_METHOD}\"\n",
+    "number_of_chunks = {NUMBER_OF_CHUNKS}\n",
+    "search_mode = \"{SEARCH_MODE}\"\n",
+    "ranker_strategy = \"{RANKER_STRATEGY}\"\n",
+    "ranker_k = {RANKER_K}\n",
+    "ranker_alpha = {RANKER_ALPHA}\n",
+    "\n",
+    "# Build retriever kwargs, only including non-None hybrid search parameters\n",
+    "retriever_kwargs = dict(((\"vector_store\", vector_store), (\"method\", method), (\"number_of_chunks\", number_of_chunks)))\n",
+    "if search_mode is not None:\n",
+    "    retriever_kwargs[\"search_mode\"] = search_mode\n",
+    "if ranker_strategy != \"None\":\n",
+    "    retriever_kwargs[\"ranker_strategy\"] = ranker_strategy\n",
+    "if ranker_k is not None:\n",
+    "    retriever_kwargs[\"ranker_k\"] = ranker_k\n",
+    "if ranker_alpha is not None:\n",
+    "    retriever_kwargs[\"ranker_alpha\"] = ranker_alpha\n",
+    "\n",
+    "retriever = Retriever(**retriever_kwargs)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/ai4rag/components/optimization/search_space_preparation.py
+++ b/ai4rag/components/optimization/search_space_preparation.py
@@ -275,5 +275,3 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
         search_space=verbose_repr,
         selected_models=selected_models,
     )
-
-

--- a/ai4rag/components/optimization/search_space_preparation.py
+++ b/ai4rag/components/optimization/search_space_preparation.py
@@ -18,9 +18,13 @@ from ai4rag.core.experiment.mps import ModelsPreSelector
 from ai4rag.rag.embedding.base_model import BaseEmbeddingModel
 from ai4rag.rag.foundation_models.base_model import BaseFoundationModel
 from ai4rag.search_space.prepare.prepare_search_space import prepare_search_space_with_ogx
+from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
+from ai4rag.utils.validators import validate_model_list
 
 _logger = logging.getLogger("search-space-preparation")
 _logger.addHandler(handler)
+
+_validate_model_list = validate_model_list
 
 _DEFAULT_METRIC = "faithfulness"
 _DEFAULT_TOP_N_GENERATION = 3
@@ -113,6 +117,7 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
     chunk_sizes: list[int] | None = None,
     chunk_overlaps: list[int] | None = None,
     inference_max_threads: int = 10,
+    pre_validated_search_space: AI4RAGSearchSpace | None = None,
 ) -> SearchSpaceReport:
     """Run model pre-selection and prepare a search-space report.
 
@@ -161,6 +166,13 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
         RAG service during benchmark evaluation.  Lower values reduce
         per-request concurrency (useful when each request carries more
         retrieved context).  Defaults to ``10``.
+    pre_validated_search_space
+        When provided, the function skips model-list validation,
+        payload construction, and the
+        :func:`prepare_search_space_with_ogx` call and uses this
+        search space directly.  Pass the result of an earlier
+        validation step to avoid redundant OGX API calls.
+        ``None`` (default) preserves the original behaviour.
 
     Returns
     -------
@@ -185,32 +197,35 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
         or *chunk_overlaps* contains values outside
         ``[ChunkingConstraints.MIN_CHUNK_OVERLAP, ChunkingConstraints.MAX_CHUNK_OVERLAP]``.
     """
-    _validate_model_list(embedding_models, "embedding_models")
-    _validate_model_list(generation_models, "generation_models")
+    if pre_validated_search_space is not None:
+        search_space = pre_validated_search_space
+    else:
+        _validate_model_list(embedding_models, "embedding_models")
+        _validate_model_list(generation_models, "generation_models")
 
-    # Build payload and create search space via OGX
-    payload: dict[str, Any] = {}
-    if generation_models:
-        payload["foundation_models"] = [{"model_id": gm} for gm in generation_models]
-    if embedding_models:
-        payload["embedding_models"] = [{"model_id": em} for em in embedding_models]
-    if chunking_methods is not None:
-        payload["chunking_methods"] = chunking_methods
-    if chunk_sizes is not None:
-        payload["chunk_sizes"] = chunk_sizes
-    if chunk_overlaps is not None:
-        payload["chunk_overlaps"] = chunk_overlaps
+        payload: dict[str, Any] = {}
+        if generation_models:
+            payload["foundation_models"] = [{"model_id": gm} for gm in generation_models]
+        if embedding_models:
+            payload["embedding_models"] = [{"model_id": em} for em in embedding_models]
+        if chunking_methods is not None:
+            payload["chunking_methods"] = chunking_methods
+        if chunk_sizes is not None:
+            payload["chunk_sizes"] = chunk_sizes
+        if chunk_overlaps is not None:
+            payload["chunk_overlaps"] = chunk_overlaps
 
-    # Load benchmark data and documents
+        benchmark_df = pd.read_json(Path(test_data_path))
+        search_space = prepare_search_space_with_ogx(
+            payload,
+            client=ogx_client,
+            benchmark_data=benchmark_df,
+        )
+
     benchmark_df = pd.read_json(Path(test_data_path))
     benchmark_data = BenchmarkData(benchmark_df)
     documents = load_docling_documents(extracted_text_path)
 
-    search_space = prepare_search_space_with_ogx(
-        payload,
-        client=ogx_client,
-        benchmark_data=benchmark_df,
-    )
     _logger.info(
         "Search space chunking_method=%s chunk_size=%s chunk_overlap=%s",
         list(search_space["chunking_method"].values),
@@ -262,12 +277,3 @@ def prepare_search_space_report(  # pylint: disable=too-many-locals,too-many-arg
     )
 
 
-def _validate_model_list(models: list[str] | None, name: str) -> None:
-    """Validate that a model list, if provided, contains only non-empty strings."""
-    if models is None:
-        return
-    if not isinstance(models, list):
-        raise TypeError(f"{name} must be a list.")
-    for i, m in enumerate(models):
-        if not m:
-            raise TypeError(f"{name}[{i}] must be a non-empty string.")

--- a/ai4rag/utils/validators.py
+++ b/ai4rag/utils/validators.py
@@ -66,3 +66,14 @@ class OneOf(Validator[T]):
                 f"on attribute {self.private_name[1:]}."
             )
         return value
+
+
+def validate_model_list(models: list[str] | None, name: str) -> None:
+    """Validate that a model list, if provided, contains only non-empty strings."""
+    if models is None:
+        return
+    if not isinstance(models, list):
+        raise TypeError(f"{name} must be a list.")
+    for i, m in enumerate(models):
+        if not m:
+            raise TypeError(f"{name}[{i}] must be a non-empty string.")

--- a/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
+++ b/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
@@ -12,10 +12,10 @@ from ai4rag.components.optimization.search_space_preparation import (
     _validate_model_list,
     prepare_search_space_report,
 )
-from ai4rag.utils.validators import validate_model_list
 from ai4rag.search_space.src.parameter import Parameter
 from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
 from ai4rag.utils.constants import AI4RAGParamNames
+from ai4rag.utils.validators import validate_model_list
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
+++ b/tests/unit/ai4rag/components/optimization/test_search_space_prep.py
@@ -12,6 +12,7 @@ from ai4rag.components.optimization.search_space_preparation import (
     _validate_model_list,
     prepare_search_space_report,
 )
+from ai4rag.utils.validators import validate_model_list
 from ai4rag.search_space.src.parameter import Parameter
 from ai4rag.search_space.src.search_space import AI4RAGSearchSpace
 from ai4rag.utils.constants import AI4RAGParamNames
@@ -214,3 +215,121 @@ class TestPrepareSearchSpaceReportFiltering:
         assert result.search_space["chunk_size"] == []
         assert result.search_space["chunk_overlap"] == []
         assert result.search_space["chunking_method"] == []
+
+
+# ---------------------------------------------------------------------------
+# validate_model_list shared location
+# ---------------------------------------------------------------------------
+
+
+class TestValidateModelListShared:
+    """Verify that the shared validator is accessible from both locations."""
+
+    def test_shared_validator_is_same_function(self):
+        """The alias in search_space_preparation must point to the shared function."""
+        assert _validate_model_list is validate_model_list
+
+
+# ---------------------------------------------------------------------------
+# pre_validated_search_space parameter
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareSearchSpaceReportPreValidated:
+    """Test the pre_validated_search_space bypass path."""
+
+    def _make_search_space(self) -> AI4RAGSearchSpace:
+        mock_em = MagicMock()
+        mock_em.params.context_length = None
+        return AI4RAGSearchSpace(
+            params=[
+                Parameter(name=AI4RAGParamNames.FOUNDATION_MODEL, values=(MagicMock(),)),
+                Parameter(name=AI4RAGParamNames.EMBEDDING_MODEL, values=(mock_em,)),
+                Parameter(name=AI4RAGParamNames.CHUNKING_METHOD, values=("recursive",)),
+                Parameter(name=AI4RAGParamNames.CHUNK_SIZE, values=(512,)),
+                Parameter(name=AI4RAGParamNames.CHUNK_OVERLAP, values=(128,)),
+            ]
+        )
+
+    def test_skips_ogx_call_when_pre_validated(self, mocker):
+        """prepare_search_space_with_ogx must not be called when pre_validated_search_space is given."""
+        search_space = self._make_search_space()
+        mock_prepare = mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.prepare_search_space_with_ogx",
+        )
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.pd.read_json",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.load_docling_documents",
+            return_value=[],
+        )
+        mocker.patch("ai4rag.components.optimization.search_space_preparation.BenchmarkData")
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation._serialize_model",
+            return_value={"model_id": "mock"},
+        )
+
+        prepare_search_space_report(
+            test_data_path="dummy.json",
+            extracted_text_path="dummy_dir",
+            ogx_client=MagicMock(),
+            pre_validated_search_space=search_space,
+        )
+
+        mock_prepare.assert_not_called()
+
+    def test_uses_provided_search_space(self, mocker):
+        """The report must reflect parameters from the pre-validated search space."""
+        search_space = self._make_search_space()
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.pd.read_json",
+            return_value=MagicMock(),
+        )
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.load_docling_documents",
+            return_value=[],
+        )
+        mocker.patch("ai4rag.components.optimization.search_space_preparation.BenchmarkData")
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation._serialize_model",
+            return_value={"model_id": "mock"},
+        )
+
+        result = prepare_search_space_report(
+            test_data_path="dummy.json",
+            extracted_text_path="dummy_dir",
+            ogx_client=MagicMock(),
+            pre_validated_search_space=search_space,
+        )
+
+        assert result.search_space["chunk_size"] == [512]
+        assert result.search_space["chunk_overlap"] == [128]
+        assert result.search_space["chunking_method"] == ["recursive"]
+
+    def test_still_loads_documents(self, mocker):
+        """Documents must still be loaded even when pre_validated_search_space is given (needed for MPS)."""
+        search_space = self._make_search_space()
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.pd.read_json",
+            return_value=MagicMock(),
+        )
+        mock_load_docs = mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation.load_docling_documents",
+            return_value=[],
+        )
+        mocker.patch("ai4rag.components.optimization.search_space_preparation.BenchmarkData")
+        mocker.patch(
+            "ai4rag.components.optimization.search_space_preparation._serialize_model",
+            return_value={"model_id": "mock"},
+        )
+
+        prepare_search_space_report(
+            test_data_path="dummy.json",
+            extracted_text_path="dummy_dir",
+            ogx_client=MagicMock(),
+            pre_validated_search_space=search_space,
+        )
+
+        mock_load_docs.assert_called_once_with("dummy_dir")


### PR DESCRIPTION
## Description
We should fail fast when it come to the checking of space_preparation step, right now user can launch experiment that will take hours, and after that we will show him info "yo, your model is wrong" he cannot re-trigger it with a changed config, he cannot do anything to save hours of computing. So we need to fail fast to give him info that his provided input is "ok" or "nook"
## Motivation
https://redhat.atlassian.net/browse/RHOAIENG-57709

## Changes
1. ai4rag/utils/validators.py — added validate_model_list() function (moved from search_space_preparation.py)
  2. ai4rag/components/optimization/search_space_preparation.py —
    - Imports validate_model_list from shared location + AI4RAGSearchSpace
    - Adds _validate_model_list = validate_model_list alias for backward compat
    - Adds pre_validated_search_space: AI4RAGSearchSpace | None = None parameter to prepare_search_space_report()
    - When provided: skips model validation, payload construction, and prepare_search_space_with_ogx() call
    - When None: existing behavior unchanged
  3. tests/unit/ai4rag/components/optimization/test_search_space_prep.py —
    - Added TestValidateModelListShared (verifies alias identity)
    - Added TestPrepareSearchSpaceReportPreValidated with 3 tests: skips OGX call, uses provided search space, still loads documents
    

## Testing
- created dev image
- pushed it to quay
- use url in pipeline.yaml
- run a test with changed image
- Step passed - failed it is that there is ai4rag 0.11 and PLC do not have that image yet so it failed last step
<img width="1173" height="580" alt="image" src="https://github.com/user-attachments/assets/8a82f78f-f4bf-468a-8437-c0951cefdb33" />


## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
