### PR TITLE
fix(vector_store): fall back to sequential scan past pgvector's 2000-dim limit

### DIFF
--- a/ai4rag/rag/vector_store/pgvector.py
+++ b/ai4rag/rag/vector_store/pgvector.py
@@ -58,11 +58,12 @@ class PGVectorStore(BaseVectorStore):
 
     # pgvector caps HNSW (and IVFFlat) indexes on the ``vector`` type at 2000
     # dimensions (https://github.com/pgvector/pgvector#hnsw). Higher-dimensional
-    # vectors still store and query correctly, but the index cannot be built. Since
-    # indexes are created lazily on the first search (see ``_ensure_indexes``), an
-    # oversized model would otherwise crash on the first query — after a full, and
-    # potentially costly, embed-and-insert cycle. Rejecting it here fails fast,
-    # before a connection is opened or a single document is embedded.
+    # vectors still store and query correctly — only the ANN index cannot be built.
+    # Rather than rejecting oversized models outright, ``_ensure_indexes`` skips
+    # building the HNSW index above this threshold and lets PostgreSQL fall back to
+    # an exact sequential scan: slower per query, but still fully correct (in fact
+    # exact rather than HNSW's approximate result), and every other code path
+    # (storage, keyword search, hybrid fusion) is unaffected by the dimension.
     _MAX_INDEXABLE_DIMENSION = 2000
 
     _DISTANCE_METRIC_TO_OPERATOR: dict[str, str] = {
@@ -111,19 +112,18 @@ class PGVectorStore(BaseVectorStore):
         Raises
         ------
         ValueError
-            If ``distance_metric`` is not one of the supported metrics, or if the
-            model's embedding dimension exceeds pgvector's HNSW index limit of
-            :attr:`_MAX_INDEXABLE_DIMENSION` dimensions.
+            If ``distance_metric`` is not one of the supported metrics.
         """
         super().__init__(embedding_model, config, distance_metric, collection_name)
         self._embedding_dimension = resolve_embedding_dimension(self.embedding_model)
         if self._embedding_dimension > self._MAX_INDEXABLE_DIMENSION:
-            raise ValueError(
-                f"Embedding dimension {self._embedding_dimension} exceeds pgvector's "
-                f"{self._MAX_INDEXABLE_DIMENSION}-dimension limit for HNSW indexes. "
-                f"Use an embedding model with at most {self._MAX_INDEXABLE_DIMENSION} "
-                "dimensions, or a backend that supports higher-dimensional indexing "
-                "(e.g. Milvus)."
+            logger.warning(
+                "Embedding dimension %d exceeds pgvector's %d-dimension limit for HNSW "
+                "indexes; searches on collection %r will use an exact sequential scan "
+                "instead of an approximate nearest-neighbor index.",
+                self._embedding_dimension,
+                self._MAX_INDEXABLE_DIMENSION,
+                self._collection_name,
             )
 
         distance_key = distance_metric.lower()
@@ -253,6 +253,12 @@ class PGVectorStore(BaseVectorStore):
         catalog. The lock prevents that race for this instance; the ``UniqueViolation``
         catch below is a second line of defense for a collection shared across instances
         (e.g. reused by another trial), where no Python-level lock can help.
+
+        The HNSW index is only built when :attr:`_embedding_dimension` is within
+        pgvector's :attr:`_MAX_INDEXABLE_DIMENSION` limit; above it, this step is
+        skipped entirely (search then falls back to an exact sequential scan) while
+        the GIN full-text index is still built unconditionally, since it does not
+        depend on the embedding column at all.
         """
         if self._indexes_built:
             return
@@ -267,13 +273,23 @@ class PGVectorStore(BaseVectorStore):
                 # Each statement is guarded independently, not by one shared try/except:
                 # under autocommit there is no transaction spanning them, so a race lost on
                 # one index must not skip creating the other.
-                self._create_index_ignoring_race(
-                    conn,
-                    f"""
-                    CREATE INDEX IF NOT EXISTS {hnsw_idx}
-                    ON {self._quoted_table()} USING hnsw (embedding {self._index_ops})
-                    """,
-                )
+                if self._embedding_dimension <= self._MAX_INDEXABLE_DIMENSION:
+                    self._create_index_ignoring_race(
+                        conn,
+                        f"""
+                        CREATE INDEX IF NOT EXISTS {hnsw_idx}
+                        ON {self._quoted_table()} USING hnsw (embedding {self._index_ops})
+                        """,
+                    )
+                else:
+                    logger.info(
+                        "Skipping HNSW index for %s: embedding dimension %d exceeds "
+                        "pgvector's %d-dimension limit; search will use an exact "
+                        "sequential scan.",
+                        self._collection_name,
+                        self._embedding_dimension,
+                        self._MAX_INDEXABLE_DIMENSION,
+                    )
                 self._create_index_ignoring_race(
                     conn,
                     f"""

--- a/docs/architecture/rag-components.md
+++ b/docs/architecture/rag-components.md
@@ -856,8 +856,8 @@ config = PGVectorConfig(host="localhost", port=5432, dbname="ai4rag", user="ai4r
 
 The resolved `collection_name` is used verbatim as the physical PostgreSQL table name — created with an `id` primary key, a `document` JSONB payload, an `embedding` vector column, `content_text`, and a `tokenized_content` `tsvector` column feeding full-text search. Supported `distance_metric` values are `"cosine"`, `"l2"`, `"l1"`, and `"inner_product"`.
 
-!!! warning "Embedding dimension limit"
-    pgvector caps HNSW indexes on the `vector` type at 2000 dimensions. `PGVectorStore.__init__` raises `ValueError` up front if the embedding model's dimension exceeds this limit, rather than failing later on the first indexed search — use `MilvusVectorStore` for higher-dimensional embedding models.
+!!! note "Embedding dimensions above 2000"
+    pgvector caps HNSW/IVFFlat indexes on the `vector` type at 2000 dimensions. `PGVectorStore` still creates the table and stores/queries vectors of any dimension pgvector supports (up to 16,000) — above 2000, it simply skips building the HNSW index and logs a warning, so searches fall back to an exact sequential scan instead of an approximate one. Results remain correct; only per-query latency scales with collection size. For very large, high-dimension collections where scan latency matters, `MilvusVectorStore` remains available.
 
 **Hybrid Search:**
 

--- a/tests/functional/test_experiment.py
+++ b/tests/functional/test_experiment.py
@@ -77,6 +77,7 @@ def _make_event_handler(test_name):
     return LocalEventHandler()
 
 
+@pytest.mark.chroma
 class TestExperimentChroma:
     """Run experiment with chroma vector store and MaaS models."""
 
@@ -112,6 +113,7 @@ class TestExperimentChroma:
         assert 0 <= best_eval.final_score <= 1
 
 
+@pytest.mark.milvus
 class TestExperimentMilvus:
     """Run experiment with a direct Milvus vector store client and MaaS models."""
 
@@ -147,6 +149,7 @@ class TestExperimentMilvus:
         assert 0 <= best_eval.final_score <= 1
 
 
+@pytest.mark.pgvector
 class TestExperimentPGVector:
     """Run experiment with PG vector store and MaaS models."""
 
@@ -182,6 +185,7 @@ class TestExperimentPGVector:
         assert 0 <= best_eval.final_score <= 1
 
 
+@pytest.mark.chroma
 class TestExperimentChromaWithKnownObservations:
     """Run experiment with chroma, MaaS models, and known observations."""
 

--- a/tests/integration/vector_store/test_chroma.py
+++ b/tests/integration/vector_store/test_chroma.py
@@ -25,6 +25,7 @@ def _collection_exists(store: ChromaVectorStore, name: str) -> bool:
     return name in {collection.name for collection in store._client.list_collections()}
 
 
+@pytest.mark.chroma
 class TestChromaIntegration:
     """Full create → add → search → drop lifecycle against a live Chroma server.
 

--- a/tests/integration/vector_store/test_milvus.py
+++ b/tests/integration/vector_store/test_milvus.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.mark.milvus
 class TestMilvusIntegration:
     """Full create → add → search → drop lifecycle against a live Milvus server.
 

--- a/tests/integration/vector_store/test_pgvector.py
+++ b/tests/integration/vector_store/test_pgvector.py
@@ -19,6 +19,7 @@ import pytest
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.vector_store.config import PGVectorConfig
 from ai4rag.rag.vector_store.pgvector import PGVectorStore
+from tests.integration.vector_store.conftest import DeterministicEmbeddingModel
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("PGVECTOR_HOST") is None,
@@ -36,6 +37,7 @@ def _table_exists(store: PGVectorStore) -> bool:
     return row is not None and row[0] is not None
 
 
+@pytest.mark.pgvector
 class TestPGVectorIntegration:
     """Full create → add → search → drop lifecycle against a live pgvector server.
 
@@ -108,3 +110,66 @@ class TestPGVectorIntegration:
             assert not _table_exists(store)
         finally:
             store.close()
+
+
+def _index_names(store: PGVectorStore) -> set[str]:
+    """Return the names of every index currently defined on the store's table."""
+    with store._pool.connection() as conn:
+        rows = conn.execute(
+            "SELECT indexname FROM pg_indexes WHERE tablename = %s", (store.collection_name,)
+        ).fetchall()
+    return {row[0] for row in rows}
+
+
+@pytest.mark.pgvector
+class TestPGVectorHighDimensionIntegration:
+    """Verifies the >2000-dim fallback against a real pgvector extension.
+
+    pgvector caps HNSW/IVFFlat indexes at 2000 dimensions
+    (see :attr:`PGVectorStore._MAX_INDEXABLE_DIMENSION`); above that, the store must
+    still store, index (full-text only), and search correctly — just without an ANN
+    index on the embedding column. This class exercises that against a live server,
+    since ``TestPGVectorIntegration`` above only covers the ≤2000-dim path and the
+    unit suite only mocks the DDL rather than running it against a real pgvector
+    extension.
+    """
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def vector_store(sample_chunks):
+        store = PGVectorStore(
+            embedding_model=DeterministicEmbeddingModel(dimension=2100),
+            config=PGVectorConfig.from_env(),
+            collection_name="ai4rag_integration_test_highdim",
+        )
+        store.add_documents(sample_chunks)
+        try:
+            yield store
+        finally:
+            store.clean_collection()
+            store.close()
+
+    def test_hnsw_index_is_not_created_but_gin_is(self, vector_store):
+        """Triggering index creation (first search) skips HNSW but still builds GIN."""
+        vector_store.search("anything", k=1)  # triggers _ensure_indexes
+
+        names = _index_names(vector_store)
+        assert not any("hnsw" in name for name in names)
+        assert any("gin" in name for name in names)
+
+    def test_search_returns_exact_relevant_chunk(self, vector_store, sample_chunks):
+        """Without an ANN index, search still returns the exact nearest match."""
+        target = sample_chunks[0]
+        results = vector_store.search(target.text, k=len(sample_chunks))
+
+        assert results, "search returned no results"
+        assert results[0].text == target.text
+        assert results[0].metadata["document_id"] == target.metadata["document_id"]
+
+    def test_hybrid_search_still_works(self, vector_store, sample_chunks):
+        """Hybrid (dense + keyword) fusion is unaffected by the missing ANN index."""
+        target = sample_chunks[0]
+        results = vector_store.search(target.text, k=len(sample_chunks), search_mode="hybrid", ranker_strategy="rrf")
+
+        assert results
+        assert target.text in {result.text for result in results}

--- a/tests/unit/ai4rag/rag/vector_store/test_pgvector.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_pgvector.py
@@ -33,6 +33,19 @@ def mock_embedding():
     return _MockEmbeddingModel()
 
 
+class _HighDimEmbedding:
+    """Mock embedding model above pgvector's 2000-dimension HNSW index limit."""
+
+    model_id = "big-embedding"
+    params = {"embedding_dimension": 3072}
+
+    def embed_documents(self, texts):
+        return [[0.1] * 3072 for _ in texts]
+
+    def embed_query(self, query):
+        return [0.1] * 3072
+
+
 @pytest.fixture
 def pgvector_config():
     return PGVectorConfig(host="localhost", port=5432, dbname="testdb", user="testuser")
@@ -78,24 +91,23 @@ class TestPGVectorStoreInit:
         with pytest.raises(ValueError, match="Unsupported distance metric"):
             PGVectorStore(mock_embedding, pgvector_config, distance_metric="hamming")
 
-    def test_embedding_dimension_over_limit_raises_before_pool_opens(self, mock_pool_cls, pgvector_config):
+    def test_embedding_dimension_over_limit_logs_warning_and_proceeds(self, mock_pool_cls, pgvector_config, caplog):
         from ai4rag.rag.vector_store.pgvector import PGVectorStore
 
-        class _HighDimEmbedding:
-            model_id = "big-embedding"
-            params = {"embedding_dimension": 3072}
+        conn = _conn_from(mock_pool_cls)
 
-            def embed_documents(self, texts):
-                return [[0.1] * 3072 for _ in texts]
+        with caplog.at_level("WARNING"):
+            store = PGVectorStore(_HighDimEmbedding(), pgvector_config)
 
-            def embed_query(self, query):
-                return [0.1] * 3072
+        # Construction succeeds and opens a pool like any other dimension — the store
+        # is fully usable, just without an HNSW index (asserted separately in
+        # TestPGVectorStoreSearch.test_high_dimension_search_skips_hnsw_builds_gin).
+        mock_pool_cls.assert_called_once()
+        assert store.collection_name.startswith("ai4rag_")
+        assert any("exceeds pgvector's" in record.message for record in caplog.records)
 
-        with pytest.raises(ValueError, match="exceeds pgvector's"):
-            PGVectorStore(_HighDimEmbedding(), pgvector_config)
-
-        # The guard must fire before any expensive work: no pool is opened.
-        mock_pool_cls.assert_not_called()
+        executed = " ".join(str(c) for c in conn.execute.call_args_list)
+        assert "vector(3072)" in executed
 
     def test_embedding_dimension_at_limit_allowed(self, mock_pool_cls, pgvector_config):
         from ai4rag.rag.vector_store.pgvector import PGVectorStore
@@ -205,6 +217,34 @@ class TestPGVectorStoreSearch:
         conn.execute.return_value.fetchall.return_value = []
         store.search("query", k=1)
         assert "hnsw" not in " ".join(str(c) for c in conn.execute.call_args_list)
+
+    def test_high_dimension_search_skips_hnsw_builds_gin(self, mock_pool_cls, pgvector_config):
+        """Above pgvector's 2000-dim limit, HNSW is skipped but GIN and search still work."""
+        from ai4rag.rag.vector_store.pgvector import PGVectorStore
+
+        conn = _conn_from(mock_pool_cls)
+        store = PGVectorStore(_HighDimEmbedding(), pgvector_config, collection_name="ai4rag_highdim")
+        conn.execute.return_value.fetchall.return_value = [("hello", {}, 0.5)]
+
+        results = store.search("query", k=1)
+
+        executed = " ".join(str(c) for c in conn.execute.call_args_list)
+        assert "hnsw" not in executed
+        assert "USING gin" in executed
+        assert results[0].text == "hello"
+
+    def test_high_dimension_hybrid_search_still_fuses(self, mock_pool_cls, pgvector_config):
+        """Hybrid fusion is independent of the embedding dimension/index tier."""
+        from ai4rag.rag.vector_store.pgvector import PGVectorStore
+
+        conn = _conn_from(mock_pool_cls)
+        store = PGVectorStore(_HighDimEmbedding(), pgvector_config, collection_name="ai4rag_highdim_hybrid")
+        conn.execute.return_value.fetchall.return_value = [("hello", {}, 0.5)]
+
+        results = store.search("query", k=1, search_mode="hybrid", ranker_strategy="rrf")
+
+        assert len(results) == 1
+        assert results[0].text == "hello"
 
     def test_ensure_indexes_is_thread_safe_under_concurrent_search(
         self, mock_pool_cls, mock_embedding, pgvector_config


### PR DESCRIPTION
PGVectorStore raised ValueError at construction whenever an embedding model's dimension exceeded pgvector's 2000-dimension HNSW/IVFFlat index cap, blocking those models outright even though pgvector can store and query vectors up to 16,000 dimensions — only the ANN index is capped.

Mirror the graceful-degradation behavior the OGX server used for this same problem: skip building the HNSW index above the limit and log a warning instead of raising, letting PostgreSQL fall back to an exact sequential scan. Storage, keyword search, and hybrid fusion are unaffected, since none of them depend on the ANN index. Add unit coverage for the warn-and-proceed path and a live integration test confirming HNSW is skipped (GIN still built) against a real pgvector extension.

Also add @pytest.mark.{chroma,milvus,pgvector} markers to the functional and integration vector store test suites for backend-based test selection.


Assisted-by: Claude Code

## Description
Brief summary of changes

## Motivation
Why is this change needed?

## Changes
- Bullet point list of changes
- Another change

## Testing
How did you test this?

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
