### PR TITLE
Release 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ MaaS is the integration `ai4rag` ships helpers for, so the walkthrough below use
 
 - **SDK:** [openai](https://pypi.org/project/openai/) >= 2, < 3 (Python package used by ai4RAG; installs with this project).
 - **Deployment:** an OpenShift AI MaaS instance exposing at least one foundation model and one embedding model.
-- **Endpoints:** MaaS serves **everything from a single OpenAI-compatible endpoint** — `MAAS_BASE_URL`, used verbatim. One client lists the available models (`models.list()`) and serves chat/completions and embeddings for all of them. Model ids are used verbatim, exactly as `models.list()` reports them.
+- **Endpoints:** MaaS serves **everything from a single OpenAI-compatible endpoint** — `MAAS_BASE_URL` (host-only or `/v1`-suffixed; normalized automatically). One client lists the available models (`models.list()`) and serves chat/completions and embeddings for all of them. Model ids are used verbatim, exactly as `models.list()` reports them.
 
 **Features used by ai4rag**
 

--- a/ai4rag/__init__.py
+++ b/ai4rag/__init__.py
@@ -5,7 +5,7 @@
 import logging
 import os
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 logger = logging.getLogger("ai4rag")
 logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,18 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.13.0](https://github.com/IBM/ai4rag/releases/tag/v0.13.0)
 
 ### Added
 - **Text extraction** — optional RapidOCR via Docling, configured through a single `DoclingExtractionConfig` passed to `extract_text` (`do_ocr`, `ocr_lang`, custom ONNX model paths); OCR remains off by default
 - **Document discovery / extraction** — JPEG, PNG, and TIFF image extensions supported for OCR-capable ingestion
 - **Text extraction** — audio ingestion (`.wav`, `.mp3`, `.m4a`, `.aac`, `.ogg`, `.flac`) transcribed via Docling's ASR pipeline (Whisper), with automatic language detection
 
+### Changed
+- **Dependencies** — split docling's heavy conversion stack (`torch`, `docling-ibm-models`, `rapidocr`, `whisper`) out of the base install into a new `text-extraction` extra; core RAG code (chunking, experiment, evaluator, templates) only needs `docling-slim[feat-chunking]`. The `test` extra now depends on `ai4rag[text-extraction]` so unit tests keep exercising the full conversion stack
+- **Model pre-selection** — default foundation/embedding model counts used by `ModelsPreSelector` extracted into a new `PreSelectorConstants` (`ai4rag.utils.constants`)
+
 ### Fixed
 - **Text extraction / OCR** — fail fast with bake instructions when `DOCLING_ARTIFACTS_PATH` is set but RapidOCR ONNX models are missing; current PyPI `rapidocr` wheels no longer ship model files (bake via `tmp/Containerfile.autorag-dev`)
+- **Vector store (pgvector)** — embedding models whose dimension exceeds pgvector's 2000-dimension HNSW/IVFFlat index cap are no longer rejected at construction; `PGVectorStore` now skips building the HNSW index above the limit and logs a warning, falling back to an exact sequential scan (storage, keyword search, and hybrid fusion are unaffected)
+- **Vector store (pgvector)** — the connection pool and backing table are now created lazily on the first `add_documents()`/search call, guarded by double-checked locking, instead of during `__init__`; avoids idle pooled connections accumulating while the (potentially slow) embedding step runs before the first insert
+- **Model access** — `create_maas_client()` now normalizes `base_url` by stripping any trailing slash and appending `/v1` if missing, so both host-only and fully-qualified endpoint URLs work (previously the URL was used verbatim, requiring the exact `/v1`-suffixed endpoint)
 
 ### Removed
 - **Vector store** — `ChromaVectorStore`, `MilvusVectorStore`, and `PGVectorStore` are no longer re-exported from `ai4rag.rag.vector_store`; import each directly from its backend module instead (`ai4rag.rag.vector_store.chroma`, `.milvus`, `.pgvector`). This keeps each backend's client library (`chromadb`, `pymilvus`, `psycopg`) — and its own import-time requirements, notably chromadb's minimum sqlite3 version — isolated to callers that actually use that backend. `BaseVectorStore`, `ChromaConfig`/`MilvusConfig`/`PGVectorConfig`, `get_vector_store`, `get_vector_store_config`, and `get_vector_store_env_vars` are unaffected and remain importable from `ai4rag.rag.vector_store`
+- **Internal utilities** — removed the unused `ai4rag.utils.validators` module
 
 ---
 

--- a/docs/api-reference/components/data.md
+++ b/docs/api-reference/components/data.md
@@ -17,6 +17,7 @@ Data processing functions for the AutoRAG pipeline.
     options:
       members:
         - extract_text
+        - DoclingExtractionConfig
         - ExtractionResult
 
 ## Test Data Loading

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,6 +32,17 @@ If you want to use specific version, please use e.g. `"@v0.1.1"`
 Vector store clients — `chromadb`, `pymilvus`, `pgvector`, and `psycopg` — are core dependencies and install automatically.
 No extra step is needed to use Chroma, Milvus, or PostgreSQL/pgvector as a vector store.
 
+!!! note "OCR and audio ingestion"
+    Text extraction from born-digital documents (PDF, DOCX, Markdown, HTML, …) works out of the box.
+    Scanned PDFs/images (via RapidOCR) and audio transcription (via Whisper) additionally require the
+    `text-extraction` extra, which pulls in `torch`, `docling-ibm-models`, `rapidocr`, and `whisper`:
+
+    ```bash
+    pip install "ai4rag[text-extraction] @ git+https://github.com/IBM/ai4rag.git@main"
+    ```
+
+    See [Pipeline Components](../user-guide/pipeline-components.md#text-extraction) for usage.
+
 ---
 
 ## Development Installation
@@ -99,14 +110,14 @@ Obtain access to an OpenShift AI MaaS deployment that exposes:
 - At least one **embedding model** (e.g., `bge-m3`)
 
 MaaS serves **all models from a single OpenAI-compatible endpoint** —
-`MAAS_BASE_URL`, used verbatim. No extra package is required — the `openai`
+`MAAS_BASE_URL`. No extra package is required — the `openai`
 SDK ships with `ai4rag` as a core dependency.
 
 ### 2. Note Your Credentials
 
 Record the MaaS base URL and API key for use in `ai4rag`:
 
-- **`MAAS_BASE_URL`** — the complete OpenAI-compatible endpoint URL, used verbatim (e.g. `https://<host>/v1`)
+- **`MAAS_BASE_URL`** — the OpenAI-compatible endpoint URL (e.g. `https://<host>`); a trailing `/v1` is appended automatically if not already present
 - **`MAAS_API_KEY`** — a single API key for the single client that serves listing, chat, and embeddings
 
 ---

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -26,7 +26,7 @@ Before starting, ensure you have:
 ### 1. Prepare the MaaS Client
 
 OpenShift MaaS serves every model from a single OpenAI-compatible endpoint —
-`MAAS_BASE_URL`, used verbatim. One client discovers the available models
+`MAAS_BASE_URL`. One client discovers the available models
 and is reused, unchanged, to serve every model wrapper.
 
 The `dev_utils` helpers wrap this setup — `create_dev_maas_client()`

--- a/docs/user-guide/pipeline-components.md
+++ b/docs/user-guide/pipeline-components.md
@@ -36,7 +36,7 @@ and Kubernetes-specific concerns (secrets, resource limits).  All business logic
 
 ## Installation
 
-S3 support (`boto3`), multiprocessing (`multiprocess`), and text extraction (`docling`) are all included in the core `ai4rag` install — no extra dependencies are needed to use pipeline components.
+S3 support (`boto3`), multiprocessing (`multiprocess`), and text extraction for born-digital documents (`docling-slim[feat-chunking]`) are all included in the core `ai4rag` install. OCR (scanned PDFs/images) and audio transcription additionally require the `text-extraction` extra — see [Installation](../getting-started/installation.md#basic-installation).
 
 ## Data Components
 
@@ -73,7 +73,7 @@ result = extract_text(
 print(f"Processed {result.processed_count}/{result.total_documents}")
 ```
 
-Supported document extensions include PDF, DOCX, PPTX, Markdown, HTML, TXT, ODT/ODP, AsciiDoc, LaTeX, EPUB, email, Quarto/R Markdown, XHTML, and images (JPEG, PNG, TIFF).
+Supported document extensions include PDF, DOCX, PPTX, Markdown, HTML, TXT, ODT/ODP, AsciiDoc, LaTeX, EPUB, email, Quarto/R Markdown, XHTML, images (JPEG, PNG, TIFF), and audio (WAV, MP3, M4A, AAC, OGG, FLAC).
 
 OCR is **off by default**. Conversion behaviour (table structure and OCR) is
 controlled through a single `DoclingExtractionConfig` instance. To enable
@@ -105,6 +105,20 @@ models. `ocr_lang` accepts a single string (`"english"`) or a sequence
 (`["english", "chinese"]`) and defaults to `["english"]` when OCR is enabled.
 
 Default RapidOCR models are **not** in current PyPI `rapidocr` wheels. On AutoRAG/OpenShift images with `DOCLING_ARTIFACTS_PATH` set, bake ONNX models under `$DOCLING_ARTIFACTS_PATH/RapidOcr/` at image build time (see `tmp/Containerfile.autorag-dev`). Docling auto-detects pages that need OCR when `do_ocr=True`. Override with `ocr_*_model_path` for custom ONNX sets.
+
+#### Audio Transcription
+
+Audio files (`.wav`, `.mp3`, `.m4a`, `.aac`, `.ogg`, `.flac`) are transcribed automatically — no configuration flag is needed, unlike OCR. `extract_text` routes them through Docling's ASR pipeline using a Whisper (`whisper-tiny`) model, with the spoken language auto-detected per file:
+
+```python
+from ai4rag.components.data import extract_text
+
+result = extract_text(
+    documents=[{"key": "recordings/call.mp3", "size_bytes": 4096}],
+    bucket="my-bucket",
+    output_dir="/tmp/extracted",
+)
+```
 
 ### Test Data Loading
 
@@ -177,7 +191,7 @@ The `ai4rag.components` package provides three shared utility modules used acros
 | Module | Function | Purpose |
 |--------|----------|---------|
 | `utils.s3` | `create_s3_client()` | S3 client factory with env-var fallback |
-| `utils.maas_client` | `create_maas_client()` | Single MaaS client (endpoint from `MAAS_BASE_URL`, used verbatim) for listing, chat, and embeddings, with SSL self-signed cert fallback |
+| `utils.maas_client` | `create_maas_client()` | Single MaaS client (endpoint from `MAAS_BASE_URL`, normalized to a `/v1`-suffixed URL) for listing, chat, and embeddings, with SSL self-signed cert fallback |
 | `utils.docling_io` | `load_docling_documents()` | Load DoclingDocument JSON files |
 
 These are importable from `ai4rag.components` or `ai4rag.components.utils`:

--- a/docs/user-guide/provider-agnostic.md
+++ b/docs/user-guide/provider-agnostic.md
@@ -30,7 +30,7 @@ For **models**, `ai4rag` speaks the OpenAI API: any OpenAI-compatible endpoint w
 - **Foundation Models**: Any chat/completion model deployed on your MaaS instance
 - **Embedding Models**: Any embedding model deployed on your MaaS instance
 
-**How it works**: a single client, pointing at `MAAS_BASE_URL` (used verbatim), serves everything — it lists the available models (`models.list()`) and is reused, unchanged, to serve `chat.completions` and `embeddings` for every model. Model ids are used verbatim, exactly as `models.list()` reports them (ids may contain `/`).
+**How it works**: a single client, pointing at `MAAS_BASE_URL`, serves everything — it lists the available models (`models.list()`) and is reused, unchanged, to serve `chat.completions` and `embeddings` for every model. `MAAS_BASE_URL` may be host-only or already `/v1`-suffixed — `create_maas_client()` normalizes it either way. Model ids are used verbatim, exactly as `models.list()` reports them (ids may contain `/`).
 
 !!! note "No model metadata"
     Unlike some registries, MaaS `models.list()` carries no metadata (model type, embedding dimension, context length). So embedding dimension and context length are auto-detected by `OpenAIEmbeddingModel` at construction time (or supplied via `params`), and the caller declares which model ids are foundation vs. embedding.


### PR DESCRIPTION
# Release v0.13.0

## Summary

This release extends document ingestion beyond born-digital text: scanned PDFs and images can now be OCR'd via RapidOCR, and audio files can be transcribed via Docling's Whisper-based ASR pipeline, both off by default and opt-in through `DoclingExtractionConfig`. The heavy conversion stack these features pull in (`torch`, `docling-ibm-models`, `rapidocr`, `whisper`) is split out of the base install into a new `text-extraction` extra, so core RAG usage stays lightweight. The vector-store layer gets a further import-isolation pass and two pgvector reliability fixes (high-dimension embedding fallback, lazy pool/table creation), and the MaaS client now tolerates host-only `base_url` values.

## Changes

### Added
- **Text extraction** — optional RapidOCR via Docling, configured through a single `DoclingExtractionConfig` passed to `extract_text` (`do_ocr`, `ocr_lang`, custom ONNX model paths); OCR remains off by default.
- **Document discovery / extraction** — JPEG, PNG, and TIFF image extensions supported for OCR-capable ingestion.
- **Text extraction** — audio ingestion (`.wav`, `.mp3`, `.m4a`, `.aac`, `.ogg`, `.flac`) transcribed via Docling's ASR pipeline (Whisper), with automatic language detection.

### Changed
- **Dependencies** — split docling's heavy conversion stack (`torch`, `docling-ibm-models`, `rapidocr`, `whisper`) out of the base install into a new `text-extraction` extra; core RAG code (chunking, experiment, evaluator, templates) only needs `docling-slim[feat-chunking]`. The `test` extra now depends on `ai4rag[text-extraction]` so unit tests keep exercising the full conversion stack.
- **Model pre-selection** — default foundation/embedding model counts used by `ModelsPreSelector` extracted into a new `PreSelectorConstants` (`ai4rag.utils.constants`).

### Fixed
- **Text extraction / OCR** — fail fast with bake instructions when `DOCLING_ARTIFACTS_PATH` is set but RapidOCR ONNX models are missing; current PyPI `rapidocr` wheels no longer ship model files (bake via `tmp/Containerfile.autorag-dev`).
- **Vector store (pgvector)** — embedding models whose dimension exceeds pgvector's 2000-dimension HNSW/IVFFlat index cap are no longer rejected at construction; `PGVectorStore` now skips building the HNSW index above the limit and logs a warning, falling back to an exact sequential scan (storage, keyword search, and hybrid fusion are unaffected).
- **Vector store (pgvector)** — the connection pool and backing table are now created lazily on the first `add_documents()`/search call, guarded by double-checked locking, instead of during `__init__`; avoids idle pooled connections accumulating while the (potentially slow) embedding step runs before the first insert.
- **Model access** — `create_maas_client()` now normalizes `base_url` by stripping any trailing slash and appending `/v1` if missing, so both host-only and fully-qualified endpoint URLs work (previously the URL was used verbatim, requiring the exact `/v1`-suffixed endpoint).

### Removed
- **Vector store** — `ChromaVectorStore`, `MilvusVectorStore`, and `PGVectorStore` are no longer re-exported from `ai4rag.rag.vector_store`; import each directly from its backend module instead (`ai4rag.rag.vector_store.chroma`, `.milvus`, `.pgvector`). This keeps each backend's client library (`chromadb`, `pymilvus`, `psycopg`) — and its own import-time requirements, notably chromadb's minimum sqlite3 version — isolated to callers that actually use that backend. `BaseVectorStore`, `ChromaConfig`/`MilvusConfig`/`PGVectorConfig`, `get_vector_store`, `get_vector_store_config`, and `get_vector_store_env_vars` are unaffected and remain importable from `ai4rag.rag.vector_store`.
- **Internal utilities** — removed the unused `ai4rag.utils.validators` module.

## Migration notes

This is a breaking release. Upgrading from `0.12.x` requires the following changes:

1. **Vector store imports** — replace `from ai4rag.rag.vector_store import ChromaVectorStore/MilvusVectorStore/PGVectorStore` with a direct import from the backend module: `from ai4rag.rag.vector_store.chroma import ChromaVectorStore`, `.milvus import MilvusVectorStore`, or `.pgvector import PGVectorStore`. Config classes and factory functions (`ChromaConfig`, `MilvusConfig`, `PGVectorConfig`, `get_vector_store`, `get_vector_store_config`, `get_vector_store_env_vars`) are unaffected.
2. **OCR / audio ingestion** — if you use `extract_text` for scanned PDFs, images, or audio files, install the new `text-extraction` extra: `pip install ai4rag[text-extraction]` (or `uv sync --extra text-extraction`). These formats are no longer pulled in by the base install.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.13.0`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
