### PR TITLE
Release 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ search_space = AI4RAGSearchSpace(
 > When omitted, both methods are included by default.
 
 > [!tip]
-> To validate model IDs and build a search space from a MaaS deployment in one call, use `prepare_search_space_with_maas()` from `ai4rag.search_space.prepare_search_space`, passing the MaaS client and the foundation/embedding model IDs per type.
+> To validate model IDs and build a search space from a MaaS deployment in one call, use `prepare_search_space_with_maas()` from `ai4rag.search_space.prepare`, passing the MaaS client and the foundation/embedding model IDs per type.
 
 
 ### Configure optimizer
@@ -239,8 +239,11 @@ experiment.search()
 best_eval = experiment.results.get_best_evaluations(k=1)[0]
 print(best_eval)
 
-print(best_eval.rag_pattern.generate("What ai4rag can be used for?"))
+print(f"Best pattern: {best_eval.pattern_name} (score: {best_eval.final_score})")
 ```
+
+> [!note]
+> Each trial closes its vector store once it finishes, so `EvaluationResult` no longer exposes a reusable `rag_pattern`. Read the outcome from its fields (`pattern_name`, `final_score`, `scores`, `rag_params`); rebuild the pattern from those settings if you want to run inference.
 
 > [!tip]
 > For production use, implement your own custom `EventHandler` to handle status changes and artifacts produced during the experiment.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,20 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-### Changed
-- **Model provider** — replaced OGX integration with any model handled via OpenAI client
-- **Search space preparation** — renamed `prepare_search_space_with_ogx` to `prepare_search_space_with_maas`, now accepting an `openai.OpenAI` client. Because MaaS `models.list()` carries no metadata (model type, embedding dimension, context length), the payload must declare foundation and embedding model IDs explicitly; embedding dimension and context length are auto-detected at construction time
-- **Client factory** — replaced `create_ogx_client` with `create_maas_client`, a single client that serves listing, chat, and embeddings for every model at the one MaaS endpoint
-- **Notebook templates** — renamed the generated `ogx_{indexing,inference}` templates to `maas_{indexing,inference}`, building a single `OpenAI` client from `MAAS_BASE_URL` / `MAAS_API_KEY` and reusing it for every model; the inference notebook now also rebuilds the pattern's detected generation language and passes it to `OpenAIFoundationModel`, so answers keep the benchmark's language
-- **Model ids** — model ids are used verbatim, exactly as `models.list()` reports them (including any `/` characters); there is no more model-specific URL derivation
-
-### Removed
-- **OGX** — removed all OGX support: the `ogx-client` dependency, `OGXFoundationModel`, `OGXEmbeddingModel`, `OGXModelParameters`, `OGXEmbeddingParams`, `create_ogx_client`, the `ogx_utils` module, the `ogx_inference_base_url` helper, and the `OGX_CLIENT_BASE_URL` / `OGX_CLIENT_API_KEY` environment variables (replaced by `MAAS_BASE_URL` / `MAAS_API_KEY`)
+## [0.12.0](https://github.com/IBM/ai4rag/releases/tag/v0.12.0)
 
 ### Added
-- **Dependencies** — added `openai` as the model-access SDK, replacing `ogx-client`
+- **Vector store** — direct backend clients for Chroma, Milvus, and PostgreSQL/pgvector (`ChromaVectorStore`, `MilvusVectorStore`, `PGVectorStore`), each selected via a typed, frozen config dataclass (`ChromaConfig`, `MilvusConfig`, `PGVectorConfig`) passed as a single `vector_store_config`
+- **Vector store** — `reranker` module implementing RRF and weighted fusion for hybrid search
+- **Vector store** — `BaseVectorStore` now supports `close()` and the context-manager protocol; each optimization trial scopes its store in a `with` block, so connections and pools are no longer leaked per trial
+- **Vector store (pgvector)** — connection pooling via `psycopg_pool.ConnectionPool` with a configurable `PGVectorConfig.pool_max_size` (default 10); `AI4RAGExperiment` sizes the pool from `inference_max_threads` so it tracks real query concurrency
+- **Evaluator** — optional `RagasEvaluator` (with RAGAS adapter classes `AI4RAGRagasLLM` / `AI4RAGRagasEmbeddings`) enabling RAGAS-based metrics; `ragas` is now a regular dependency
+- **RAG optimization component** — `llm_judge_mode` selector (`base` / `ragas` / `all` / `none`) on `run_rag_optimization()` to choose which LLM-as-a-Judge evaluators run
+- **Evaluator** — `build_aggregate_metric()` shared helper on `BaseEvaluator` for constructing aggregate metric payloads
+- **Search space preparation** — `build_search_space_report()` and `serialize_model()` in `ai4rag.search_space.prepare`, co-locating the model↔spec round-trip (`serialize_model()` is the write mirror of the model restore path)
+- **Model access** — `create_maas_client()` and shared model discovery/restore helpers `get_foundation_models()` / `get_embedding_models()` in `ai4rag.search_space.prepare.models`, accepting either bare model ids (discovery) or serialized report specs (restore)
+- **Assets generator** — `get_vector_store_config()` / `get_vector_store_env_vars()` factories that build a backend config from a provider discriminator and expose each backend's required environment variables for documentation
+- **Dependencies** — added `openai` as the model-access SDK (replacing `ogx-client`), plus `chromadb`, `pymilvus`, `pgvector`, and `psycopg[binary,pool]` for the direct vector-store clients
+
+### Changed
+- **Model provider** — replaced the OGX integration with any OpenAI-compatible endpoint; the shipped integration targets OpenShift AI Models-as-a-Service (MaaS), which serves listing, chat, and embeddings from a single endpoint
+- **Vector store** — `get_vector_store()` and `AI4RAGExperiment` now take a single `vector_store_config` and dispatch on `config.provider`, replacing the `vector_store_type` string plus the OGX `vector_io` provider id
+- **Vector store** — collection-name resolution centralized in `BaseVectorStore`, enforcing a mandatory `ai4rag` prefix as the cross-backend isolation guard
+- **Vector store** — hybrid-search reranking parameter renamed `impact_factor` → `k`
+- **Search space** — default `vector_store_type` changed from `ogx` to `milvus`; the default Chroma search space no longer includes the `window` retrieval method
+- **Search space preparation** — renamed `prepare_search_space_with_ogx` to `prepare_search_space_with_maas`, now accepting an `openai.OpenAI` client. Because MaaS `models.list()` carries no metadata (model type, embedding dimension, context length), the payload must declare foundation and embedding model IDs explicitly; embedding dimension and context length are auto-detected at construction time
+- **Model ids** — model ids are used verbatim, exactly as `models.list()` reports them (including any `/` characters); there is no more model-specific URL derivation or id stripping
+- **Client factory** — replaced `create_ogx_client` with `create_maas_client`, a single client that serves listing, chat, and embeddings for every model at the one MaaS endpoint
+- **Notebook templates** — renamed the generated `ogx_{indexing,inference}` templates to `maas_{indexing,inference}`, each building a single `OpenAI` client from `MAAS_BASE_URL` / `MAAS_API_KEY` and reusing it for every model; the inference notebook now also rebuilds the pattern's detected generation language and passes it to `OpenAIFoundationModel`, so answers keep the benchmark's language
+- **Experiment / evaluator** — `metrics` and `optimization_metric` now require `RAGMetric` instances selected from `Metrics` and reject bare metric-name strings, which are ambiguous now that a name (e.g. `faithfulness`) is shared across the unitxt and RAGAS evaluators
+- **Model helpers** — model-instantiation helpers moved to `ai4rag.search_space.prepare.models`, removing the components↔search_space coupling
+- **Search space report** — model pre-selection decoupled from report building into an explicit `ModelsPreSelector` step; `SearchSpaceReport` slimmed to the search-space dict and no longer carries `selected_models` or a per-model `base_url`, and `pattern.json` no longer carries `base_url`
+- **Leaderboard** — aggregate scores are keyed by a collision-free key (unitxt and custom metrics keep their bare name; other evaluators are prefixed, e.g. `ragas_faithfulness`), so colliding metric names each get their own column instead of overwriting one another
+
+### Fixed
+- **Vector store (Milvus)** — forced `consistency_level="Strong"` on vector/hybrid search so a query immediately following an `add_documents()` upsert can no longer race Milvus's default bounded-staleness read and return zero hits against a collection that does contain matching data
+- **Vector store (pgvector)** — corrected `inner_product` scoring: the `<#>` operator returns the negative inner product, so the score is now derived by negation (cosine/l2/l1 keep `1/dist`), fixing an inverted ranking
+- **Vector store (pgvector)** — guarded lazy index creation with double-checked locking (plus a `UniqueViolation` fallback) so concurrent search threads no longer race on `CREATE INDEX`
+- **Experiment** — an optimization metric that is produced but unscored (`None` mean) is now recorded as a failed — not fatal — iteration; a genuinely absent metric still raises a `RAGExperimentError` with an evaluator-qualified message
+- **Components** — added `vector_db_secret_name` to the indexing pipeline params
+- **Core** — `ensure_ascii=False` when JSON-dumping documents that may reach the end user, preserving non-ASCII characters
+- **Benchmark data** — reject `BenchmarkData` records with zero correct answers, preventing a downstream unitxt `TokenOverlap` crash on `max()` of an empty iterable
+- **Experiment** — benchmark JSON is now read with an explicit UTF-8 encoding
+
+### Removed
+- **OGX** — removed all OGX support: the `ogx-client` dependency, `OGXFoundationModel`, `OGXEmbeddingModel`, `OGXVectorStore`, `OGXModelParameters`, `OGXEmbeddingParams`, `create_ogx_client`, the `ogx_utils` module, the `ogx_inference_base_url` helper, and the `OGX_CLIENT_BASE_URL` / `OGX_CLIENT_API_KEY` environment variables (replaced by `MAAS_BASE_URL` / `MAAS_API_KEY`)
+- **Assets generator** — removed the OGX-only `pattern_builder` and `prompt_filters` modules and the `build_pattern_json` export; indexing-spec enrichment is now inlined
+- **Search space preparation** — `prepare_search_space_report()` and the `search_space_preparation` module removed from `ai4rag.components.optimization`; build a search space with `prepare_search_space_with_maas()`, then call `build_search_space_report()` from `ai4rag.search_space.prepare`
+- **Experiment** — `EvaluationResult` no longer carries a `rag_pattern` field; a trial's vector store is closed once the trial finishes, so read `pattern_name` / `scores` from `EvaluationResult` instead of calling `.generate()` on a previously returned pattern
+- **Dependencies** — removed `langchain-chroma`; Chroma is now used directly via `chromadb`
+- **Samples** — removed the outdated `samples/run_ai4rag.ipynb` notebook
 
 ---
 

--- a/docs/api-reference/evaluator/evaluator.md
+++ b/docs/api-reference/evaluator/evaluator.md
@@ -29,6 +29,11 @@
       show_root_heading: true
       show_source: true
 
+::: ai4rag.evaluator.base_evaluator.build_aggregate_metric
+    options:
+      show_root_heading: true
+      show_source: true
+
 ## Unitxt Evaluator
 
 ::: ai4rag.evaluator.unitxt_evaluator.UnitxtEvaluator

--- a/docs/user-guide/evaluation.md
+++ b/docs/user-guide/evaluation.md
@@ -18,7 +18,7 @@ ai4rag uses **multiple evaluator types** to detect these failures and guide opti
 
 ## Available Metrics
 
-ai4rag evaluates four complementary aspects of RAG performance using two evaluator types — **Unitxt** (reference-based) and **LLM-as-a-Judge**:
+ai4rag evaluates several complementary aspects of RAG performance. The core metrics below use two evaluator types — **Unitxt** (reference-based) and **LLM-as-a-Judge**; the optional **RAGAS** evaluator and the derived **overall score** are covered later on this page:
 
 ### Faithfulness
 
@@ -470,7 +470,7 @@ from ai4rag.evaluator.ragas_evaluator import RagasEvaluator
 from ai4rag.rag.foundation_models.openai_model import OpenAIFoundationModel
 from ai4rag.rag.embedding.openai_model import OpenAIEmbeddingModel
 
-# `maas_client` is the shared OpenAI-compatible client (see create_maas_client).
+# `maas_client` is the shared OpenAI-compatible client (see create_dev_maas_client).
 ragas_model = OpenAIFoundationModel(model_id="qwen3-8b-fp8-dynamic", client=maas_client)
 ragas_embeddings = OpenAIEmbeddingModel(model_id="bge-m3", client=maas_client)
 
@@ -598,7 +598,7 @@ for m in best.scores["metrics"]:
 - Review your ground truth answers - are they too specific?
 - Provide multiple acceptable phrasings in `correct_answers`
 - Check if the retrieved context actually contains the information needed
-- Consider optimizing for `ANSWER_CORRECTNESS` instead
+- Consider optimizing for `Metrics.ANSWER_CORRECTNESS` instead
 
 ---
 

--- a/docs/user-guide/provider-agnostic.md
+++ b/docs/user-guide/provider-agnostic.md
@@ -93,6 +93,7 @@ vector_store_config = MilvusConfig.from_env()
 ```python
 # Can use with any foundation/embedding models
 from ai4rag.rag.vector_store import ChromaConfig
+from ai4rag.utils.event_handler import LocalEventHandler
 
 experiment = AI4RAGExperiment(
     documents=documents,
@@ -100,6 +101,7 @@ experiment = AI4RAGExperiment(
     search_space=search_space,
     vector_store_config=ChromaConfig(),  # In-memory vector store
     optimizer_settings=optimizer_settings,
+    event_handler=LocalEventHandler(output_path="./output"),  # required
 )
 ```
 
@@ -228,6 +230,7 @@ Use MaaS for foundation and embedding models, and Milvus (direct client) as the 
 ```python
 from ai4rag.rag.vector_store import MilvusConfig
 from ai4rag.core.experiment.experiment import AI4RAGExperiment
+from ai4rag.utils.event_handler import LocalEventHandler
 
 experiment = AI4RAGExperiment(
     documents=documents,
@@ -241,6 +244,7 @@ experiment = AI4RAGExperiment(
     ),
     vector_store_config=MilvusConfig.from_env(),
     optimizer_settings=optimizer_settings,
+    event_handler=LocalEventHandler(output_path="./output"),  # required
 )
 ```
 
@@ -253,6 +257,7 @@ Use MaaS for models, but ChromaDB for quick local development:
 ```python
 from ai4rag.rag.vector_store import ChromaConfig
 from ai4rag.core.experiment.experiment import AI4RAGExperiment
+from ai4rag.utils.event_handler import LocalEventHandler
 
 experiment = AI4RAGExperiment(
     documents=documents,
@@ -266,6 +271,7 @@ experiment = AI4RAGExperiment(
     ),
     vector_store_config=ChromaConfig(),  # In-memory ChromaDB
     optimizer_settings=optimizer_settings,
+    event_handler=LocalEventHandler(output_path="./output"),  # required
 )
 ```
 
@@ -286,6 +292,7 @@ No configuration needed - just pass `vector_store_config=ChromaConfig()`:
 from pathlib import Path
 from ai4rag.core.experiment.experiment import AI4RAGExperiment
 from ai4rag.rag.vector_store import ChromaConfig
+from ai4rag.utils.event_handler import LocalEventHandler
 
 from dev_utils.file_store import FileStore
 from dev_utils.utils import read_benchmark_from_json
@@ -301,6 +308,7 @@ experiment = AI4RAGExperiment(
     search_space=search_space,
     vector_store_config=ChromaConfig(),  # In-memory, zero config
     optimizer_settings=optimizer_settings,
+    event_handler=LocalEventHandler(output_path="./output"),  # required
 )
 
 best_pattern = experiment.search()

--- a/docs/user-guide/search-space.md
+++ b/docs/user-guide/search-space.md
@@ -158,7 +158,7 @@ Parameter(
 ```
 
 !!! note "Real Type Not Fully Supported"
-    Currently, Real parameters cannot be enumerated (no `.all_values()` method). For practical optimization, use Categorical with discrete float values instead:
+    Currently, Real parameters cannot be enumerated (`all_values()` raises `ParameterValueError` for Real params). For practical optimization, use Categorical with discrete float values instead:
     ```python
     Parameter(name="ranker_alpha", param_type="C", values=[0.0, 0.3, 0.5, 0.7, 1.0])
     ```
@@ -260,7 +260,7 @@ If you don't specify certain parameters, `AI4RAGSearchSpace` uses sensible defau
 | `chunking_method` | `("recursive", "hybrid")` | `("recursive", "hybrid")` | Categorical |
 | `chunk_size` | `(512, 1024, 2048)` | `(512, 1024, 2048)` | Categorical |
 | `chunk_overlap` | `(0, 128, 256)` | `(0, 128, 256)` | Categorical |
-| `retrieval_method` | `("simple",)` | `("simple", "window")` | Categorical |
+| `retrieval_method` | `("simple",)` | `("simple",)` | Categorical |
 | `window_size` | `(0,)` | `(0, 1, 3, 5)` | Categorical |
 | `number_of_chunks` | `(3, 5, 10)` | `(3, 5, 10)` | Categorical |
 | `search_mode` | `("vector", "hybrid")` | `("vector",)` | Categorical |
@@ -270,7 +270,7 @@ If you don't specify certain parameters, `AI4RAGSearchSpace` uses sensible defau
 
 !!! note "Why Different Defaults?"
     - **Chroma** doesn't support hybrid search, so `search_mode` is fixed to `"vector"` and ranker parameters are excluded
-    - **Chroma** defaults include window retrieval options since it's an in-memory store (faster experimentation)
+    - **Chroma** defaults explore a wider range of `window_size` values (`(0, 1, 3, 5)` vs `(0,)`) since it's an in-memory store (faster experimentation)
     - **Milvus** and **PGVector** defaults focus on simple retrieval but include hybrid search exploration
 
 ---


### PR DESCRIPTION
# Release v0.12.0

## Summary

This release makes ai4rag genuinely provider-agnostic. Model access is now built on a plain OpenAI-compatible client — the shipped integration targets OpenShift AI Models-as-a-Service (MaaS), which serves listing, chat, and embeddings from a single endpoint — replacing the OGX-specific stack entirely. The vector-store layer is rebuilt on direct backend clients for Chroma, Milvus, and PostgreSQL/pgvector, configured through typed config dataclasses and with proper connection lifecycle and concurrency handling. Evaluation gains an optional RAGAS evaluator alongside the existing LLM-as-a-Judge path, selectable per optimization run.

## Changes

### Added
- **Vector store** — direct backend clients for Chroma, Milvus, and PostgreSQL/pgvector (`ChromaVectorStore`, `MilvusVectorStore`, `PGVectorStore`), each selected via a typed, frozen config dataclass (`ChromaConfig`, `MilvusConfig`, `PGVectorConfig`) passed as a single `vector_store_config`.
- **Vector store** — `reranker` module implementing RRF and weighted fusion for hybrid search.
- **Vector store** — `BaseVectorStore` now supports `close()` and the context-manager protocol; each optimization trial scopes its store in a `with` block, so connections and pools are no longer leaked per trial.
- **Vector store (pgvector)** — connection pooling via `psycopg_pool.ConnectionPool` with a configurable `PGVectorConfig.pool_max_size` (default 10); `AI4RAGExperiment` sizes the pool from `inference_max_threads` so it tracks real query concurrency.
- **Evaluator** — optional `RagasEvaluator` (with RAGAS adapter classes `AI4RAGRagasLLM` / `AI4RAGRagasEmbeddings`) enabling RAGAS-based metrics; `ragas` is now a regular dependency.
- **RAG optimization component** — `llm_judge_mode` selector (`base` / `ragas` / `all` / `none`) on `run_rag_optimization()` to choose which LLM-as-a-Judge evaluators run.
- **Evaluator** — `build_aggregate_metric()` shared helper on `BaseEvaluator` for constructing aggregate metric payloads.
- **Search space preparation** — `build_search_space_report()` and `serialize_model()` in `ai4rag.search_space.prepare`, co-locating the model↔spec round-trip (`serialize_model()` is the write mirror of the model restore path).
- **Model access** — `create_maas_client()` and shared model discovery/restore helpers `get_foundation_models()` / `get_embedding_models()` in `ai4rag.search_space.prepare.models`, accepting either bare model ids (discovery) or serialized report specs (restore).
- **Assets generator** — `get_vector_store_config()` / `get_vector_store_env_vars()` factories that build a backend config from a provider discriminator and expose each backend's required environment variables for documentation.
- **Dependencies** — added `openai` as the model-access SDK (replacing `ogx-client`), plus `chromadb`, `pymilvus`, `pgvector`, and `psycopg[binary,pool]` for the direct vector-store clients.

### Changed
- **Model provider** — replaced the OGX integration with any OpenAI-compatible endpoint; the shipped integration targets OpenShift AI Models-as-a-Service (MaaS), which serves listing, chat, and embeddings from a single endpoint.
- **Vector store** — `get_vector_store()` and `AI4RAGExperiment` now take a single `vector_store_config` and dispatch on `config.provider`, replacing the `vector_store_type` string plus the OGX `vector_io` provider id.
- **Vector store** — collection-name resolution centralized in `BaseVectorStore`, enforcing a mandatory `ai4rag` prefix as the cross-backend isolation guard.
- **Vector store** — hybrid-search reranking parameter renamed `impact_factor` → `k`.
- **Search space** — default `vector_store_type` changed from `ogx` to `milvus`; the default Chroma search space no longer includes the `window` retrieval method.
- **Search space preparation** — renamed `prepare_search_space_with_ogx` to `prepare_search_space_with_maas`, now accepting an `openai.OpenAI` client. Because MaaS `models.list()` carries no metadata (model type, embedding dimension, context length), the payload must declare foundation and embedding model IDs explicitly; embedding dimension and context length are auto-detected at construction time.
- **Model ids** — model ids are used verbatim, exactly as `models.list()` reports them (including any `/` characters); there is no more model-specific URL derivation or id stripping.
- **Client factory** — replaced `create_ogx_client` with `create_maas_client`, a single client that serves listing, chat, and embeddings for every model at the one MaaS endpoint.
- **Notebook templates** — renamed the generated `ogx_{indexing,inference}` templates to `maas_{indexing,inference}`, each building a single `OpenAI` client from `MAAS_BASE_URL` / `MAAS_API_KEY` and reusing it for every model; the inference notebook now also rebuilds the pattern's detected generation language and passes it to `OpenAIFoundationModel`, so answers keep the benchmark's language.
- **Experiment / evaluator** — `metrics` and `optimization_metric` now require `RAGMetric` instances selected from `Metrics` and reject bare metric-name strings, which are ambiguous now that a name (e.g. `faithfulness`) is shared across the unitxt and RAGAS evaluators.
- **Model helpers** — model-instantiation helpers moved to `ai4rag.search_space.prepare.models`, removing the components↔search_space coupling.
- **Search space report** — model pre-selection decoupled from report building into an explicit `ModelsPreSelector` step; `SearchSpaceReport` slimmed to the search-space dict and no longer carries `selected_models` or a per-model `base_url`, and `pattern.json` no longer carries `base_url`.
- **Leaderboard** — aggregate scores are keyed by a collision-free key (unitxt and custom metrics keep their bare name; other evaluators are prefixed, e.g. `ragas_faithfulness`), so colliding metric names each get their own column instead of overwriting one another.

### Fixed
- **Vector store (Milvus)** — forced `consistency_level="Strong"` on vector/hybrid search so a query immediately following an `add_documents()` upsert can no longer race Milvus's default bounded-staleness read and return zero hits against a collection that does contain matching data.
- **Vector store (pgvector)** — corrected `inner_product` scoring: the `<#>` operator returns the negative inner product, so the score is now derived by negation (cosine/l2/l1 keep `1/dist`), fixing an inverted ranking.
- **Vector store (pgvector)** — guarded lazy index creation with double-checked locking (plus a `UniqueViolation` fallback) so concurrent search threads no longer race on `CREATE INDEX`.
- **Experiment** — an optimization metric that is produced but unscored (`None` mean) is now recorded as a failed — not fatal — iteration; a genuinely absent metric still raises a `RAGExperimentError` with an evaluator-qualified message.
- **Components** — added `vector_db_secret_name` to the indexing pipeline params.
- **Core** — `ensure_ascii=False` when JSON-dumping documents that may reach the end user, preserving non-ASCII characters.
- **Benchmark data** — reject `BenchmarkData` records with zero correct answers, preventing a downstream unitxt `TokenOverlap` crash on `max()` of an empty iterable.
- **Experiment** — benchmark JSON is now read with an explicit UTF-8 encoding.

### Removed
- **OGX** — removed all OGX support: the `ogx-client` dependency, `OGXFoundationModel`, `OGXEmbeddingModel`, `OGXVectorStore`, `OGXModelParameters`, `OGXEmbeddingParams`, `create_ogx_client`, the `ogx_utils` module, the `ogx_inference_base_url` helper, and the `OGX_CLIENT_BASE_URL` / `OGX_CLIENT_API_KEY` environment variables (replaced by `MAAS_BASE_URL` / `MAAS_API_KEY`).
- **Assets generator** — removed the OGX-only `pattern_builder` and `prompt_filters` modules and the `build_pattern_json` export; indexing-spec enrichment is now inlined.
- **Search space preparation** — `prepare_search_space_report()` and the `search_space_preparation` module removed from `ai4rag.components.optimization`; build a search space with `prepare_search_space_with_maas()`, then call `build_search_space_report()` from `ai4rag.search_space.prepare`.
- **Experiment** — `EvaluationResult` no longer carries a `rag_pattern` field; a trial's vector store is closed once the trial finishes, so read `pattern_name` / `scores` from `EvaluationResult` instead of calling `.generate()` on a previously returned pattern.
- **Dependencies** — removed `langchain-chroma`; Chroma is now used directly via `chromadb`.
- **Samples** — removed the outdated `samples/run_ai4rag.ipynb` notebook.

## Migration notes

This is a breaking release. Upgrading from `0.11.x` requires the following changes:

1. **Environment variables** — replace `OGX_CLIENT_BASE_URL` / `OGX_CLIENT_API_KEY` with `MAAS_BASE_URL` / `MAAS_API_KEY`. `MAAS_BASE_URL` must be the full OpenAI-compatible endpoint, used verbatim (e.g. `https://<host>/v1`).
2. **Model access** — replace `create_ogx_client(...)` with `create_maas_client(base_url, api_key)`. All OGX model classes (`OGXFoundationModel`, `OGXEmbeddingModel`, and their parameter types) are gone; use `OpenAIFoundationModel` / `OpenAIEmbeddingModel`. Model ids are now used verbatim as reported by `models.list()` — do not strip path segments.
3. **Search space preparation** — replace `prepare_search_space_with_ogx(...)` with `prepare_search_space_with_maas(...)`, passing an `openai.OpenAI` client and **explicit** foundation and embedding model IDs (MaaS `models.list()` returns no metadata). To produce a report, call `build_search_space_report()` from `ai4rag.search_space.prepare` — `prepare_search_space_report()` no longer exists in `ai4rag.components.optimization`. Model pre-selection is now a separate `ModelsPreSelector` step, and `SearchSpaceReport` no longer carries `selected_models`.
4. **Vector store** — replace the `vector_store_type` string (and any OGX `vector_io` provider id / `client` argument) with a single `vector_store_config` built from `ChromaConfig`, `MilvusConfig`, or `PGVectorConfig`. The `ogx` vector-store backend is removed and the default is now `milvus`. If you tune hybrid search, rename the reranking parameter `impact_factor` → `k`.
5. **Results** — `EvaluationResult` no longer exposes `rag_pattern`. Read `pattern_name` and `scores` from `EvaluationResult` instead of calling `.generate()` on a previously returned pattern; the trial's vector store is closed once the trial finishes.
6. **Metrics API** — pass `RAGMetric` instances selected from `Metrics` to `metrics` / `optimization_metric`; bare metric-name strings are no longer accepted, because a name such as `faithfulness` is now shared across the unitxt and RAGAS evaluators.
7. **Dependencies** — `ogx-client` and `langchain-chroma` are removed. The new runtime dependencies (`openai`, `chromadb`, `pymilvus`, `pgvector`, `psycopg[binary,pool]`, `ragas`) are installed automatically; re-sync your environment (`uv sync`).

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.12.0`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
