### PR TITLE
Fix gam opt warm start

### DIFF
--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -182,13 +182,9 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     # --- Input validation ---
     valid_strategies = {"random", "greedy", "balanced"}
     if warm_start_strategy not in valid_strategies:
-        raise ValueError(
-            f"warm_start_strategy must be one of {sorted(valid_strategies)}; got {warm_start_strategy!r}."
-        )
+        raise ValueError(f"warm_start_strategy must be one of {sorted(valid_strategies)}; got {warm_start_strategy!r}.")
     if warm_start_strategy == "balanced" and not fields_to_balance:
-        raise ValueError(
-            "fields_to_balance must be a non-empty list when warm_start_strategy='balanced'."
-        )
+        raise ValueError("fields_to_balance must be a non-empty list when warm_start_strategy='balanced'.")
 
     valid_modes = list(get_args(LLMJudgeMode))
     if llm_judge_mode not in valid_modes:
@@ -243,14 +239,13 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         n_modes = len(search_space_raw.get("search_mode", ["vector"]))
         if warm_start_strategy == "greedy":
             max_str_unique = max(
-                (len(vals) for vals in search_space_raw.values()
-                 if vals and isinstance(vals[0], (str, dict))),
+                (len(vals) for vals in search_space_raw.values() if vals and isinstance(vals[0], (str, dict))),
                 default=1,
             )
             n_random_nodes = max(4, 2 * max_str_unique)
         elif warm_start_strategy == "balanced":
             n_balanced = 1
-            for field in (fields_to_balance or []):
+            for field in fields_to_balance or []:
                 if field == "foundation_model":
                     n_balanced *= n_llms
                 elif field == "embedding_model":
@@ -263,9 +258,12 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         else:  # "random"
             n_random_nodes = max(4, n_llms * n_embeddings)
         _logger.info(
-            "Auto-computed n_random_nodes=%d for warm_start_strategy=%r "
-            "(n_llms=%d, n_embeddings=%d, n_modes=%d).",
-            n_random_nodes, warm_start_strategy, n_llms, n_embeddings, n_modes,
+            "Auto-computed n_random_nodes=%d for warm_start_strategy=%r " "(n_llms=%d, n_embeddings=%d, n_modes=%d).",
+            n_random_nodes,
+            warm_start_strategy,
+            n_llms,
+            n_embeddings,
+            n_modes,
         )
 
     evaluators = _build_evaluators(

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -88,6 +88,8 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     inference_max_threads: int = 10,
     indexing_pipeline_params: dict | None = None,
     llm_judge_mode: LLMJudgeMode = DEFAULT_LLM_JUDGE_MODE,
+    n_random_nodes: int = 4,
+    warm_start_strategy: Literal["mode_balanced", "model_mode_balanced"] = "mode_balanced",
 ) -> OptimizationResult:
     """Run a full AI4RAG optimization experiment and generate output artefacts.
 
@@ -142,6 +144,15 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
 
         Any mode other than ``"none"`` requires at least one foundation model
         and one embedding model in the search space.
+    n_random_nodes : int, default=4
+        Number of random configurations to evaluate before starting GAM iterations.
+        Passed directly to :class:`~ai4rag.core.hpo.gam_opt.GAMOptSettings`.
+    warm_start_strategy : {"mode_balanced", "model_mode_balanced"}, default="mode_balanced"
+        Controls how the initial random nodes are ordered across buckets.
+        ``"mode_balanced"`` round-robins across ``search_mode`` values;
+        ``"model_mode_balanced"`` round-robins across
+        ``(foundation_model, embedding_model, search_mode)`` triples.
+        Passed directly to :class:`~ai4rag.core.hpo.gam_opt.GAMOptSettings`.
 
     Returns
     -------
@@ -219,7 +230,11 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     max_rag_patterns = settings.get("max_number_of_rag_patterns", DEFAULT_MAX_RAG_PATTERNS)
     if isinstance(max_rag_patterns, str):
         max_rag_patterns = int(max_rag_patterns.strip())
-    optimizer_settings = GAMOptSettings(max_evals=max_rag_patterns)
+    optimizer_settings = GAMOptSettings(
+        max_evals=max_rag_patterns,
+        n_random_nodes=n_random_nodes,
+        warm_start_strategy=warm_start_strategy,
+    )
 
     event_handler = KFPEventHandler()
 

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -88,8 +88,9 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     inference_max_threads: int = 10,
     indexing_pipeline_params: dict | None = None,
     llm_judge_mode: LLMJudgeMode = DEFAULT_LLM_JUDGE_MODE,
-    warm_start_strategy: Literal["mode_balanced", "model_mode_balanced"] = "mode_balanced",
+    warm_start_strategy: Literal["random", "greedy", "balanced"] = "random",
     n_random_nodes: int | None = None,
+    fields_to_balance: list[str] | None = None,
 ) -> OptimizationResult:
     """Run a full AI4RAG optimization experiment and generate output artefacts.
 
@@ -144,26 +145,24 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
 
         Any mode other than ``"none"`` requires at least one foundation model
         and one embedding model in the search space.
-    warm_start_strategy : {"mode_balanced", "model_mode_balanced"}, default="mode_balanced"
-        Controls how the initial random nodes are ordered across buckets.
-        ``"mode_balanced"`` round-robins across ``search_mode`` values;
-        ``"model_mode_balanced"`` round-robins across
-        ``(foundation_model, embedding_model, search_mode)`` triples.
+    warm_start_strategy : {"random", "greedy", "balanced"}, default="random"
+        Controls how the initial random nodes are selected/ordered.
+        ``"random"``   — shuffled order, no reordering.
+        ``"greedy"``   — greedy selection so every string column value appears >= 2 times.
+        ``"balanced"`` — round-robin across ``fields_to_balance`` value tuples.
         Passed directly to :class:`~ai4rag.core.hpo.gam_opt.GAMOptSettings`.
     n_random_nodes : int | None, default=None
         Number of random configurations to evaluate before starting GAM iterations.
-        When ``None`` (default), derived automatically from the search space so that
-        every model and search mode appears at least once before GAM training:
+        When ``None`` (default), derived automatically:
 
-        - ``"mode_balanced"`` (preset *speed*):
-          ``max(4, n_llms * n_embeddings)`` — enough slots for all
-          (foundation_model, embedding_model) pairs to each appear at least once
-          across the balanced search_mode round-robin.
-        - ``"model_mode_balanced"`` (preset *balanced*):
-          ``max(8, n_modes * n_llms * n_embeddings)`` — one slot per
-          (foundation_model, embedding_model, search_mode) triple.
+        - ``"random"``  : ``max(4, n_llms * n_embeddings)``
+        - ``"greedy"``  : ``max(4, 2 * max_unique_values_per_string_column)``
+        - ``"balanced"``: ``max(8, product of unique values for fields_to_balance)``
 
         Pass an explicit integer only when you need to override the formula.
+    fields_to_balance : list[str] | None, default=None
+        Required when ``warm_start_strategy="balanced"``. Names of search space fields
+        whose unique value combinations are balanced by round-robin in the initial phase.
 
     Returns
     -------
@@ -181,6 +180,16 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         If ``optimization_settings`` has invalid types.
     """
     # --- Input validation ---
+    valid_strategies = {"random", "greedy", "balanced"}
+    if warm_start_strategy not in valid_strategies:
+        raise ValueError(
+            f"warm_start_strategy must be one of {sorted(valid_strategies)}; got {warm_start_strategy!r}."
+        )
+    if warm_start_strategy == "balanced" and not fields_to_balance:
+        raise ValueError(
+            "fields_to_balance must be a non-empty list when warm_start_strategy='balanced'."
+        )
+
     valid_modes = list(get_args(LLMJudgeMode))
     if llm_judge_mode not in valid_modes:
         raise ValueError(f"llm_judge_mode {llm_judge_mode!r} is not supported. Select one of {valid_modes}.")
@@ -228,18 +237,30 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
 
     search_space = AI4RAGSearchSpace(params=params)
 
-    # Derive n_random_nodes from the search space when not explicitly overridden.
-    # mode_balanced:       max(4, n_llms × n_embeddings)
-    # model_mode_balanced: max(8, n_modes × n_llms × n_embeddings)
-    #   chunking_method is not balanced explicitly; the floor of 8 is large enough
-    #   that all chunking methods appear at least once via the random shuffle.
     if n_random_nodes is None:
         n_llms = len(foundation_models)
         n_embeddings = len(embedding_models)
         n_modes = len(search_space_raw.get("search_mode", ["vector"]))
-        if warm_start_strategy == "model_mode_balanced":
-            n_random_nodes = max(8, n_modes * n_llms * n_embeddings)
-        else:
+        if warm_start_strategy == "greedy":
+            max_str_unique = max(
+                (len(vals) for vals in search_space_raw.values()
+                 if vals and isinstance(vals[0], (str, dict))),
+                default=1,
+            )
+            n_random_nodes = max(4, 2 * max_str_unique)
+        elif warm_start_strategy == "balanced":
+            n_balanced = 1
+            for field in (fields_to_balance or []):
+                if field == "foundation_model":
+                    n_balanced *= n_llms
+                elif field == "embedding_model":
+                    n_balanced *= n_embeddings
+                elif field == "search_mode":
+                    n_balanced *= n_modes
+                else:
+                    n_balanced *= 2
+            n_random_nodes = max(8, n_balanced)
+        else:  # "random"
             n_random_nodes = max(4, n_llms * n_embeddings)
         _logger.info(
             "Auto-computed n_random_nodes=%d for warm_start_strategy=%r "
@@ -264,6 +285,7 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         max_evals=max_rag_patterns,
         n_random_nodes=n_random_nodes,
         warm_start_strategy=warm_start_strategy,
+        fields_to_balance=fields_to_balance,
     )
 
     event_handler = KFPEventHandler()

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -88,8 +88,8 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     inference_max_threads: int = 10,
     indexing_pipeline_params: dict | None = None,
     llm_judge_mode: LLMJudgeMode = DEFAULT_LLM_JUDGE_MODE,
-    n_random_nodes: int = 4,
     warm_start_strategy: Literal["mode_balanced", "model_mode_balanced"] = "mode_balanced",
+    n_random_nodes: int | None = None,
 ) -> OptimizationResult:
     """Run a full AI4RAG optimization experiment and generate output artefacts.
 
@@ -144,15 +144,26 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
 
         Any mode other than ``"none"`` requires at least one foundation model
         and one embedding model in the search space.
-    n_random_nodes : int, default=4
-        Number of random configurations to evaluate before starting GAM iterations.
-        Passed directly to :class:`~ai4rag.core.hpo.gam_opt.GAMOptSettings`.
     warm_start_strategy : {"mode_balanced", "model_mode_balanced"}, default="mode_balanced"
         Controls how the initial random nodes are ordered across buckets.
         ``"mode_balanced"`` round-robins across ``search_mode`` values;
         ``"model_mode_balanced"`` round-robins across
         ``(foundation_model, embedding_model, search_mode)`` triples.
         Passed directly to :class:`~ai4rag.core.hpo.gam_opt.GAMOptSettings`.
+    n_random_nodes : int | None, default=None
+        Number of random configurations to evaluate before starting GAM iterations.
+        When ``None`` (default), derived automatically from the search space so that
+        every model and search mode appears at least once before GAM training:
+
+        - ``"mode_balanced"`` (preset *speed*):
+          ``max(4, n_llms * n_embeddings)`` — enough slots for all
+          (foundation_model, embedding_model) pairs to each appear at least once
+          across the balanced search_mode round-robin.
+        - ``"model_mode_balanced"`` (preset *balanced*):
+          ``max(8, n_modes * n_llms * n_embeddings)`` — one slot per
+          (foundation_model, embedding_model, search_mode) triple.
+
+        Pass an explicit integer only when you need to override the formula.
 
     Returns
     -------
@@ -216,6 +227,25 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
         params.append(Parameter(param_name, "C", values=values))
 
     search_space = AI4RAGSearchSpace(params=params)
+
+    # Derive n_random_nodes from the search space when not explicitly overridden.
+    # mode_balanced:       max(4, n_llms × n_embeddings)
+    # model_mode_balanced: max(8, n_modes × n_llms × n_embeddings)
+    #   chunking_method is not balanced explicitly; the floor of 8 is large enough
+    #   that all chunking methods appear at least once via the random shuffle.
+    if n_random_nodes is None:
+        n_llms = len(foundation_models)
+        n_embeddings = len(embedding_models)
+        n_modes = len(search_space_raw.get("search_mode", ["vector"]))
+        if warm_start_strategy == "model_mode_balanced":
+            n_random_nodes = max(8, n_modes * n_llms * n_embeddings)
+        else:
+            n_random_nodes = max(4, n_llms * n_embeddings)
+        _logger.info(
+            "Auto-computed n_random_nodes=%d for warm_start_strategy=%r "
+            "(n_llms=%d, n_embeddings=%d, n_modes=%d).",
+            n_random_nodes, warm_start_strategy, n_llms, n_embeddings, n_modes,
+        )
 
     evaluators = _build_evaluators(
         llm_judge_mode=llm_judge_mode,

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -75,6 +75,48 @@ class OptimizationResult:
     evaluations: list
 
 
+def _compute_n_random_nodes(
+    warm_start_strategy: str,
+    search_space_raw: dict,
+    fields_to_balance: list[str] | None,
+    foundation_models: list,
+    embedding_models: list,
+) -> int:
+    """Auto-compute n_random_nodes from search space dimensions when not supplied explicitly."""
+    n_llms = len(foundation_models)
+    n_embeddings = len(embedding_models)
+    n_modes = len(search_space_raw.get("search_mode", ["vector"]))
+    if warm_start_strategy == "greedy":
+        max_str_unique = max(
+            (len(vals) for vals in search_space_raw.values() if vals and isinstance(vals[0], (str, dict))),
+            default=1,
+        )
+        result = max(4, 2 * max_str_unique)
+    elif warm_start_strategy == "balanced":
+        n_balanced = 1
+        for field in fields_to_balance or []:
+            if field == "foundation_model":
+                n_balanced *= n_llms
+            elif field == "embedding_model":
+                n_balanced *= n_embeddings
+            elif field == "search_mode":
+                n_balanced *= n_modes
+            else:
+                n_balanced *= 2
+        result = max(8, n_balanced)
+    else:  # "random"
+        result = max(4, n_llms * n_embeddings)
+    _logger.info(
+        "Auto-computed n_random_nodes=%d for warm_start_strategy=%r (n_llms=%d, n_embeddings=%d, n_modes=%d).",
+        result,
+        warm_start_strategy,
+        n_llms,
+        n_embeddings,
+        n_modes,
+    )
+    return result
+
+
 def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments
     extracted_text_path: str | Path,
     test_data_path: str | Path,
@@ -234,36 +276,8 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     search_space = AI4RAGSearchSpace(params=params)
 
     if n_random_nodes is None:
-        n_llms = len(foundation_models)
-        n_embeddings = len(embedding_models)
-        n_modes = len(search_space_raw.get("search_mode", ["vector"]))
-        if warm_start_strategy == "greedy":
-            max_str_unique = max(
-                (len(vals) for vals in search_space_raw.values() if vals and isinstance(vals[0], (str, dict))),
-                default=1,
-            )
-            n_random_nodes = max(4, 2 * max_str_unique)
-        elif warm_start_strategy == "balanced":
-            n_balanced = 1
-            for field in fields_to_balance or []:
-                if field == "foundation_model":
-                    n_balanced *= n_llms
-                elif field == "embedding_model":
-                    n_balanced *= n_embeddings
-                elif field == "search_mode":
-                    n_balanced *= n_modes
-                else:
-                    n_balanced *= 2
-            n_random_nodes = max(8, n_balanced)
-        else:  # "random"
-            n_random_nodes = max(4, n_llms * n_embeddings)
-        _logger.info(
-            "Auto-computed n_random_nodes=%d for warm_start_strategy=%r " "(n_llms=%d, n_embeddings=%d, n_modes=%d).",
-            n_random_nodes,
-            warm_start_strategy,
-            n_llms,
-            n_embeddings,
-            n_modes,
+        n_random_nodes = _compute_n_random_nodes(
+            warm_start_strategy, search_space_raw, fields_to_balance, foundation_models, embedding_models
         )
 
     evaluators = _build_evaluators(

--- a/ai4rag/components/optimization/rag_templates_optimization.py
+++ b/ai4rag/components/optimization/rag_templates_optimization.py
@@ -317,12 +317,23 @@ def run_rag_optimization(  # pylint: disable=too-many-locals,too-many-arguments,
     # --- Run the optimization loop ---
     rag_exp.search()
 
+    # --- Select patterns for the leaderboard ---
+    patterns_raw = event_handler.patterns
+    if warm_start_strategy in ("greedy", "balanced") and hasattr(rag_exp, "optimizer"):
+        opt = rag_exp.optimizer
+        patterns_raw = _select_patterns_for_leaderboard(
+            patterns=patterns_raw,
+            warm_start_count=opt.warm_start_evaluation_count,
+            effective_warm_start=opt._compute_warm_start_effective_target(),
+            max_rag_patterns=max_rag_patterns,
+        )
+
     # --- Generate output artefacts ---
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     patterns = _generate_output_artifacts(
-        patterns_raw=event_handler.patterns,
+        patterns_raw=patterns_raw,
         output_dir=output_dir,
         input_data_key=input_data_key,
         test_data_key=test_data_key,
@@ -405,6 +416,51 @@ def _build_evaluators(  # pylint: disable=too-many-arguments,too-many-positional
         _logger.info("RAGAS evaluator enabled with model: %s", ragas_model.model_id)
 
     return evaluators
+
+
+def _get_pattern_score(pattern: dict) -> float:
+    """Extract the optimization metric mean score from a pattern dict."""
+    metrics = pattern.get("payload", {}).get("evaluation", {}).get("metrics", [])
+    for m in metrics:
+        if m.get("optimization_metric"):
+            score = m.get("scores", {}).get("mean")
+            if score is not None:
+                return float(score)
+    return 0.0
+
+
+def _select_patterns_for_leaderboard(
+    patterns: list[dict],
+    warm_start_count: int,
+    effective_warm_start: int,
+    max_rag_patterns: int,
+) -> list[dict]:
+    """Select the final patterns for the leaderboard from warm-start and GAM evaluations.
+
+    Takes the top ``effective_warm_start // 4`` patterns from the warm-start phase
+    and the top ``max_rag_patterns - effective_warm_start // 4`` from the GAM phase,
+    ordered best-first within each group.
+    """
+    n_from_warmstart = effective_warm_start // 4
+    n_from_gam = max_rag_patterns - n_from_warmstart
+
+    warm_start_patterns = patterns[:warm_start_count]
+    gam_patterns = patterns[warm_start_count:]
+
+    top_warmstart = sorted(warm_start_patterns, key=_get_pattern_score, reverse=True)[:n_from_warmstart]
+    top_gam = sorted(gam_patterns, key=_get_pattern_score, reverse=True)[:n_from_gam]
+
+    _logger.info(
+        "Pattern selection for leaderboard: %d from warm start (top %d of %d) + "
+        "%d from GAM iterations (top %d of %d).",
+        len(top_warmstart),
+        n_from_warmstart,
+        len(warm_start_patterns),
+        len(top_gam),
+        n_from_gam,
+        len(gam_patterns),
+    )
+    return top_warmstart + top_gam
 
 
 def _generate_output_artifacts(

--- a/ai4rag/core/experiment/experiment.py
+++ b/ai4rag/core/experiment/experiment.py
@@ -739,6 +739,8 @@ class AI4RAGExperiment:
             final_error_msg = self._exception_handler.get_final_error_msg()
             raise RAGExperimentError(final_error_msg) from err
 
+        self.optimizer = optimizer
+
         self.event_handler.on_status_change(
             level=LogLevel.INFO,
             message="Experiment optimization process finished.",

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -397,15 +397,22 @@ class GAMOptimizer(BaseOptimizer):
             if score is not None:
                 successful_evaluations += 1
             self._evaluated_combinations.append(params)
-            params_with_score = params | {"score": score}
-            self.evaluations.append(params_with_score)
+            self.evaluations.append(params | {"score": score})
 
             if len(self.evaluations) == self.max_iterations:
                 break
 
+        self._log_uncovered_values(discrete_cols_in_space, self.evaluations, self.settings.n_random_nodes)
+
+    @staticmethod
+    def _log_uncovered_values(
+        discrete_cols_in_space: dict[str, set],
+        evaluations: list[dict],
+        n_random_nodes: int,
+    ) -> None:
         uncovered_by_col: dict[str, list[str]] = {}
         for col, vals_in_space in discrete_cols_in_space.items():
-            covered = {_str_val(e.get(col)) for e in self.evaluations if e.get("score") is not None}
+            covered = {_str_val(e.get(col)) for e in evaluations if e.get("score") is not None}
             uncovered = vals_in_space - covered
             if uncovered:
                 uncovered_by_col[col] = sorted(uncovered)
@@ -413,7 +420,7 @@ class GAMOptimizer(BaseOptimizer):
             logger.warning(
                 "n_random_nodes=%d was too small to cover all discrete column values. "
                 "Uncovered values by column: %s. Consider increasing n_random_nodes.",
-                self.settings.n_random_nodes,
+                n_random_nodes,
                 uncovered_by_col,
             )
 

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -3,14 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
 import random
+from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from math import ceil
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 import numpy as np
 import pandas as pd
 from pygam import LinearGAM
+from pygam import f as gam_f
+from pygam import s as gam_s
 from sklearn.preprocessing import LabelEncoder
 
 from ai4rag import logger
@@ -18,6 +21,32 @@ from ai4rag.core.hpo.base_optimizer import BaseOptimizer, FailedIterationError, 
 from ai4rag.search_space.src.search_space import SearchSpace
 
 __all__ = ["GAMOptSettings", "GAMOptimizer"]
+
+
+def _serialize_dict_col(series: pd.Series) -> pd.Series:
+    """Serialize dict-valued cells to their model_id string (or str(x) fallback)."""
+    if series.apply(lambda x: isinstance(x, dict)).any():
+        return series.apply(lambda x: x.get("model_id", str(x)) if isinstance(x, dict) else x)
+    return series
+
+
+def _round_robin(combinations: list[dict], key_fn: Callable[[dict], Any]) -> list[dict]:
+    """Re-order combinations by round-robin across buckets determined by key_fn."""
+    buckets: dict[Any, deque] = defaultdict(deque)
+    for c in combinations:
+        buckets[key_fn(c)].append(c)
+    bucket_list = list(buckets.values())
+    balanced: list[dict] = []
+    i = 0
+    while bucket_list:
+        idx = i % len(bucket_list)
+        bucket = bucket_list[idx]
+        if bucket:
+            balanced.append(bucket.popleft())
+            i += 1
+        else:
+            bucket_list.pop(idx)
+    return balanced
 
 
 @dataclass
@@ -33,15 +62,17 @@ class GAMOptSettings(OptimizerSettings):
         Maximum number of evaluations performed during optimization process.
     n_random_nodes : int, default=4
         Number of random configurations to evaluate before starting GAM iterations.
-        The initial sample is stratified: for every string-valued categorical
-        parameter (e.g. ``search_mode``, ``chunking_method``, ``ranker_strategy``),
-        at least one configuration for each unique value is guaranteed to appear
-        before the random fill, regardless of raw search space imbalance.
-        Integer/float parameters are not stratified.  Set this to at least the
-        number of unique values of the most varied string parameter to guarantee
-        full categorical coverage; a warning is emitted when the value is too small.
+        Selection is balanced across search_mode values (mode_balanced strategy) or
+        across (foundation_model, embedding_model, search_mode) triples
+        (model_mode_balanced strategy), ensuring the GAM receives representative
+        signal on the most impactful categorical dimensions before training begins.
     evals_per_trial : int, default=1
         Number of configurations to evaluate per GAM iteration.
+    warm_start_strategy : {"mode_balanced", "model_mode_balanced"}, default="mode_balanced"
+        Controls how the initial n_random_nodes observations are ordered.
+        "mode_balanced"        — round-robin across search_mode values.
+        "model_mode_balanced"  — round-robin across (foundation_model,
+                                 embedding_model, search_mode) triples.
     random_state : int, default=64
         Inherited from OptimizerSettings. Controls shuffle order of initial
         random exploration phase. Does NOT control GAM model randomness
@@ -50,6 +81,15 @@ class GAMOptSettings(OptimizerSettings):
 
     n_random_nodes: int = 4
     evals_per_trial: int = 1
+    warm_start_strategy: Literal["mode_balanced", "model_mode_balanced"] = "mode_balanced"
+
+    def __post_init__(self) -> None:
+        valid = {"mode_balanced", "model_mode_balanced"}
+        if self.warm_start_strategy not in valid:
+            raise ValueError(
+                f"warm_start_strategy must be one of {sorted(valid)}; "
+                f"got {self.warm_start_strategy!r}."
+            )
 
 
 class GAMOptimizer(BaseOptimizer):
@@ -93,7 +133,7 @@ class GAMOptimizer(BaseOptimizer):
         self.settings = settings
         self.evaluations = []
         self._evaluated_combinations = []
-        self._encoders_with_columns: list[tuple[str, LabelEncoder]] = []
+        self._typed_encoders_with_columns: list[tuple[str, LabelEncoder]] = []
 
         if known_observations:
             self._load_known_observations(known_observations)
@@ -198,15 +238,11 @@ class GAMOptimizer(BaseOptimizer):
         already-successful evaluations count toward the n_random_nodes target
         and already-evaluated combinations are excluded from candidates.
 
-        The selection is stratified: combinations that introduce at least one new
-        unique value for any categorical (string-valued) parameter are moved to the
-        front of the queue before the random fill. This guarantees that every
-        distinct categorical value (e.g. ``search_mode="vector"`` vs
-        ``search_mode="hybrid"``) is evaluated at least once before GAM training
-        begins, regardless of how skewed the raw search space is.
-
-        A warning is logged when ``n_random_nodes`` is smaller than the estimated
-        minimum required to guarantee full categorical coverage.
+        The selection is balanced: combinations are ordered by round-robin across
+        search_mode values (mode_balanced) or across (foundation_model,
+        embedding_model, search_mode) triples (model_mode_balanced), ensuring
+        the GAM receives representative signal on the most impactful categorical
+        dimensions before training begins.
         """
         successful_evaluations = sum(1 for e in self.evaluations if e["score"] is not None)
 
@@ -224,26 +260,12 @@ class GAMOptimizer(BaseOptimizer):
         combinations_local = [c for c in copy(self._search_space.combinations) if c not in self._evaluated_combinations]
         random.Random(self.settings.random_state).shuffle(combinations_local)
 
-        # Values already covered by successful warm-start observations so
-        # stratification does not waste early slots on redundant coverage.
-        already_covered: dict[str, set[str]] = {}
-        for eval_entry in self.evaluations:
-            if eval_entry.get("score") is not None:
-                for col, val in eval_entry.items():
-                    if col != "score" and isinstance(val, str):
-                        already_covered.setdefault(col, set()).add(val)
+        if self.settings.warm_start_strategy == "model_mode_balanced":
+            combinations_local = self._get_model_mode_balanced_combinations(combinations_local)
+        else:  # "mode_balanced"
+            combinations_local = self._get_mode_balanced_combinations(combinations_local)
 
-        min_needed = self._min_n_random_nodes_for_coverage(combinations_local, already_covered)
-        if min_needed > self.settings.n_random_nodes:
-            logger.warning(
-                "n_random_nodes=%d may be too small to guarantee full categorical coverage "
-                "(estimated minimum: %d). Consider increasing n_random_nodes.",
-                self.settings.n_random_nodes,
-                min_needed,
-            )
-
-        combinations_local = self._get_stratified_combinations(combinations_local, already_covered)
-
+        modes_in_space = {c.get("search_mode") for c in combinations_local}
         gen = (x for x in combinations_local)
 
         while successful_evaluations < self.settings.n_random_nodes:
@@ -258,170 +280,117 @@ class GAMOptimizer(BaseOptimizer):
             if len(self.evaluations) == self.max_iterations:
                 break
 
-    @staticmethod
-    def _min_n_random_nodes_for_coverage(
-        combinations: list[dict],
-        already_covered: dict[str, set[str]] | None = None,
-    ) -> int:
-        """
-        Estimate the minimum ``n_random_nodes`` required for stratified coverage.
-
-        Returns the maximum number of uncovered unique values across all
-        string-typed categorical parameters, after accounting for values already
-        seen in warm-start observations.
-
-        Parameters
-        ----------
-        combinations : list[dict]
-            Candidate combinations to stratify over.
-        already_covered : dict[str, set[str]], optional
-            String-param values already seen in successful warm-start evaluations.
-
-        Returns
-        -------
-        int
-            Estimated lower bound on ``n_random_nodes`` needed for full coverage.
-        """
-        if not combinations:
-            return 0
-        categorical_cols = [col for col, val in combinations[0].items() if isinstance(val, str)]
-        if not categorical_cols:
-            return 1
-        seen = already_covered or {}
-        return max(len({c[col] for c in combinations} - seen.get(col, set())) for col in categorical_cols)
+        modes_covered = {e.get("search_mode") for e in self.evaluations if e.get("score") is not None}
+        uncovered = modes_in_space - modes_covered
+        if uncovered:
+            logger.warning(
+                "n_random_nodes=%d was too small to cover all search_mode values. "
+                "Uncovered modes: %s. Consider increasing n_random_nodes.",
+                self.settings.n_random_nodes,
+                sorted(str(m) for m in uncovered),
+            )
 
     @staticmethod
-    def _get_stratified_combinations(
-        combinations: list[dict],
-        already_seen: dict[str, set[str]] | None = None,
-    ) -> list[dict]:
+    def _get_mode_balanced_combinations(combinations: list[dict]) -> list[dict]:
+        """Order combinations by round-robin across search_mode values."""
+        return _round_robin(combinations, lambda c: c.get("search_mode", None))
+
+    @staticmethod
+    def _get_model_mode_balanced_combinations(combinations: list[dict]) -> list[dict]:
+        """Order combinations by round-robin across (foundation_model, embedding_model, search_mode) triples."""
+        def _model_id(v: object) -> str:
+            return v.get("model_id", str(v)) if isinstance(v, dict) else str(v)
+
+        def _key(c: dict) -> tuple:
+            return (
+                _model_id(c.get("foundation_model", None)),
+                _model_id(c.get("embedding_model", None)),
+                c.get("search_mode", None),
+            )
+
+        return _round_robin(combinations, _key)
+
+    def _prepare_typed_encoder(self) -> None:
         """
-        Re-order *already-shuffled* combinations so the first entries collectively
-        cover every unique value of each string-valued (semantic categorical)
-        parameter before falling back to the original shuffle order.
+        Fit label encoders on the full search space for all varying columns.
 
-        Only string-typed columns are stratified over. Integer/float parameters
-        (``chunk_size``, ``ranker_k``, etc.) are excluded because they tend to have
-        high cardinality; including them would consume all ``n_random_nodes`` slots
-        covering their many unique values and crowd out the minority string-param
-        values the stratification is meant to protect.
-
-        This prevents the initial random phase from being biased toward
-        over-represented parameter values (e.g. ``search_mode="hybrid"`` in a
-        search space where hybrid configurations outnumber vector ones 2:1).
-
-        Parameters
-        ----------
-        combinations : list[dict]
-            Shuffled list of parameter combinations.
-        already_seen : dict[str, set[str]], optional
-            String-param values already covered by successful warm-start
-            observations.  These are treated as pre-seen so stratification does
-            not waste early slots on redundant coverage.
-
-        Returns
-        -------
-        list[dict]
-            The same combinations with diversity-maximising entries moved to the
-            front; the relative order within each group (stratified / remainder)
-            is preserved from the input shuffle.
+        Dict-valued columns (model objects) are serialized to their model_id
+        strings. Constant columns (single unique value) are dropped — they
+        carry no signal for the GAM.
         """
-        if not combinations:
-            return combinations
-
-        # Stratify only string-typed parameters (search_mode, chunking_method,
-        # ranker_strategy, …). Integer/float params (chunk_size, ranker_k, …) are
-        # quantitative: stratifying them would consume initial slots covering their
-        # many unique values, leaving no room for minority string-param values.
-        categorical_cols = [col for col, val in combinations[0].items() if isinstance(val, str)]
-        if not categorical_cols:
-            return combinations
-
-        all_values = {col: {c[col] for c in combinations} for col in categorical_cols}
-        # Intersect with all_values so warm-start values absent from the remaining
-        # combinations do not prevent the all_covered check from ever firing.
-        seen: dict[str, set[str]] = {
-            col: (set(already_seen.get(col, ())) & all_values[col]) if already_seen else set()
-            for col in categorical_cols
-        }
-
-        stratified: list[dict] = []
-        remainder: list[dict] = []
-
-        for combo in combinations:
-            all_covered = all(seen[col] == all_values[col] for col in categorical_cols)
-            if all_covered:
-                remainder.append(combo)
-                continue
-
-            introduces_new = any(combo[col] not in seen[col] for col in categorical_cols)
-            if introduces_new:
-                stratified.append(combo)
-                for col in categorical_cols:
-                    seen[col].add(combo[col])
-            else:
-                remainder.append(combo)
-
-        return stratified + remainder
+        if self._typed_encoders_with_columns:
+            return
+        logger.debug("Preparing typed encoder for %s...", self.__class__.__name__)
+        df = pd.DataFrame(data=self._search_space.combinations)
+        for col in df.columns:
+            df[col] = _serialize_dict_col(df[col])
+        varying_cols = [c for c in df.columns if df[c].nunique() > 1]
+        for col in varying_cols:
+            self._typed_encoders_with_columns.append(
+                (col, LabelEncoder().fit(df[col]))
+            )
+        logger.debug("Typed encoder for %s has been prepared.", self.__class__.__name__)
 
     # pylint: disable=too-many-locals
     def _run_iteration(self) -> None:
         """
-        Run single optimization iteration that consists of training GAM model
-        to predict score for remaining nodes in the solutions space and choose
-        the best n ones for further evaluation.
+        Run single optimization iteration using a factor-typed LinearGAM.
+
+        String-typed columns receive f() (factor) terms; numeric columns receive
+        s() (spline) terms. Constant columns are excluded. Dict-valued model
+        columns are serialized to model_id strings before encoding.
         """
-        self._prepare_encoder()
-        df = pd.DataFrame(data=self.evaluations)  # --> These are already known observations with scores.
+        self._prepare_typed_encoder()
+        encoders = self._typed_encoders_with_columns
+
+        if not encoders:
+            return
+
+        df = pd.DataFrame(data=self.evaluations)
         df = df[df["score"].notna()].copy()
         data = df.drop(columns=["score"])
+        for col in data.columns:
+            data[col] = _serialize_dict_col(data[col])
         target = df["score"]
 
-        x_train_enc = []
-        for column, encoder in self._encoders_with_columns:
-            x_train_enc.append(encoder.transform(data[column]))
-        x_train_enc = np.column_stack(x_train_enc)
+        x_train_enc = np.column_stack(
+            [enc.transform(data[col]) for col, enc in encoders]
+        )
 
-        gam = LinearGAM()
+        terms = None
+        for i, (_, enc) in enumerate(encoders):
+            term = gam_f(i) if isinstance(enc.classes_[0], str) else gam_s(i)
+            terms = term if terms is None else terms + term
+
+        gam = LinearGAM(terms)
         gam.fit(x_train_enc, target)
 
         remaining_evaluations = self._get_remaining_evaluations(
             self._search_space.combinations, self._evaluated_combinations
         )
 
-        remaining_evaluations_df = pd.DataFrame(remaining_evaluations)
+        if not remaining_evaluations:
+            return
 
-        # Optimize encoding: build array directly
-        encoded_data_to_predict = np.column_stack(
-            [encoder.transform(remaining_evaluations_df[column]) for column, encoder in self._encoders_with_columns]
+        remaining_df = pd.DataFrame(remaining_evaluations)
+        for col in remaining_df.columns:
+            remaining_df[col] = _serialize_dict_col(remaining_df[col])
+
+        encoded = np.column_stack(
+            [enc.transform(remaining_df[col]) for col, enc in encoders]
         )
-
-        predictions = gam.predict(encoded_data_to_predict)
+        predictions = gam.predict(encoded)
 
         for idx, val in enumerate(remaining_evaluations):
             val["score"] = predictions[idx]
 
-        # Sort in descending order to get highest predictions first
         best_predictions = sorted(remaining_evaluations, key=lambda d: d["score"], reverse=True)
 
-        n_best_predictions = best_predictions[: self.settings.evals_per_trial]
-
-        for params in n_best_predictions:
+        for params in best_predictions[: self.settings.evals_per_trial]:
             params.pop("score", None)
             score = self._objective_function(params)
             self._evaluated_combinations.append(params)
             self.evaluations.append(params | {"score": score})
-
-    def _prepare_encoder(self) -> None:
-        """
-        Prepare encoder for the further processing based on all available combinations.
-        """
-        if not self._encoders_with_columns:
-            logger.debug("Preparing encoder for %s...", self.__class__.__name__)
-            df = pd.DataFrame(data=self._search_space.combinations)
-            for column in df.columns:
-                self._encoders_with_columns.append((column, LabelEncoder().fit(df[column])))
-            logger.debug("Encoder for %s has been prepared.", self.__class__.__name__)
 
     @staticmethod
     def _get_remaining_evaluations(all_combinations: list[dict], evaluations: list[dict]) -> list[dict]:

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -459,22 +459,29 @@ class GAMOptimizer(BaseOptimizer):
         str_cols = _get_discrete_column_values(combinations)
         other_str_fields = [col for col in str_cols if col not in fields_to_balance]
 
+        outer_buckets: dict[tuple, list[dict]] = defaultdict(list)
+        for c in combinations:
+            outer_buckets[_outer_key(c)].append(c)
+
         if other_str_fields:
-            def _inner_key(c: dict) -> tuple:
-                return tuple(_str_val(c.get(f)) for f in other_str_fields)
+            # Apply round-robin per non-balanced field in ascending cardinality order
+            # so the highest-cardinality field (e.g. chunk_size) dominates the cycling
+            # pattern.  Using a full-tuple key creates unique keys for every combination
+            # (single-item buckets), making _round_robin a no-op — so we must apply it
+            # one field at a time.
+            fields_by_cardinality = sorted(other_str_fields, key=lambda f: len(str_cols[f]))
 
-            outer_buckets: dict[tuple, list[dict]] = defaultdict(list)
-            for c in combinations:
-                outer_buckets[_outer_key(c)].append(c)
+            per_bucket_balanced: dict[tuple, list[dict]] = {}
+            for key, combs in outer_buckets.items():
+                result: list[dict] = list(combs)
+                for field in fields_by_cardinality:
+                    result = _round_robin(result, lambda c, f=field: _str_val(c.get(f)))
+                per_bucket_balanced[key] = result
+        else:
+            per_bucket_balanced = dict(outer_buckets)
 
-            per_bucket_balanced = {
-                key: _round_robin(combs, _inner_key)
-                for key, combs in outer_buckets.items()
-            }
-            ordered = [c for combs in per_bucket_balanced.values() for c in combs]
-            return _round_robin(ordered, _outer_key)
-
-        return _round_robin(combinations, _outer_key)
+        ordered = [c for combs in per_bucket_balanced.values() for c in combs]
+        return _round_robin(ordered, _outer_key)
 
     def _prepare_typed_encoder(self) -> None:
         """

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -29,6 +29,7 @@ def _serialize_dict_col(series: pd.Series) -> pd.Series:
     Handles both dict-valued models ({"model_id": "..."}, production) and
     model object instances with a model_id attribute (tests / direct API use).
     """
+
     def _needs_serialization(x: object) -> bool:
         return isinstance(x, dict) or hasattr(x, "model_id")
 
@@ -134,13 +135,10 @@ class GAMOptSettings(OptimizerSettings):
         valid = {"random", "greedy", "balanced"}
         if self.warm_start_strategy not in valid:
             raise ValueError(
-                f"warm_start_strategy must be one of {sorted(valid)}; "
-                f"got {self.warm_start_strategy!r}."
+                f"warm_start_strategy must be one of {sorted(valid)}; " f"got {self.warm_start_strategy!r}."
             )
         if self.warm_start_strategy == "balanced" and not self.fields_to_balance:
-            raise ValueError(
-                "fields_to_balance must be a non-empty list when warm_start_strategy='balanced'."
-            )
+            raise ValueError("fields_to_balance must be a non-empty list when warm_start_strategy='balanced'.")
 
 
 class GAMOptimizer(BaseOptimizer):
@@ -291,17 +289,14 @@ class GAMOptimizer(BaseOptimizer):
             if effective_budget < min_required:
                 raise ValueError(
                     f"n_random_nodes={self.settings.n_random_nodes} is too small for "
-                    f"warm_start_strategy='greedy': each string column value must appear "
+                    f"warm_start_strategy='greedy': each discrete column value must appear "
                     f"at least twice (max unique values per column: {max_unique}). "
                     f"Set n_random_nodes >= {min_required}."
                 )
 
         elif strategy == "balanced":
             fields_to_balance = self.settings.fields_to_balance or []
-            balanced_tuples = {
-                tuple(_str_val(c.get(f)) for f in fields_to_balance)
-                for c in combinations
-            }
+            balanced_tuples = {tuple(_str_val(c.get(f)) for f in fields_to_balance) for c in combinations}
             n_balanced = len(balanced_tuples)
             non_balanced = {col: vals for col, vals in str_cols.items() if col not in fields_to_balance}
             max_non_balanced = max((len(vals) for vals in non_balanced.values()), default=0)
@@ -445,9 +440,7 @@ class GAMOptimizer(BaseOptimizer):
         if not str_cols:
             return combinations
 
-        coverage: dict[str, dict[str, int]] = {
-            col: {val: 0 for val in vals} for col, vals in str_cols.items()
-        }
+        coverage: dict[str, dict[str, int]] = {col: {val: 0 for val in vals} for col, vals in str_cols.items()}
         if initial_coverage:
             for col, val_counts in initial_coverage.items():
                 if col in coverage:
@@ -456,10 +449,7 @@ class GAMOptimizer(BaseOptimizer):
                             coverage[col][val] = min(count, 2)
 
         def _gain(c: dict) -> int:
-            return sum(
-                1 for col, val_counts in coverage.items()
-                if val_counts.get(_str_val(c.get(col)), 0) < 2
-            )
+            return sum(1 for col, val_counts in coverage.items() if val_counts.get(_str_val(c.get(col)), 0) < 2)
 
         remaining_indices = list(range(len(combinations)))
         selected_indices: list[int] = []
@@ -536,9 +526,7 @@ class GAMOptimizer(BaseOptimizer):
             df[col] = _serialize_dict_col(df[col])
         varying_cols = [c for c in df.columns if df[c].nunique() > 1]
         for col in varying_cols:
-            self._typed_encoders_with_columns.append(
-                (col, LabelEncoder().fit(df[col]))
-            )
+            self._typed_encoders_with_columns.append((col, LabelEncoder().fit(df[col])))
         logger.debug("Typed encoder for %s has been prepared.", self.__class__.__name__)
 
     # pylint: disable=too-many-locals
@@ -568,9 +556,7 @@ class GAMOptimizer(BaseOptimizer):
                 data[col] = enc.classes_[0]
         target = df["score"]
 
-        x_train_enc = np.column_stack(
-            [enc.transform(data[col]) for col, enc in encoders]
-        )
+        x_train_enc = np.column_stack([enc.transform(data[col]) for col, enc in encoders])
 
         terms = None
         for i, (_, enc) in enumerate(encoders):
@@ -591,9 +577,7 @@ class GAMOptimizer(BaseOptimizer):
         for col in remaining_df.columns:
             remaining_df[col] = _serialize_dict_col(remaining_df[col])
 
-        encoded = np.column_stack(
-            [enc.transform(remaining_df[col]) for col, enc in encoders]
-        )
+        encoded = np.column_stack([enc.transform(remaining_df[col]) for col, enc in encoders])
         predictions = gam.predict(encoded)
 
         for idx, val in enumerate(remaining_evaluations):

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -277,12 +277,18 @@ class GAMOptimizer(BaseOptimizer):
 
         str_cols = _get_discrete_column_values(combinations)
 
+        # Already-successful known_observations count toward the coverage budget.
+        successful_known = sum(1 for e in self.evaluations if e.get("score") is not None)
+        # effective_budget: the larger of n_random_nodes and what known_observations
+        # already provide — if known obs alone meet the minimum, no raise is needed.
+        effective_budget = max(self.settings.n_random_nodes, successful_known)
+
         if strategy == "greedy":
             if not str_cols:
                 return
             max_unique = max(len(vals) for vals in str_cols.values())
             min_required = max(4, 2 * max_unique)
-            if self.settings.n_random_nodes < min_required:
+            if effective_budget < min_required:
                 raise ValueError(
                     f"n_random_nodes={self.settings.n_random_nodes} is too small for "
                     f"warm_start_strategy='greedy': each string column value must appear "
@@ -300,7 +306,7 @@ class GAMOptimizer(BaseOptimizer):
             non_balanced = {col: vals for col, vals in str_cols.items() if col not in fields_to_balance}
             max_non_balanced = max((len(vals) for vals in non_balanced.values()), default=0)
             min_required = max(4, n_balanced, max_non_balanced)
-            if self.settings.n_random_nodes < min_required:
+            if effective_budget < min_required:
                 raise ValueError(
                     f"n_random_nodes={self.settings.n_random_nodes} is too small for "
                     f"warm_start_strategy='balanced' with fields_to_balance={fields_to_balance!r}. "
@@ -366,14 +372,28 @@ class GAMOptimizer(BaseOptimizer):
         random.Random(self.settings.random_state).shuffle(combinations_local)
 
         if self.settings.warm_start_strategy == "greedy":
-            combinations_local = self._get_greedy_combinations(combinations_local, self.settings.n_random_nodes)
+            str_cols = _get_discrete_column_values(combinations_local)
+            initial_coverage: dict[str, dict[str, int]] = {
+                col: {val: 0 for val in vals} for col, vals in str_cols.items()
+            }
+            for obs in self.evaluations:
+                if obs.get("score") is None:
+                    continue
+                for col in initial_coverage:
+                    val = _str_val(obs.get(col))
+                    if val in initial_coverage[col]:
+                        initial_coverage[col][val] = min(initial_coverage[col][val] + 1, 2)
+            remaining_budget = self.settings.n_random_nodes - successful_evaluations
+            combinations_local = self._get_greedy_combinations(
+                combinations_local, remaining_budget, initial_coverage=initial_coverage
+            )
         elif self.settings.warm_start_strategy == "balanced":
             combinations_local = self._get_balanced_combinations(
                 combinations_local, self.settings.fields_to_balance or []
             )
         # "random": use shuffled list as-is
 
-        modes_in_space = {c.get("search_mode") for c in combinations_local}
+        discrete_cols_in_space = _get_discrete_column_values(combinations_local)
         gen = (x for x in combinations_local)
 
         while successful_evaluations < self.settings.n_random_nodes:
@@ -388,24 +408,35 @@ class GAMOptimizer(BaseOptimizer):
             if len(self.evaluations) == self.max_iterations:
                 break
 
-        modes_covered = {e.get("search_mode") for e in self.evaluations if e.get("score") is not None}
-        uncovered = modes_in_space - modes_covered
-        if uncovered:
+        uncovered_by_col: dict[str, list[str]] = {}
+        for col, vals_in_space in discrete_cols_in_space.items():
+            covered = {_str_val(e.get(col)) for e in self.evaluations if e.get("score") is not None}
+            uncovered = vals_in_space - covered
+            if uncovered:
+                uncovered_by_col[col] = sorted(uncovered)
+        if uncovered_by_col:
             logger.warning(
-                "n_random_nodes=%d was too small to cover all search_mode values. "
-                "Uncovered modes: %s. Consider increasing n_random_nodes.",
+                "n_random_nodes=%d was too small to cover all discrete column values. "
+                "Uncovered values by column: %s. Consider increasing n_random_nodes.",
                 self.settings.n_random_nodes,
-                sorted(str(m) for m in uncovered),
+                uncovered_by_col,
             )
 
     @staticmethod
-    def _get_greedy_combinations(combinations: list[dict], n: int) -> list[dict]:
+    def _get_greedy_combinations(
+        combinations: list[dict],
+        n: int,
+        initial_coverage: dict[str, dict[str, int]] | None = None,
+    ) -> list[dict]:
         """Greedily select n combinations ensuring every discrete column value appears >= 2 times.
 
         At each step the candidate with the highest coverage gain (number of discrete column
         values — string or numeric — whose current count is still below 2) is selected.
         Ties are broken by the shuffle order coming in. The n selected combinations are
         returned first, followed by the remaining combinations in their original (shuffled) order.
+
+        initial_coverage seeds the per-value counts so that values already covered by
+        known_observations are not redundantly targeted.
         """
         if not combinations or n <= 0:
             return combinations
@@ -417,6 +448,12 @@ class GAMOptimizer(BaseOptimizer):
         coverage: dict[str, dict[str, int]] = {
             col: {val: 0 for val in vals} for col, vals in str_cols.items()
         }
+        if initial_coverage:
+            for col, val_counts in initial_coverage.items():
+                if col in coverage:
+                    for val, count in val_counts.items():
+                        if val in coverage[col]:
+                            coverage[col][val] = min(count, 2)
 
         def _gain(c: dict) -> int:
             return sum(
@@ -524,6 +561,11 @@ class GAMOptimizer(BaseOptimizer):
         data = df.drop(columns=["score"])
         for col in data.columns:
             data[col] = _serialize_dict_col(data[col])
+        # known_observations may omit columns that vary in the search space; fill
+        # with the encoder's first class so transform() does not KeyError.
+        for col, enc in encoders:
+            if col not in data.columns:
+                data[col] = enc.classes_[0]
         target = df["score"]
 
         x_train_enc = np.column_stack(
@@ -537,9 +579,6 @@ class GAMOptimizer(BaseOptimizer):
 
         gam = LinearGAM(terms)
         gam.fit(x_train_enc, target)
-        print("#" * 100)
-        print(gam.terms)
-        print(encoders)
 
         remaining_evaluations = self._get_remaining_evaluations(
             self._search_space.combinations, self._evaluated_combinations

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -24,9 +24,23 @@ __all__ = ["GAMOptSettings", "GAMOptimizer"]
 
 
 def _serialize_dict_col(series: pd.Series) -> pd.Series:
-    """Serialize dict-valued cells to their model_id string (or str(x) fallback)."""
-    if series.apply(lambda x: isinstance(x, dict)).any():
-        return series.apply(lambda x: x.get("model_id", str(x)) if isinstance(x, dict) else x)
+    """Serialize model-valued cells to their model_id string.
+
+    Handles both dict-valued models ({"model_id": "..."}, production) and
+    model object instances with a model_id attribute (tests / direct API use).
+    """
+    def _needs_serialization(x: object) -> bool:
+        return isinstance(x, dict) or hasattr(x, "model_id")
+
+    def _to_model_id(x: object) -> object:
+        if isinstance(x, dict):
+            return x.get("model_id", str(x))
+        if hasattr(x, "model_id"):
+            return x.model_id
+        return x
+
+    if series.apply(_needs_serialization).any():
+        return series.apply(_to_model_id)
     return series
 
 
@@ -138,6 +152,8 @@ class GAMOptimizer(BaseOptimizer):
         if known_observations:
             self._load_known_observations(known_observations)
 
+        self._validate_n_random_nodes()
+
         self.max_iterations = self.settings.max_evals
 
     @property
@@ -201,6 +217,58 @@ class GAMOptimizer(BaseOptimizer):
         """
         iterations_limit = ceil((self.max_iterations - len(self.evaluations)) / self.settings.evals_per_trial)
         return iterations_limit
+
+    def _validate_n_random_nodes(self) -> None:
+        """Raise ValueError when n_random_nodes is below the required minimum for the strategy.
+
+        Counts unique foundation_model, embedding_model, and search_mode values in
+        the search space and enforces:
+
+        - mode_balanced:       n_random_nodes >= max(4, n_llms * n_embeddings)
+          The 2-level round-robin (outer: search_mode, inner: (llm, em) pair) can
+          only guarantee every model appears at least once when there are enough
+          slots — n_llms * n_embeddings evaluations total, regardless of n_modes.
+
+        - model_mode_balanced: n_random_nodes >= max(8, n_modes * n_llms * n_embeddings)
+          Round-robins across (llm, em, mode) triples; full coverage requires one slot
+          per triple. The floor of 8 ensures all chunking methods (not part of the key)
+          appear at least once via the random shuffle within each triple's bucket.
+        """
+        combinations = self._search_space.combinations
+        if not combinations:
+            return
+
+        def _unique_ids(key: str) -> int:
+            seen: set[str] = set()
+            for c in combinations:
+                v = c.get(key)
+                if v is None:
+                    continue
+                if isinstance(v, dict):
+                    seen.add(v.get("model_id", str(v)))
+                elif hasattr(v, "model_id"):
+                    seen.add(v.model_id)
+                else:
+                    seen.add(str(v))
+            return len(seen)
+
+        n_llms = _unique_ids("foundation_model")
+        n_embeddings = _unique_ids("embedding_model")
+        n_modes = _unique_ids("search_mode") or 1
+
+        if self.settings.warm_start_strategy == "model_mode_balanced":
+            recommended = max(8, n_modes * n_llms * n_embeddings)
+        else:  # mode_balanced
+            recommended = max(4, n_llms * n_embeddings)
+
+        if self.settings.n_random_nodes < recommended:
+            raise ValueError(
+                f"n_random_nodes={self.settings.n_random_nodes} is too small for "
+                f"warm_start_strategy={self.settings.warm_start_strategy!r} with "
+                f"n_llms={n_llms}, n_embeddings={n_embeddings}, n_modes={n_modes}. "
+                f"Set n_random_nodes >= {recommended} to ensure every model appears "
+                f"at least once before GAM training."
+            )
 
     def _load_known_observations(self, known_observations: list[dict]) -> None:
         """
@@ -292,14 +360,52 @@ class GAMOptimizer(BaseOptimizer):
 
     @staticmethod
     def _get_mode_balanced_combinations(combinations: list[dict]) -> list[dict]:
-        """Order combinations by round-robin across search_mode values."""
-        return _round_robin(combinations, lambda c: c.get("search_mode", None))
+        """Order by outer round-robin across search_mode and inner round-robin across (foundation_model, embedding_model) pairs.
+
+        Within each search_mode bucket, combinations are sorted so that distinct
+        (foundation_model, embedding_model) pairs appear before any pair repeats.
+        The outer round-robin then interleaves the two sorted mode lists. With
+        n_random_nodes >= n_llms * n_embeddings, every foundation_model and every
+        embedding_model is guaranteed to appear at least once before GAM training.
+        """
+        def _model_id(v: object) -> str:
+            if isinstance(v, dict):
+                return v.get("model_id", str(v))
+            return getattr(v, "model_id", str(v))
+
+        def _model_pair_key(c: dict) -> tuple:
+            return (_model_id(c.get("foundation_model")), _model_id(c.get("embedding_model")))
+
+        # Group by search_mode; within each mode apply inner round-robin by model pair
+        mode_buckets: dict[Any, list[dict]] = defaultdict(list)
+        for c in combinations:
+            mode_buckets[c.get("search_mode")].append(c)
+
+        per_mode_balanced = {
+            mode: _round_robin(combs, _model_pair_key)
+            for mode, combs in mode_buckets.items()
+        }
+
+        # Flatten preserving per-mode order, then outer round-robin interleaves modes.
+        # _round_robin preserves insertion order within each mode bucket, so the
+        # inner model-pair ordering is carried through the outer interleave.
+        ordered = [c for combs in per_mode_balanced.values() for c in combs]
+        return _round_robin(ordered, lambda c: c.get("search_mode"))
 
     @staticmethod
     def _get_model_mode_balanced_combinations(combinations: list[dict]) -> list[dict]:
-        """Order combinations by round-robin across (foundation_model, embedding_model, search_mode) triples."""
+        """Order combinations by round-robin across (foundation_model, embedding_model, search_mode) triples.
+
+        With n_random_nodes >= max(8, n_modes * n_llms * n_embeddings), every
+        (foundation_model, embedding_model, search_mode) triple is guaranteed to
+        appear at least once before GAM training. chunking_method is not part of the
+        key — each triple's bucket is shuffled randomly so all chunking methods
+        appear naturally with enough n_random_nodes.
+        """
         def _model_id(v: object) -> str:
-            return v.get("model_id", str(v)) if isinstance(v, dict) else str(v)
+            if isinstance(v, dict):
+                return v.get("model_id", str(v))
+            return getattr(v, "model_id", str(v))
 
         def _key(c: dict) -> tuple:
             return (
@@ -364,6 +470,9 @@ class GAMOptimizer(BaseOptimizer):
 
         gam = LinearGAM(terms)
         gam.fit(x_train_enc, target)
+        print("#" * 100)
+        print(gam.terms)
+        print(encoders)
 
         remaining_evaluations = self._get_remaining_evaluations(
             self._search_space.combinations, self._evaluated_combinations

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -74,8 +74,13 @@ def _str_val(v: object) -> str:
     return str(v)
 
 
-def _get_string_column_values(combinations: list[dict]) -> dict[str, set[str]]:
-    """Return {col: set_of_str_values} for all string-like columns in the combinations."""
+def _get_discrete_column_values(combinations: list[dict]) -> dict[str, set[str]]:
+    """Return {col: set_of_str_values} for all discrete columns in the combinations.
+
+    All parameter types are included — strings, model objects, numeric values — so
+    that coverage tracking works for columns like chunk_size and chunk_overlap as
+    well as string columns like chunking_method or search_mode.
+    """
     if not combinations:
         return {}
     result: dict[str, set[str]] = {}
@@ -83,8 +88,7 @@ def _get_string_column_values(combinations: list[dict]) -> dict[str, set[str]]:
         sample = next((c.get(col) for c in combinations if c.get(col) is not None), None)
         if sample is None:
             continue
-        if isinstance(sample, (str, dict)) or hasattr(sample, "model_id"):
-            result[col] = {_str_val(c.get(col)) for c in combinations}
+        result[col] = {_str_val(c.get(col)) for c in combinations}
     return result
 
 
@@ -109,7 +113,7 @@ class GAMOptSettings(OptimizerSettings):
         "greedy"   — greedily pick n combinations so every string column value
                      appears at least twice (raises if n_random_nodes is too small).
         "balanced" — round-robin across the tuple of fields_to_balance values;
-                     non-balanced string column values each appear at least once.
+                     non-balanced discrete column values each appear at least once.
                      Requires fields_to_balance to be set.
     fields_to_balance : list[str] | None, default=None
         Field names to balance by round-robin when warm_start_strategy="balanced".
@@ -255,12 +259,12 @@ class GAMOptimizer(BaseOptimizer):
         """Raise ValueError when n_random_nodes is below the required minimum for the strategy.
 
         - random:   No minimum enforced — combinations are taken in shuffle order.
-        - greedy:   n_random_nodes >= 2 * max_unique_values_per_string_column, so
-                    every string column value can appear at least twice.
+        - greedy:   n_random_nodes >= 2 * max_unique_values_per_column, so every
+                    discrete column value (string or numeric) appears at least twice.
         - balanced: n_random_nodes >= max(n_balanced_tuples, max_non_balanced_unique),
                     where n_balanced_tuples is the number of unique value-tuples for
                     fields_to_balance and max_non_balanced_unique is the max number of
-                    unique values among the remaining string columns.
+                    unique values among the remaining discrete columns.
         """
         combinations = self._search_space.combinations
         if not combinations:
@@ -271,7 +275,7 @@ class GAMOptimizer(BaseOptimizer):
         if strategy == "random":
             return
 
-        str_cols = _get_string_column_values(combinations)
+        str_cols = _get_discrete_column_values(combinations)
 
         if strategy == "greedy":
             if not str_cols:
@@ -396,17 +400,17 @@ class GAMOptimizer(BaseOptimizer):
 
     @staticmethod
     def _get_greedy_combinations(combinations: list[dict], n: int) -> list[dict]:
-        """Greedily select n combinations ensuring every string column value appears >= 2 times.
+        """Greedily select n combinations ensuring every discrete column value appears >= 2 times.
 
-        At each step the candidate with the highest coverage gain (number of string column
-        values whose current count is still below 2) is selected. Ties are broken by the
-        shuffle order coming in. The n selected combinations are returned first, followed
-        by the remaining combinations in their original (shuffled) order.
+        At each step the candidate with the highest coverage gain (number of discrete column
+        values — string or numeric — whose current count is still below 2) is selected.
+        Ties are broken by the shuffle order coming in. The n selected combinations are
+        returned first, followed by the remaining combinations in their original (shuffled) order.
         """
         if not combinations or n <= 0:
             return combinations
 
-        str_cols = _get_string_column_values(combinations)
+        str_cols = _get_discrete_column_values(combinations)
         if not str_cols:
             return combinations
 
@@ -443,8 +447,8 @@ class GAMOptimizer(BaseOptimizer):
 
         The outer round-robin guarantees every fields_to_balance value-tuple appears
         at least once when n_random_nodes >= n_balanced_tuples. The inner round-robin
-        ensures non-balanced string columns (e.g. chunking_method) also vary across
-        the initial evaluations rather than repeating the same value for each bucket.
+        ensures non-balanced discrete columns (e.g. chunking_method, chunk_size) also
+        vary across the initial evaluations rather than repeating the same value for each bucket.
         """
         if not combinations or not fields_to_balance:
             return combinations
@@ -452,7 +456,7 @@ class GAMOptimizer(BaseOptimizer):
         def _outer_key(c: dict) -> tuple:
             return tuple(_str_val(c.get(f)) for f in fields_to_balance)
 
-        str_cols = _get_string_column_values(combinations)
+        str_cols = _get_discrete_column_values(combinations)
         other_str_fields = [col for col in str_cols if col not in fields_to_balance]
 
         if other_str_fields:

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -438,18 +438,39 @@ class GAMOptimizer(BaseOptimizer):
 
     @staticmethod
     def _get_balanced_combinations(combinations: list[dict], fields_to_balance: list[str]) -> list[dict]:
-        """Order by round-robin across the value tuple of fields_to_balance.
+        """Order by outer round-robin across fields_to_balance tuples, with an inner
+        round-robin across remaining string columns within each balanced bucket.
 
-        With n_random_nodes >= number of unique value-tuples for fields_to_balance,
-        every such tuple is guaranteed to appear at least once before GAM training.
+        The outer round-robin guarantees every fields_to_balance value-tuple appears
+        at least once when n_random_nodes >= n_balanced_tuples. The inner round-robin
+        ensures non-balanced string columns (e.g. chunking_method) also vary across
+        the initial evaluations rather than repeating the same value for each bucket.
         """
-        if not fields_to_balance:
+        if not combinations or not fields_to_balance:
             return combinations
 
-        def _key(c: dict) -> tuple:
+        def _outer_key(c: dict) -> tuple:
             return tuple(_str_val(c.get(f)) for f in fields_to_balance)
 
-        return _round_robin(combinations, _key)
+        str_cols = _get_string_column_values(combinations)
+        other_str_fields = [col for col in str_cols if col not in fields_to_balance]
+
+        if other_str_fields:
+            def _inner_key(c: dict) -> tuple:
+                return tuple(_str_val(c.get(f)) for f in other_str_fields)
+
+            outer_buckets: dict[tuple, list[dict]] = defaultdict(list)
+            for c in combinations:
+                outer_buckets[_outer_key(c)].append(c)
+
+            per_bucket_balanced = {
+                key: _round_robin(combs, _inner_key)
+                for key, combs in outer_buckets.items()
+            }
+            ordered = [c for combs in per_bucket_balanced.values() for c in combs]
+            return _round_robin(ordered, _outer_key)
+
+        return _round_robin(combinations, _outer_key)
 
     def _prepare_typed_encoder(self) -> None:
         """

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -63,6 +63,31 @@ def _round_robin(combinations: list[dict], key_fn: Callable[[dict], Any]) -> lis
     return balanced
 
 
+def _str_val(v: object) -> str:
+    """Normalize any cell value to a string key (handles model objects and plain strings)."""
+    if v is None:
+        return "__none__"
+    if isinstance(v, dict):
+        return v.get("model_id", str(v))
+    if hasattr(v, "model_id"):
+        return v.model_id
+    return str(v)
+
+
+def _get_string_column_values(combinations: list[dict]) -> dict[str, set[str]]:
+    """Return {col: set_of_str_values} for all string-like columns in the combinations."""
+    if not combinations:
+        return {}
+    result: dict[str, set[str]] = {}
+    for col in combinations[0]:
+        sample = next((c.get(col) for c in combinations if c.get(col) is not None), None)
+        if sample is None:
+            continue
+        if isinstance(sample, (str, dict)) or hasattr(sample, "model_id"):
+            result[col] = {_str_val(c.get(col)) for c in combinations}
+    return result
+
+
 @dataclass
 class GAMOptSettings(OptimizerSettings):
     """
@@ -76,17 +101,20 @@ class GAMOptSettings(OptimizerSettings):
         Maximum number of evaluations performed during optimization process.
     n_random_nodes : int, default=4
         Number of random configurations to evaluate before starting GAM iterations.
-        Selection is balanced across search_mode values (mode_balanced strategy) or
-        across (foundation_model, embedding_model, search_mode) triples
-        (model_mode_balanced strategy), ensuring the GAM receives representative
-        signal on the most impactful categorical dimensions before training begins.
     evals_per_trial : int, default=1
         Number of configurations to evaluate per GAM iteration.
-    warm_start_strategy : {"mode_balanced", "model_mode_balanced"}, default="mode_balanced"
-        Controls how the initial n_random_nodes observations are ordered.
-        "mode_balanced"        — round-robin across search_mode values.
-        "model_mode_balanced"  — round-robin across (foundation_model,
-                                 embedding_model, search_mode) triples.
+    warm_start_strategy : {"random", "greedy", "balanced"}, default="random"
+        Controls how the initial n_random_nodes observations are selected/ordered.
+        "random"   — shuffle the candidate list and take the first n as-is.
+        "greedy"   — greedily pick n combinations so every string column value
+                     appears at least twice (raises if n_random_nodes is too small).
+        "balanced" — round-robin across the tuple of fields_to_balance values;
+                     non-balanced string column values each appear at least once.
+                     Requires fields_to_balance to be set.
+    fields_to_balance : list[str] | None, default=None
+        Field names to balance by round-robin when warm_start_strategy="balanced".
+        Each unique value combination of these fields is guaranteed to appear at
+        least once in the first n_random_nodes evaluations.
     random_state : int, default=64
         Inherited from OptimizerSettings. Controls shuffle order of initial
         random exploration phase. Does NOT control GAM model randomness
@@ -95,14 +123,19 @@ class GAMOptSettings(OptimizerSettings):
 
     n_random_nodes: int = 4
     evals_per_trial: int = 1
-    warm_start_strategy: Literal["mode_balanced", "model_mode_balanced"] = "mode_balanced"
+    warm_start_strategy: Literal["random", "greedy", "balanced"] = "random"
+    fields_to_balance: list[str] | None = None
 
     def __post_init__(self) -> None:
-        valid = {"mode_balanced", "model_mode_balanced"}
+        valid = {"random", "greedy", "balanced"}
         if self.warm_start_strategy not in valid:
             raise ValueError(
                 f"warm_start_strategy must be one of {sorted(valid)}; "
                 f"got {self.warm_start_strategy!r}."
+            )
+        if self.warm_start_strategy == "balanced" and not self.fields_to_balance:
+            raise ValueError(
+                "fields_to_balance must be a non-empty list when warm_start_strategy='balanced'."
             )
 
 
@@ -221,54 +254,55 @@ class GAMOptimizer(BaseOptimizer):
     def _validate_n_random_nodes(self) -> None:
         """Raise ValueError when n_random_nodes is below the required minimum for the strategy.
 
-        Counts unique foundation_model, embedding_model, and search_mode values in
-        the search space and enforces:
-
-        - mode_balanced:       n_random_nodes >= max(4, n_llms * n_embeddings)
-          The 2-level round-robin (outer: search_mode, inner: (llm, em) pair) can
-          only guarantee every model appears at least once when there are enough
-          slots — n_llms * n_embeddings evaluations total, regardless of n_modes.
-
-        - model_mode_balanced: n_random_nodes >= max(8, n_modes * n_llms * n_embeddings)
-          Round-robins across (llm, em, mode) triples; full coverage requires one slot
-          per triple. The floor of 8 ensures all chunking methods (not part of the key)
-          appear at least once via the random shuffle within each triple's bucket.
+        - random:   No minimum enforced — combinations are taken in shuffle order.
+        - greedy:   n_random_nodes >= 2 * max_unique_values_per_string_column, so
+                    every string column value can appear at least twice.
+        - balanced: n_random_nodes >= max(n_balanced_tuples, max_non_balanced_unique),
+                    where n_balanced_tuples is the number of unique value-tuples for
+                    fields_to_balance and max_non_balanced_unique is the max number of
+                    unique values among the remaining string columns.
         """
         combinations = self._search_space.combinations
         if not combinations:
             return
 
-        def _unique_ids(key: str) -> int:
-            seen: set[str] = set()
-            for c in combinations:
-                v = c.get(key)
-                if v is None:
-                    continue
-                if isinstance(v, dict):
-                    seen.add(v.get("model_id", str(v)))
-                elif hasattr(v, "model_id"):
-                    seen.add(v.model_id)
-                else:
-                    seen.add(str(v))
-            return len(seen)
+        strategy = self.settings.warm_start_strategy
 
-        n_llms = _unique_ids("foundation_model")
-        n_embeddings = _unique_ids("embedding_model")
-        n_modes = _unique_ids("search_mode") or 1
+        if strategy == "random":
+            return
 
-        if self.settings.warm_start_strategy == "model_mode_balanced":
-            recommended = max(8, n_modes * n_llms * n_embeddings)
-        else:  # mode_balanced
-            recommended = max(4, n_llms * n_embeddings)
+        str_cols = _get_string_column_values(combinations)
 
-        if self.settings.n_random_nodes < recommended:
-            raise ValueError(
-                f"n_random_nodes={self.settings.n_random_nodes} is too small for "
-                f"warm_start_strategy={self.settings.warm_start_strategy!r} with "
-                f"n_llms={n_llms}, n_embeddings={n_embeddings}, n_modes={n_modes}. "
-                f"Set n_random_nodes >= {recommended} to ensure every model appears "
-                f"at least once before GAM training."
-            )
+        if strategy == "greedy":
+            if not str_cols:
+                return
+            max_unique = max(len(vals) for vals in str_cols.values())
+            min_required = max(4, 2 * max_unique)
+            if self.settings.n_random_nodes < min_required:
+                raise ValueError(
+                    f"n_random_nodes={self.settings.n_random_nodes} is too small for "
+                    f"warm_start_strategy='greedy': each string column value must appear "
+                    f"at least twice (max unique values per column: {max_unique}). "
+                    f"Set n_random_nodes >= {min_required}."
+                )
+
+        elif strategy == "balanced":
+            fields_to_balance = self.settings.fields_to_balance or []
+            balanced_tuples = {
+                tuple(_str_val(c.get(f)) for f in fields_to_balance)
+                for c in combinations
+            }
+            n_balanced = len(balanced_tuples)
+            non_balanced = {col: vals for col, vals in str_cols.items() if col not in fields_to_balance}
+            max_non_balanced = max((len(vals) for vals in non_balanced.values()), default=0)
+            min_required = max(4, n_balanced, max_non_balanced)
+            if self.settings.n_random_nodes < min_required:
+                raise ValueError(
+                    f"n_random_nodes={self.settings.n_random_nodes} is too small for "
+                    f"warm_start_strategy='balanced' with fields_to_balance={fields_to_balance!r}. "
+                    f"n_balanced_tuples={n_balanced}, max_non_balanced_unique={max_non_balanced}. "
+                    f"Set n_random_nodes >= {min_required}."
+                )
 
     def _load_known_observations(self, known_observations: list[dict]) -> None:
         """
@@ -306,11 +340,10 @@ class GAMOptimizer(BaseOptimizer):
         already-successful evaluations count toward the n_random_nodes target
         and already-evaluated combinations are excluded from candidates.
 
-        The selection is balanced: combinations are ordered by round-robin across
-        search_mode values (mode_balanced) or across (foundation_model,
-        embedding_model, search_mode) triples (model_mode_balanced), ensuring
-        the GAM receives representative signal on the most impactful categorical
-        dimensions before training begins.
+        The selection order depends on warm_start_strategy:
+        "random"   — shuffled order (no reordering).
+        "greedy"   — greedy selection maximizing string-column coverage (each value >= 2 times).
+        "balanced" — round-robin across fields_to_balance value tuples.
         """
         successful_evaluations = sum(1 for e in self.evaluations if e["score"] is not None)
 
@@ -328,10 +361,13 @@ class GAMOptimizer(BaseOptimizer):
         combinations_local = [c for c in copy(self._search_space.combinations) if c not in self._evaluated_combinations]
         random.Random(self.settings.random_state).shuffle(combinations_local)
 
-        if self.settings.warm_start_strategy == "model_mode_balanced":
-            combinations_local = self._get_model_mode_balanced_combinations(combinations_local)
-        else:  # "mode_balanced"
-            combinations_local = self._get_mode_balanced_combinations(combinations_local)
+        if self.settings.warm_start_strategy == "greedy":
+            combinations_local = self._get_greedy_combinations(combinations_local, self.settings.n_random_nodes)
+        elif self.settings.warm_start_strategy == "balanced":
+            combinations_local = self._get_balanced_combinations(
+                combinations_local, self.settings.fields_to_balance or []
+            )
+        # "random": use shuffled list as-is
 
         modes_in_space = {c.get("search_mode") for c in combinations_local}
         gen = (x for x in combinations_local)
@@ -359,60 +395,59 @@ class GAMOptimizer(BaseOptimizer):
             )
 
     @staticmethod
-    def _get_mode_balanced_combinations(combinations: list[dict]) -> list[dict]:
-        """Order by outer round-robin across search_mode and inner round-robin across (foundation_model, embedding_model) pairs.
+    def _get_greedy_combinations(combinations: list[dict], n: int) -> list[dict]:
+        """Greedily select n combinations ensuring every string column value appears >= 2 times.
 
-        Within each search_mode bucket, combinations are sorted so that distinct
-        (foundation_model, embedding_model) pairs appear before any pair repeats.
-        The outer round-robin then interleaves the two sorted mode lists. With
-        n_random_nodes >= n_llms * n_embeddings, every foundation_model and every
-        embedding_model is guaranteed to appear at least once before GAM training.
+        At each step the candidate with the highest coverage gain (number of string column
+        values whose current count is still below 2) is selected. Ties are broken by the
+        shuffle order coming in. The n selected combinations are returned first, followed
+        by the remaining combinations in their original (shuffled) order.
         """
-        def _model_id(v: object) -> str:
-            if isinstance(v, dict):
-                return v.get("model_id", str(v))
-            return getattr(v, "model_id", str(v))
+        if not combinations or n <= 0:
+            return combinations
 
-        def _model_pair_key(c: dict) -> tuple:
-            return (_model_id(c.get("foundation_model")), _model_id(c.get("embedding_model")))
+        str_cols = _get_string_column_values(combinations)
+        if not str_cols:
+            return combinations
 
-        # Group by search_mode; within each mode apply inner round-robin by model pair
-        mode_buckets: dict[Any, list[dict]] = defaultdict(list)
-        for c in combinations:
-            mode_buckets[c.get("search_mode")].append(c)
-
-        per_mode_balanced = {
-            mode: _round_robin(combs, _model_pair_key)
-            for mode, combs in mode_buckets.items()
+        coverage: dict[str, dict[str, int]] = {
+            col: {val: 0 for val in vals} for col, vals in str_cols.items()
         }
 
-        # Flatten preserving per-mode order, then outer round-robin interleaves modes.
-        # _round_robin preserves insertion order within each mode bucket, so the
-        # inner model-pair ordering is carried through the outer interleave.
-        ordered = [c for combs in per_mode_balanced.values() for c in combs]
-        return _round_robin(ordered, lambda c: c.get("search_mode"))
+        def _gain(c: dict) -> int:
+            return sum(
+                1 for col, val_counts in coverage.items()
+                if val_counts.get(_str_val(c.get(col)), 0) < 2
+            )
+
+        remaining_indices = list(range(len(combinations)))
+        selected_indices: list[int] = []
+
+        for _ in range(min(n, len(combinations))):
+            if not remaining_indices:
+                break
+            best_pos = max(range(len(remaining_indices)), key=lambda p: _gain(combinations[remaining_indices[p]]))
+            best_idx = remaining_indices.pop(best_pos)
+            selected_indices.append(best_idx)
+            for col in str_cols:
+                val = _str_val(combinations[best_idx].get(col))
+                if val in coverage[col]:
+                    coverage[col][val] = min(coverage[col][val] + 1, 2)
+
+        return [combinations[i] for i in selected_indices] + [combinations[i] for i in remaining_indices]
 
     @staticmethod
-    def _get_model_mode_balanced_combinations(combinations: list[dict]) -> list[dict]:
-        """Order combinations by round-robin across (foundation_model, embedding_model, search_mode) triples.
+    def _get_balanced_combinations(combinations: list[dict], fields_to_balance: list[str]) -> list[dict]:
+        """Order by round-robin across the value tuple of fields_to_balance.
 
-        With n_random_nodes >= max(8, n_modes * n_llms * n_embeddings), every
-        (foundation_model, embedding_model, search_mode) triple is guaranteed to
-        appear at least once before GAM training. chunking_method is not part of the
-        key — each triple's bucket is shuffled randomly so all chunking methods
-        appear naturally with enough n_random_nodes.
+        With n_random_nodes >= number of unique value-tuples for fields_to_balance,
+        every such tuple is guaranteed to appear at least once before GAM training.
         """
-        def _model_id(v: object) -> str:
-            if isinstance(v, dict):
-                return v.get("model_id", str(v))
-            return getattr(v, "model_id", str(v))
+        if not fields_to_balance:
+            return combinations
 
         def _key(c: dict) -> tuple:
-            return (
-                _model_id(c.get("foundation_model", None)),
-                _model_id(c.get("embedding_model", None)),
-                c.get("search_mode", None),
-            )
+            return tuple(_str_val(c.get(f)) for f in fields_to_balance)
 
         return _round_robin(combinations, _key)
 

--- a/ai4rag/core/hpo/gam_opt.py
+++ b/ai4rag/core/hpo/gam_opt.py
@@ -111,11 +111,17 @@ class GAMOptSettings(OptimizerSettings):
     warm_start_strategy : {"random", "greedy", "balanced"}, default="random"
         Controls how the initial n_random_nodes observations are selected/ordered.
         "random"   — shuffle the candidate list and take the first n as-is.
-        "greedy"   — greedily pick n combinations so every string column value
-                     appears at least twice (raises if n_random_nodes is too small).
+        "greedy"   — greedily pick combinations so every discrete column value
+                     appears at least twice. If n_random_nodes is below the
+                     computed minimum (min_required), the warm start is
+                     auto-adjusted upward to meet coverage. After warm start,
+                     runs max_evals - floor(min_required/4) GAM iterations; the
+                     final evaluations list is trimmed to the top max_evals by
+                     score.
         "balanced" — round-robin across the tuple of fields_to_balance values;
                      non-balanced discrete column values each appear at least once.
-                     Requires fields_to_balance to be set.
+                     Requires fields_to_balance to be set. Same auto-adjustment,
+                     GAM iteration count, and trimming rules as "greedy".
     fields_to_balance : list[str] | None, default=None
         Field names to balance by round-robin when warm_start_strategy="balanced".
         Each unique value combination of these fields is guaranteed to appear at
@@ -183,6 +189,7 @@ class GAMOptimizer(BaseOptimizer):
         self.evaluations = []
         self._evaluated_combinations = []
         self._typed_encoders_with_columns: list[tuple[str, LabelEncoder]] = []
+        self.warm_start_evaluation_count: int = 0
 
         if known_observations:
             self._load_known_observations(known_observations)
@@ -230,10 +237,17 @@ class GAMOptimizer(BaseOptimizer):
         """
         self.evaluate_initial_random_nodes()
 
-        iterations_limit = self._get_iterations_limit()
-
-        for _ in range(iterations_limit):
-            self._run_iteration()
+        strategy = self.settings.warm_start_strategy
+        if strategy in ("greedy", "balanced"):
+            effective_warm_start = self._compute_warm_start_effective_target()
+            n_gam_iters = self.settings.max_evals - (effective_warm_start // 4)
+            for _ in range(n_gam_iters):
+                self._run_iteration()
+            self._trim_evaluations_to_top(self.settings.max_evals)
+        else:
+            iterations_limit = self._get_iterations_limit()
+            for _ in range(iterations_limit):
+                self._run_iteration()
 
         successful_evaluations = [evaluation for evaluation in self.evaluations if evaluation["score"] is not None]
         if not successful_evaluations:
@@ -254,15 +268,13 @@ class GAMOptimizer(BaseOptimizer):
         return iterations_limit
 
     def _validate_n_random_nodes(self) -> None:
-        """Raise ValueError when n_random_nodes is below the required minimum for the strategy.
+        """Log a warning when n_random_nodes is below the required minimum for the strategy.
 
         - random:   No minimum enforced — combinations are taken in shuffle order.
-        - greedy:   n_random_nodes >= 2 * max_unique_values_per_column, so every
-                    discrete column value (string or numeric) appears at least twice.
-        - balanced: n_random_nodes >= max(n_balanced_tuples, max_non_balanced_unique),
-                    where n_balanced_tuples is the number of unique value-tuples for
-                    fields_to_balance and max_non_balanced_unique is the max number of
-                    unique values among the remaining discrete columns.
+        - greedy:   If n_random_nodes < 2 * max_unique_values_per_column, warm start
+                    is auto-adjusted to the minimum required (no error raised).
+        - balanced: If n_random_nodes < max(n_balanced_tuples, max_non_balanced_unique),
+                    warm start is auto-adjusted to the minimum required (no error raised).
         """
         combinations = self._search_space.combinations
         if not combinations:
@@ -287,11 +299,14 @@ class GAMOptimizer(BaseOptimizer):
             max_unique = max(len(vals) for vals in str_cols.values())
             min_required = max(4, 2 * max_unique)
             if effective_budget < min_required:
-                raise ValueError(
-                    f"n_random_nodes={self.settings.n_random_nodes} is too small for "
-                    f"warm_start_strategy='greedy': each discrete column value must appear "
-                    f"at least twice (max unique values per column: {max_unique}). "
-                    f"Set n_random_nodes >= {min_required}."
+                logger.info(
+                    "n_random_nodes=%d is below the minimum required %d for "
+                    "warm_start_strategy='greedy' (max unique values per column: %d). "
+                    "Warm start will be auto-adjusted to %d nodes.",
+                    self.settings.n_random_nodes,
+                    min_required,
+                    max_unique,
+                    min_required,
                 )
 
         elif strategy == "balanced":
@@ -302,12 +317,45 @@ class GAMOptimizer(BaseOptimizer):
             max_non_balanced = max((len(vals) for vals in non_balanced.values()), default=0)
             min_required = max(4, n_balanced, max_non_balanced)
             if effective_budget < min_required:
-                raise ValueError(
-                    f"n_random_nodes={self.settings.n_random_nodes} is too small for "
-                    f"warm_start_strategy='balanced' with fields_to_balance={fields_to_balance!r}. "
-                    f"n_balanced_tuples={n_balanced}, max_non_balanced_unique={max_non_balanced}. "
-                    f"Set n_random_nodes >= {min_required}."
+                logger.info(
+                    "n_random_nodes=%d is below the minimum required %d for "
+                    "warm_start_strategy='balanced' with fields_to_balance=%r "
+                    "(n_balanced_tuples=%d, max_non_balanced_unique=%d). "
+                    "Warm start will be auto-adjusted to %d nodes.",
+                    self.settings.n_random_nodes,
+                    min_required,
+                    fields_to_balance,
+                    n_balanced,
+                    max_non_balanced,
+                    min_required,
                 )
+
+    def _compute_warm_start_effective_target(self) -> int:
+        """Return the effective number of successful warm-start nodes to evaluate.
+
+        For "greedy" and "balanced" strategies, this is
+        max(n_random_nodes, min_required) where min_required guarantees adequate
+        discrete-value coverage. For "random", returns n_random_nodes unchanged.
+        """
+        n = self.settings.n_random_nodes
+        strategy = self.settings.warm_start_strategy
+        if strategy == "random":
+            return n
+        combinations = self._search_space.combinations
+        if not combinations:
+            return n
+        str_cols = _get_discrete_column_values(combinations)
+        if strategy == "greedy":
+            if not str_cols:
+                return max(4, n)
+            max_unique = max(len(vals) for vals in str_cols.values())
+            return max(n, 4, 2 * max_unique)
+        # balanced
+        fields = self.settings.fields_to_balance or []
+        balanced_tuples = {tuple(_str_val(c.get(f)) for f in fields) for c in combinations}
+        non_balanced = {col: vals for col, vals in str_cols.items() if col not in fields}
+        max_non_balanced = max((len(vals) for vals in non_balanced.values()), default=0)
+        return max(n, 4, len(balanced_tuples), max_non_balanced)
 
     def _load_known_observations(self, known_observations: list[dict]) -> None:
         """
@@ -351,12 +399,13 @@ class GAMOptimizer(BaseOptimizer):
         "balanced" — round-robin across fields_to_balance value tuples.
         """
         successful_evaluations = sum(1 for e in self.evaluations if e["score"] is not None)
+        effective_target = self._compute_warm_start_effective_target()
 
-        if successful_evaluations >= self.settings.n_random_nodes:
+        if successful_evaluations >= effective_target:
             logger.info(
-                "Skipping random evaluation phase: %d known successful evaluations >= n_random_nodes (%d).",
+                "Skipping random evaluation phase: %d known successful evaluations >= warm_start_target (%d).",
                 successful_evaluations,
-                self.settings.n_random_nodes,
+                effective_target,
             )
             return
 
@@ -378,7 +427,7 @@ class GAMOptimizer(BaseOptimizer):
                     val = _str_val(obs.get(col))
                     if val in initial_coverage[col]:
                         initial_coverage[col][val] = min(initial_coverage[col][val] + 1, 2)
-            remaining_budget = self.settings.n_random_nodes - successful_evaluations
+            remaining_budget = effective_target - successful_evaluations
             combinations_local = self._get_greedy_combinations(
                 combinations_local, remaining_budget, initial_coverage=initial_coverage
             )
@@ -391,7 +440,7 @@ class GAMOptimizer(BaseOptimizer):
         discrete_cols_in_space = _get_discrete_column_values(combinations_local)
         gen = (x for x in combinations_local)
 
-        while successful_evaluations < self.settings.n_random_nodes:
+        while successful_evaluations < effective_target:
             params = next(gen)
             score = self._objective_function(params=params)
             if score is not None:
@@ -402,7 +451,8 @@ class GAMOptimizer(BaseOptimizer):
             if len(self.evaluations) == self.max_iterations:
                 break
 
-        self._log_uncovered_values(discrete_cols_in_space, self.evaluations, self.settings.n_random_nodes)
+        self._log_uncovered_values(discrete_cols_in_space, self.evaluations, effective_target)
+        self.warm_start_evaluation_count = len(self.evaluations)
 
     @staticmethod
     def _log_uncovered_values(
@@ -597,6 +647,19 @@ class GAMOptimizer(BaseOptimizer):
             score = self._objective_function(params)
             self._evaluated_combinations.append(params)
             self.evaluations.append(params | {"score": score})
+
+    def _trim_evaluations_to_top(self, n: int) -> None:
+        """Trim self.evaluations to the top n successful entries by score.
+
+        Failed evaluations (score is None) are discarded. Successful evaluations
+        are sorted descending by score and only the top n are retained.
+        """
+        successful = sorted(
+            [e for e in self.evaluations if e.get("score") is not None],
+            key=lambda d: d["score"],
+            reverse=True,
+        )
+        self.evaluations = successful[:n]
 
     @staticmethod
     def _get_remaining_evaluations(all_combinations: list[dict], evaluations: list[dict]) -> list[dict]:

--- a/ai4rag/rag/vector_store/pgvector.py
+++ b/ai4rag/rag/vector_store/pgvector.py
@@ -54,7 +54,19 @@ class PGVectorStore(BaseVectorStore):
     # lazily up to the caller-supplied config.pool_max_size, so a fully concurrent
     # caller never queues for a slot as long as pool_max_size covers its own
     # concurrency (see PGVectorConfig.pool_max_size).
-    _MIN_POOL_SIZE = 1
+    #
+    # min_size=0 (no proactive connections): when _create_table() borrows the one
+    # pre-warmed connection, a min_size=1 pool would immediately open a second
+    # connection to restore the minimum, leaving *two* idle connections during the
+    # subsequent embed_documents() call.  With a large corpus (e.g. 556 hybrid
+    # chunks), that call can take >80 s — long enough for the OS TCP keepalive
+    # exhaustion (keepalives_idle + count*interval = 80 s) to declare both sockets
+    # dead.  The insert then fails on the first stale connection and the single
+    # retry exhausts the second stale one, raising IndexingError.  With min_size=0
+    # the pool never proactively opens a second connection, so only one socket
+    # accumulates during embedding; the existing one-retry policy picks up a fresh
+    # connection and the insert succeeds.
+    _MIN_POOL_SIZE = 0
 
     # pgvector caps HNSW (and IVFFlat) indexes on the ``vector`` type at 2000
     # dimensions (https://github.com/pgvector/pgvector#hnsw). Higher-dimensional

--- a/ai4rag/rag/vector_store/pgvector.py
+++ b/ai4rag/rag/vector_store/pgvector.py
@@ -54,19 +54,7 @@ class PGVectorStore(BaseVectorStore):
     # lazily up to the caller-supplied config.pool_max_size, so a fully concurrent
     # caller never queues for a slot as long as pool_max_size covers its own
     # concurrency (see PGVectorConfig.pool_max_size).
-    #
-    # min_size=0 (no proactive connections): when _create_table() borrows the one
-    # pre-warmed connection, a min_size=1 pool would immediately open a second
-    # connection to restore the minimum, leaving *two* idle connections during the
-    # subsequent embed_documents() call.  With a large corpus (e.g. 556 hybrid
-    # chunks), that call can take >80 s — long enough for the OS TCP keepalive
-    # exhaustion (keepalives_idle + count*interval = 80 s) to declare both sockets
-    # dead.  The insert then fails on the first stale connection and the single
-    # retry exhausts the second stale one, raising IndexingError.  With min_size=0
-    # the pool never proactively opens a second connection, so only one socket
-    # accumulates during embedding; the existing one-retry policy picks up a fresh
-    # connection and the insert succeeds.
-    _MIN_POOL_SIZE = 0
+    _MIN_POOL_SIZE = 1
 
     # pgvector caps HNSW (and IVFFlat) indexes on the ``vector`` type at 2000
     # dimensions (https://github.com/pgvector/pgvector#hnsw). Higher-dimensional

--- a/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
+++ b/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
@@ -424,18 +424,18 @@ class TestRunRagOptimizationWarmStartParams:
     """Tests that n_random_nodes and warm_start_strategy are forwarded to GAMOptSettings."""
 
     def test_default_n_random_nodes(self):
-        """n_random_nodes must default to 4."""
+        """n_random_nodes must default to None (auto-computed)."""
         import inspect
 
         sig = inspect.signature(run_rag_optimization)
-        assert sig.parameters["n_random_nodes"].default == 4
+        assert sig.parameters["n_random_nodes"].default is None
 
     def test_default_warm_start_strategy(self):
-        """warm_start_strategy must default to 'mode_balanced'."""
+        """warm_start_strategy must default to 'random'."""
         import inspect
 
         sig = inspect.signature(run_rag_optimization)
-        assert sig.parameters["warm_start_strategy"].default == "mode_balanced"
+        assert sig.parameters["warm_start_strategy"].default == "random"
 
     def test_invalid_warm_start_strategy_raises(self, mock_maas_client):
         """An invalid warm_start_strategy must raise ValueError from GAMOptSettings."""
@@ -453,7 +453,7 @@ class TestRunRagOptimizationWarmStartParams:
 
     def test_valid_warm_start_strategies_pass_validation(self, mock_maas_client):
         """Valid strategy values pass the warm_start_strategy check and fail later on real inputs."""
-        for strategy in ("mode_balanced", "model_mode_balanced"):
+        for strategy in ("random", "greedy"):
             with pytest.raises(ValueError, match="JSON file"):
                 run_rag_optimization(
                     extracted_text_path="dummy",

--- a/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
+++ b/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
@@ -418,3 +418,50 @@ class TestRunRagOptimizationLLMJudgeMode:
                 test_data_key="bench.json",
                 llm_judge_mode="judge",  # type: ignore[arg-type]
             )
+
+
+class TestRunRagOptimizationWarmStartParams:
+    """Tests that n_random_nodes and warm_start_strategy are forwarded to GAMOptSettings."""
+
+    def test_default_n_random_nodes(self):
+        """n_random_nodes must default to 4."""
+        import inspect
+
+        sig = inspect.signature(run_rag_optimization)
+        assert sig.parameters["n_random_nodes"].default == 4
+
+    def test_default_warm_start_strategy(self):
+        """warm_start_strategy must default to 'mode_balanced'."""
+        import inspect
+
+        sig = inspect.signature(run_rag_optimization)
+        assert sig.parameters["warm_start_strategy"].default == "mode_balanced"
+
+    def test_invalid_warm_start_strategy_raises(self, mock_maas_client):
+        """An invalid warm_start_strategy must raise ValueError from GAMOptSettings."""
+        with pytest.raises(ValueError, match="warm_start_strategy"):
+            run_rag_optimization(
+                extracted_text_path="dummy",
+                test_data_path="dummy.json",
+                search_space_report_path="dummy.json",
+                output_dir="out",
+                maas_client=mock_maas_client,
+                vector_store_config=ChromaConfig(),
+                test_data_key="bench.json",
+                warm_start_strategy="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_valid_warm_start_strategies_pass_validation(self, mock_maas_client):
+        """Valid strategy values pass the warm_start_strategy check and fail later on real inputs."""
+        for strategy in ("mode_balanced", "model_mode_balanced"):
+            with pytest.raises(ValueError, match="JSON file"):
+                run_rag_optimization(
+                    extracted_text_path="dummy",
+                    test_data_path="dummy.json",
+                    search_space_report_path="dummy.json",
+                    output_dir="out",
+                    maas_client=mock_maas_client,
+                    vector_store_config=ChromaConfig(),
+                    test_data_key="bench.csv",
+                    warm_start_strategy=strategy,
+                )

--- a/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
+++ b/tests/unit/ai4rag/components/optimization/test_rag_optimization.py
@@ -13,6 +13,8 @@ from ai4rag.components.optimization.rag_templates_optimization import (
     MIN_MAX_RAG_PATTERNS_RANGE,
     SUPPORTED_OPTIMIZATION_METRICS,
     _generate_output_artifacts,
+    _get_pattern_score,
+    _select_patterns_for_leaderboard,
     _validate_optimization_settings,
     run_rag_optimization,
 )
@@ -465,3 +467,119 @@ class TestRunRagOptimizationWarmStartParams:
                     test_data_key="bench.csv",
                     warm_start_strategy=strategy,
                 )
+
+
+def _make_scored_pattern(score: float, name: str = "p") -> dict:
+    """Build a minimal pattern dict with the given optimization metric score."""
+    return {
+        "payload": {
+            "name": name,
+            "evaluation": {
+                "metrics": [
+                    {"name": "overall_score", "scores": {"mean": score}, "optimization_metric": True},
+                ]
+            },
+        },
+        "evaluation_results": [],
+    }
+
+
+class TestGetPatternScore:
+    """Tests for _get_pattern_score helper."""
+
+    def test_returns_optimization_metric_mean(self):
+        pattern = _make_scored_pattern(0.75, name="p0")
+        assert _get_pattern_score(pattern) == 0.75
+
+    def test_returns_zero_when_no_optimization_metric(self):
+        pattern = {
+            "payload": {
+                "evaluation": {
+                    "metrics": [{"name": "faithfulness", "scores": {"mean": 0.9}, "optimization_metric": False}]
+                }
+            }
+        }
+        assert _get_pattern_score(pattern) == 0.0
+
+    def test_returns_zero_on_empty_payload(self):
+        assert _get_pattern_score({}) == 0.0
+
+    def test_skips_none_score(self):
+        pattern = {
+            "payload": {
+                "evaluation": {
+                    "metrics": [{"name": "overall_score", "scores": {"mean": None}, "optimization_metric": True}]
+                }
+            }
+        }
+        assert _get_pattern_score(pattern) == 0.0
+
+
+class TestSelectPatternsForLeaderboard:
+    """Tests for _select_patterns_for_leaderboard."""
+
+    def _patterns(self, scores: list[float]) -> list[dict]:
+        return [_make_scored_pattern(s, name=f"p{i}") for i, s in enumerate(scores)]
+
+    def test_selects_top_quarter_from_warmstart_and_rest_from_gam(self):
+        # warm_start=8 → n_from_warmstart=2; max_rag_patterns=10 → n_from_gam=8
+        warm = self._patterns([0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2])
+        gam = self._patterns([0.85, 0.75, 0.65, 0.55, 0.45, 0.35, 0.25, 0.15, 0.05, 0.01])
+        result = _select_patterns_for_leaderboard(
+            patterns=warm + gam,
+            warm_start_count=8,
+            effective_warm_start=8,
+            max_rag_patterns=10,
+        )
+        assert len(result) == 10
+        # First 2 are top warm-start patterns (scores 0.9, 0.8)
+        assert _get_pattern_score(result[0]) == 0.9
+        assert _get_pattern_score(result[1]) == 0.8
+        # Next 8 are top GAM patterns (scores 0.85..0.05)
+        gam_scores = [_get_pattern_score(r) for r in result[2:]]
+        assert gam_scores == sorted(gam_scores, reverse=True)
+        assert len(gam_scores) == 8
+
+    def test_n_from_warmstart_uses_floor_division(self):
+        # effective_warm_start=9 → n_from_warmstart=9//4=2
+        warm = self._patterns([0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1])
+        gam = self._patterns([0.85] * 20)
+        result = _select_patterns_for_leaderboard(
+            patterns=warm + gam,
+            warm_start_count=9,
+            effective_warm_start=9,
+            max_rag_patterns=10,
+        )
+        assert len(result) == 10
+        assert _get_pattern_score(result[0]) == 0.9
+        assert _get_pattern_score(result[1]) == 0.8
+        assert len(result[2:]) == 8  # n_from_gam = 10 - 2 = 8
+
+    def test_fewer_patterns_than_requested_returns_what_is_available(self):
+        # Only 3 warm + 2 gam available
+        warm = self._patterns([0.9, 0.8, 0.7])
+        gam = self._patterns([0.6, 0.5])
+        result = _select_patterns_for_leaderboard(
+            patterns=warm + gam,
+            warm_start_count=3,
+            effective_warm_start=8,
+            max_rag_patterns=10,
+        )
+        # n_from_warmstart=2, n_from_gam=8
+        assert len(result) == 4  # 2 from warm + 2 from gam (only 2 available)
+
+    def test_when_max_evals_smaller_than_effective_warm_start(self):
+        # max_rag_patterns=4, effective_warm_start=8 → n_from_warmstart=2, n_from_gam=2
+        warm = self._patterns([0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2])
+        gam = self._patterns([0.85, 0.75, 0.65])
+        result = _select_patterns_for_leaderboard(
+            patterns=warm + gam,
+            warm_start_count=8,
+            effective_warm_start=8,
+            max_rag_patterns=4,
+        )
+        assert len(result) == 4
+        assert _get_pattern_score(result[0]) == 0.9  # top warm
+        assert _get_pattern_score(result[1]) == 0.8  # 2nd warm
+        assert _get_pattern_score(result[2]) == 0.85  # top GAM
+        assert _get_pattern_score(result[3]) == 0.75  # 2nd GAM

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -23,6 +23,7 @@ class TestGAMOptSettings:
         assert settings.n_random_nodes == 4
         assert settings.evals_per_trial == 1
         assert settings.random_state == 64
+        assert settings.warm_start_strategy == "mode_balanced"
 
     def test_gam_opt_settings_creation_with_custom_values(self):
         """Test that GAMOptSettings can be instantiated with custom values."""
@@ -31,15 +32,17 @@ class TestGAMOptSettings:
             n_random_nodes=10,
             evals_per_trial=2,
             random_state=42,
+            warm_start_strategy="model_mode_balanced",
         )
 
         assert settings.max_evals == 50
         assert settings.n_random_nodes == 10
         assert settings.evals_per_trial == 2
         assert settings.random_state == 42
+        assert settings.warm_start_strategy == "model_mode_balanced"
 
-    def test_gam_opt_settings_post_init_keeps_n_random_nodes_if_smaller(self):
-        """Test that __post_init__ keeps n_random_nodes if it's smaller than max_evals."""
+    def test_gam_opt_settings_stores_n_random_nodes(self):
+        """Test that GAMOptSettings stores n_random_nodes as provided."""
         settings = GAMOptSettings(max_evals=20, n_random_nodes=5)
 
         assert settings.n_random_nodes == 5
@@ -51,6 +54,11 @@ class TestGAMOptSettings:
         settings = GAMOptSettings(max_evals=10)
 
         assert isinstance(settings, OptimizerSettings)
+
+    def test_gam_opt_settings_invalid_warm_start_strategy_raises(self):
+        """Invalid warm_start_strategy is rejected at construction time."""
+        with pytest.raises(ValueError, match="warm_start_strategy"):
+            GAMOptSettings(max_evals=10, warm_start_strategy="invalid_strategy")
 
 
 class TestGAMOptimizer:
@@ -91,7 +99,7 @@ class TestGAMOptimizer:
         assert optimizer.settings == optimizer_settings
         assert optimizer.evaluations == []
         assert optimizer._evaluated_combinations == []
-        assert optimizer._encoders_with_columns == []
+        assert optimizer._typed_encoders_with_columns == []
 
     def test_max_iterations_getter(self, mock_search_space, optimizer_settings):
         """Test the max_iterations property getter."""
@@ -317,45 +325,22 @@ class TestGAMOptimizer:
         # Should stop at max_iterations=4, not n_random_nodes=10
         assert len(optimizer.evaluations) == 4
 
-    def test_prepare_encoder(self, mock_search_space, optimizer_settings, mocker):
-        """Test the _prepare_encoder method."""
+    def test_evaluate_initial_random_nodes_n_random_exceeds_max_evals(self, mock_search_space):
+        """n_random_nodes > max_evals is silently bounded by max_iterations."""
+        settings = GAMOptSettings(max_evals=3, n_random_nodes=6)
         objective_func = MagicMock(return_value=0.5)
 
         optimizer = GAMOptimizer(
             objective_function=objective_func,
             search_space=mock_search_space,
-            settings=optimizer_settings,
+            settings=settings,
         )
 
-        # Initially no encoders
-        assert len(optimizer._encoders_with_columns) == 0
+        optimizer.evaluate_initial_random_nodes()
 
-        optimizer._prepare_encoder()
-
-        # Should have created encoders for each column
-        assert len(optimizer._encoders_with_columns) == 2  # param1 and param2
-        column_names = [col for col, enc in optimizer._encoders_with_columns]
-        assert "param1" in column_names
-        assert "param2" in column_names
-
-    def test_prepare_encoder_called_only_once(self, mock_search_space, optimizer_settings):
-        """Test that _prepare_encoder only prepares encoders once."""
-        objective_func = MagicMock(return_value=0.5)
-
-        optimizer = GAMOptimizer(
-            objective_function=objective_func,
-            search_space=mock_search_space,
-            settings=optimizer_settings,
-        )
-
-        optimizer._prepare_encoder()
-        first_encoders = optimizer._encoders_with_columns.copy()
-
-        # Call again
-        optimizer._prepare_encoder()
-
-        # Should not recreate encoders
-        assert optimizer._encoders_with_columns == first_encoders
+        # Capped at max_iterations=3 (min(max_evals=3, max_combinations=6))
+        assert len(optimizer.evaluations) == 3
+        assert all(e["score"] is not None for e in optimizer.evaluations)
 
     def test_run_iteration(self, mock_search_space, mocker):
         """Test the _run_iteration method."""
@@ -536,6 +521,27 @@ class TestGAMOptimizer:
         call_args = mock_gam.fit.call_args
         assert call_args[0][0].shape[0] == 3  # X_train should have 3 samples
         assert call_args[0][1].shape[0] == 3  # y_train should have 3 samples
+
+    def test_run_iteration_does_not_crash_when_remaining_is_empty(self, mock_search_space, mocker):
+        """_run_iteration returns silently when all combinations have been evaluated."""
+        mock_gam = MagicMock()
+        mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
+
+        settings = GAMOptSettings(max_evals=6, n_random_nodes=6)
+        scores = iter([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        optimizer = GAMOptimizer(
+            objective_function=lambda _: next(scores),
+            search_space=mock_search_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+        assert len(optimizer.evaluations) == 6  # all combos evaluated
+
+        # Should not raise KeyError or any other error
+        optimizer._run_iteration()
+
+        # GAM was fitted but predict should NOT have been called (early return)
+        mock_gam.predict.assert_not_called()
 
 
 class TestGAMOptimizerKnownObservations:
@@ -760,161 +766,276 @@ class TestGAMOptimizerKnownObservations:
         assert known[0]["score"] == 0.3
 
 
-class TestGetStratifiedCombinations:
-    """Test the _get_stratified_combinations static method."""
+class TestPrepareTypedEncoder:
+    """Test the _prepare_typed_encoder method."""
 
-    def test_skewed_search_space_stratifies_minority_first(self):
-        """Minority categorical values are moved ahead of the majority."""
-        # 4 hybrid, 2 vector — mirrors the real MaaS imbalance
-        combinations = [
-            {"search_mode": "hybrid", "chunk_size": 256},
-            {"search_mode": "hybrid", "chunk_size": 512},
-            {"search_mode": "hybrid", "chunk_size": 1024},
-            {"search_mode": "hybrid", "chunk_size": 2048},
-            {"search_mode": "vector", "chunk_size": 256},
-            {"search_mode": "vector", "chunk_size": 512},
+    @pytest.fixture
+    def mock_search_space(self):
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"param1": "a", "param2": 1},
+            {"param1": "b", "param2": 2},
+            {"param1": "c", "param2": 3},
+            {"param1": "d", "param2": 4},
+            {"param1": "e", "param2": 5},
+            {"param1": "f", "param2": 6},
         ]
-        result = GAMOptimizer._get_stratified_combinations(combinations)
+        mock_space.max_combinations = 6
+        return mock_space
 
-        # The first entry is "hybrid" (first in the original list),
-        # the second must be a "vector" entry (its first occurrence).
-        assert result[0]["search_mode"] == "hybrid"
-        assert result[1]["search_mode"] == "vector"
+    @pytest.fixture
+    def optimizer_settings(self):
+        return GAMOptSettings(max_evals=6, n_random_nodes=3)
 
-    def test_all_values_represented_after_stratification(self):
-        """After stratification, both search_mode values appear in the leading section."""
-        combinations = [
-            {"search_mode": "hybrid", "chunk_size": 256},
-            {"search_mode": "hybrid", "chunk_size": 512},
-            {"search_mode": "hybrid", "chunk_size": 1024},
-            {"search_mode": "vector", "chunk_size": 256},
-        ]
-        result = GAMOptimizer._get_stratified_combinations(combinations)
-
-        leading_modes = {c["search_mode"] for c in result[:2]}
-        assert leading_modes == {"hybrid", "vector"}
-
-    def test_already_balanced_order_is_unchanged(self):
-        """When each categorical value appears exactly once, the list is returned as-is."""
-        combinations = [
-            {"mode": "a", "size": 1},
-            {"mode": "b", "size": 2},
-            {"mode": "c", "size": 3},
-        ]
-        result = GAMOptimizer._get_stratified_combinations(combinations)
-        assert result == combinations
-
-    def test_no_string_columns_returns_unchanged(self):
-        """Integer-only search spaces (no string params) are returned without reordering."""
-        combinations = [{"chunk_size": 256}, {"chunk_size": 512}, {"chunk_size": 1024}]
-        result = GAMOptimizer._get_stratified_combinations(combinations)
-        assert result == combinations
-
-    def test_empty_combinations_returns_empty(self):
-        """Empty input returns empty output."""
-        assert GAMOptimizer._get_stratified_combinations([]) == []
-
-    def test_multiple_categorical_columns_stratified(self):
-        """Stratification covers all unique values across multiple categorical columns."""
-        # search_mode: hybrid/vector, method: dense/sparse
-        combinations = [
-            {"search_mode": "hybrid", "method": "dense"},
-            {"search_mode": "hybrid", "method": "sparse"},
-            {"search_mode": "vector", "method": "dense"},
-            {"search_mode": "vector", "method": "sparse"},
-        ]
-        result = GAMOptimizer._get_stratified_combinations(combinations)
-
-        # All four combinations introduce at least one new value, so all go to stratified.
-        assert len(result) == 4
-        # Every unique value for each column is represented in the stratified prefix.
-        assert {c["search_mode"] for c in result} == {"hybrid", "vector"}
-        assert {c["method"] for c in result} == {"dense", "sparse"}
-
-    def test_already_seen_reduces_stratified_set(self):
-        """Values already covered by warm-start are treated as pre-seen."""
-        combinations = [
-            {"search_mode": "hybrid", "chunk_size": 256},
-            {"search_mode": "hybrid", "chunk_size": 512},
-            {"search_mode": "vector", "chunk_size": 256},
-            {"search_mode": "vector", "chunk_size": 512},
-        ]
-        # "hybrid" already covered by warm-start; stratification should pull vector first.
-        result = GAMOptimizer._get_stratified_combinations(combinations, already_seen={"search_mode": {"hybrid"}})
-        assert result[0]["search_mode"] == "vector"
-
-    def test_already_seen_all_values_skips_stratification(self):
-        """When warm-start covers all values, the list is returned in shuffle order."""
-        combinations = [
-            {"search_mode": "hybrid", "chunk_size": 256},
-            {"search_mode": "hybrid", "chunk_size": 512},
-        ]
-        # Both search_mode values already covered (only "hybrid" remains but it's covered).
-        result = GAMOptimizer._get_stratified_combinations(
-            combinations, already_seen={"search_mode": {"hybrid", "vector"}}
+    def test_fits_encoders_for_varying_columns(self, mock_search_space, optimizer_settings):
+        """Encoders are created for all varying columns."""
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_search_space,
+            settings=optimizer_settings,
         )
-        # All go to remainder (all_covered immediately), order preserved.
-        assert result == combinations
+        assert len(optimizer._typed_encoders_with_columns) == 0
+        optimizer._prepare_typed_encoder()
+        assert len(optimizer._typed_encoders_with_columns) == 2
+        cols = [col for col, _ in optimizer._typed_encoders_with_columns]
+        assert "param1" in cols
+        assert "param2" in cols
 
-    def test_remainder_preserves_relative_order(self):
-        """Non-stratified combos maintain the same relative ordering as the input."""
-        combinations = [
-            {"mode": "a", "n": 1},
-            {"mode": "a", "n": 2},  # remainder (mode "a" already seen)
-            {"mode": "b", "n": 3},
-            {"mode": "a", "n": 4},  # remainder
+    def test_drops_constant_columns(self):
+        """Columns with a single unique value are excluded."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"param1": "a", "param2": 1, "constant": "x"},
+            {"param1": "b", "param2": 2, "constant": "x"},
         ]
-        result = GAMOptimizer._get_stratified_combinations(combinations)
+        mock_space.max_combinations = 2
+        settings = GAMOptSettings(max_evals=2, n_random_nodes=2)
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer._prepare_typed_encoder()
+        cols = [col for col, _ in optimizer._typed_encoders_with_columns]
+        assert "constant" not in cols
+        assert "param1" in cols
+        assert "param2" in cols
 
-        # stratified = [{mode:a,n:1}, {mode:b,n:3}], remainder = [{mode:a,n:2}, {mode:a,n:4}]
-        assert result[0] == {"mode": "a", "n": 1}
-        assert result[1] == {"mode": "b", "n": 3}
-        assert result[2] == {"mode": "a", "n": 2}
-        assert result[3] == {"mode": "a", "n": 4}
+    def test_called_only_once(self, mock_search_space, optimizer_settings):
+        """Calling _prepare_typed_encoder twice does not rebuild the encoders."""
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_search_space,
+            settings=optimizer_settings,
+        )
+        optimizer._prepare_typed_encoder()
+        first = list(optimizer._typed_encoders_with_columns)
+        optimizer._prepare_typed_encoder()
+        assert optimizer._typed_encoders_with_columns == first
+
+    def test_serializes_dict_columns(self):
+        """Dict-valued model columns are serialized to model_id strings."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"foundation_model": {"model_id": "fm-a", "other": "x"}, "chunk_size": 128},
+            {"foundation_model": {"model_id": "fm-b", "other": "x"}, "chunk_size": 256},
+        ]
+        mock_space.max_combinations = 2
+        settings = GAMOptSettings(max_evals=2, n_random_nodes=2)
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer._prepare_typed_encoder()
+        cols = [col for col, _ in optimizer._typed_encoders_with_columns]
+        assert "foundation_model" in cols
+        fm_enc = next(enc for col, enc in optimizer._typed_encoders_with_columns if col == "foundation_model")
+        assert set(fm_enc.classes_) == {"fm-a", "fm-b"}
+
+    def test_string_column_gets_str_classes(self, mock_search_space, optimizer_settings):
+        """String-valued columns produce str classes so factor terms are selected."""
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_search_space,
+            settings=optimizer_settings,
+        )
+        optimizer._prepare_typed_encoder()
+        param1_enc = next(enc for col, enc in optimizer._typed_encoders_with_columns if col == "param1")
+        assert isinstance(param1_enc.classes_[0], str)
+
+    def test_numeric_column_gets_non_str_classes(self, mock_search_space, optimizer_settings):
+        """Numeric columns produce non-str classes so spline terms are selected."""
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_search_space,
+            settings=optimizer_settings,
+        )
+        optimizer._prepare_typed_encoder()
+        param2_enc = next(enc for col, enc in optimizer._typed_encoders_with_columns if col == "param2")
+        assert not isinstance(param2_enc.classes_[0], str)
 
 
-class TestStratifiedInitialSampling:
-    """Test that evaluate_initial_random_nodes uses stratified sampling."""
+class TestGetModeBalancedCombinations:
+    """Test the _get_mode_balanced_combinations static method."""
 
-    def test_skewed_space_always_includes_minority_mode(self):
+    def test_round_robins_between_two_modes(self):
+        """Combinations alternate between search_mode values."""
+        combos = (
+            [{"search_mode": "vector", "n": i} for i in range(3)] +
+            [{"search_mode": "hybrid", "n": i} for i in range(3)]
+        )
+        result = GAMOptimizer._get_mode_balanced_combinations(combos)
+        assert len(result) == 6
+        assert result[0]["search_mode"] != result[1]["search_mode"]
+        assert result[2]["search_mode"] != result[3]["search_mode"]
+
+    def test_returns_all_combinations(self):
+        """All input combinations appear in the output."""
+        combos = (
+            [{"search_mode": "vector", "n": i} for i in range(3)] +
+            [{"search_mode": "hybrid", "n": i} for i in range(3)]
+        )
+        result = GAMOptimizer._get_mode_balanced_combinations(combos)
+        assert len(result) == 6
+
+    def test_empty_returns_empty(self):
+        """Empty input returns empty output."""
+        assert GAMOptimizer._get_mode_balanced_combinations([]) == []
+
+    def test_single_mode_preserves_order(self):
+        """A single-mode space is returned in original order."""
+        combos = [{"search_mode": "vector", "n": i} for i in range(4)]
+        result = GAMOptimizer._get_mode_balanced_combinations(combos)
+        assert [c["n"] for c in result] == [0, 1, 2, 3]
+
+    def test_missing_search_mode_key_uses_fallback_bucket(self):
+        """Combinations without search_mode are collected into a single bucket."""
+        combos = [{"n": i} for i in range(3)]
+        result = GAMOptimizer._get_mode_balanced_combinations(combos)
+        assert len(result) == 3
+
+    def test_skewed_space_first_n_alternates(self):
+        """With 6 hybrid and 2 vector, the first 4 results alternate modes."""
+        combos = (
+            [{"search_mode": "hybrid", "n": i} for i in range(6)] +
+            [{"search_mode": "vector", "n": i} for i in range(2)]
+        )
+        result = GAMOptimizer._get_mode_balanced_combinations(combos)
+        modes = [c["search_mode"] for c in result[:4]]
+        assert modes.count("vector") == 2
+        assert modes.count("hybrid") == 2
+
+
+class TestGetModelModeBalancedCombinations:
+    """Test the _get_model_mode_balanced_combinations static method."""
+
+    def test_single_model_pair_equivalent_to_mode_balanced(self):
+        """With one model pair, behaviour collapses to mode-balanced."""
+        fm = {"model_id": "fm1"}
+        em = {"model_id": "em1"}
+        combos = (
+            [{"foundation_model": fm, "embedding_model": em, "search_mode": "vector", "n": i} for i in range(3)] +
+            [{"foundation_model": fm, "embedding_model": em, "search_mode": "hybrid", "n": i} for i in range(3)]
+        )
+        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        assert len(result) == 6
+        assert result[0]["search_mode"] != result[1]["search_mode"]
+
+    def test_two_model_pairs_covers_all_buckets_in_first_four(self):
+        """With 2 model pairs × 2 modes = 4 buckets, each appears in first 4 results."""
+        fm1, fm2 = {"model_id": "fm1"}, {"model_id": "fm2"}
+        em = {"model_id": "em1"}
+        combos = [
+            {"foundation_model": fm1, "embedding_model": em, "search_mode": "vector", "n": 0},
+            {"foundation_model": fm1, "embedding_model": em, "search_mode": "hybrid", "n": 0},
+            {"foundation_model": fm2, "embedding_model": em, "search_mode": "vector", "n": 0},
+            {"foundation_model": fm2, "embedding_model": em, "search_mode": "hybrid", "n": 0},
+        ]
+        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        assert len(result) == 4
+        keys = {(c["foundation_model"]["model_id"], c["search_mode"]) for c in result}
+        assert keys == {("fm1", "vector"), ("fm1", "hybrid"), ("fm2", "vector"), ("fm2", "hybrid")}
+
+    def test_returns_all_combinations(self):
+        """All input combinations appear in the output."""
+        fm = {"model_id": "fm1"}
+        em = {"model_id": "em1"}
+        combos = (
+            [{"foundation_model": fm, "embedding_model": em, "search_mode": "vector", "n": i} for i in range(4)] +
+            [{"foundation_model": fm, "embedding_model": em, "search_mode": "hybrid", "n": i} for i in range(4)]
+        )
+        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        assert len(result) == 8
+
+    def test_empty_returns_empty(self):
+        """Empty input returns empty output."""
+        assert GAMOptimizer._get_model_mode_balanced_combinations([]) == []
+
+    def test_string_model_values_are_keyed_directly(self):
+        """Non-dict model values are converted to str for keying."""
+        combos = [
+            {"foundation_model": "fm1", "embedding_model": "em1", "search_mode": "vector"},
+            {"foundation_model": "fm1", "embedding_model": "em1", "search_mode": "hybrid"},
+        ]
+        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        assert len(result) == 2
+        assert result[0]["search_mode"] != result[1]["search_mode"]
+
+
+class TestModeBalancedInitialSampling:
+    """Test that evaluate_initial_random_nodes uses mode-balanced sampling."""
+
+    def test_skewed_space_always_includes_both_modes(self):
         """With a 3:1 hybrid/vector ratio, the initial sample always includes both modes."""
         mock_space = MagicMock(spec=SearchSpace)
-        # 6 hybrid, 2 vector — minority vector must appear in the initial 4
-        mock_space.combinations = [
-            {"search_mode": "hybrid", "size": 256},
-            {"search_mode": "hybrid", "size": 512},
-            {"search_mode": "hybrid", "size": 1024},
-            {"search_mode": "hybrid", "size": 2048},
-            {"search_mode": "hybrid", "size": 4096},
-            {"search_mode": "hybrid", "size": 8192},
-            {"search_mode": "vector", "size": 256},
-            {"search_mode": "vector", "size": 512},
-        ]
+        mock_space.combinations = (
+            [{"search_mode": "hybrid", "size": i} for i in range(6)] +
+            [{"search_mode": "vector", "size": i} for i in range(2)]
+        )
         mock_space.max_combinations = 8
 
         settings = GAMOptSettings(max_evals=8, n_random_nodes=4)
-        objective_func = MagicMock(return_value=0.5)
-
         optimizer = GAMOptimizer(
-            objective_function=objective_func,
+            objective_function=MagicMock(return_value=0.5),
             search_space=mock_space,
             settings=settings,
         )
         optimizer.evaluate_initial_random_nodes()
 
-        # Assert specifically on the first n_random_nodes evaluations; if the
-        # objective ever returns None the loop draws more items and checking all
-        # evaluations would pass for the wrong reason.
-        initial_evals = optimizer.evaluations[: settings.n_random_nodes]
-        modes_sampled = {e["search_mode"] for e in initial_evals}
-        assert "vector" in modes_sampled, (
-            "Stratified sampling must include at least one 'vector' evaluation "
-            "even though 'hybrid' comprises 75% of the search space."
-        )
-        assert "hybrid" in modes_sampled
+        initial_evals = optimizer.evaluations[:settings.n_random_nodes]
+        modes = {e["search_mode"] for e in initial_evals}
+        assert "vector" in modes
+        assert "hybrid" in modes
 
-    def test_warm_start_all_majority_stratifies_remaining_for_minority(self):
-        """When all warm-start obs are the majority mode, new evals cover the minority."""
+    def test_balanced_distribution_in_initial_nodes(self):
+        """Mode-balanced gives equal representation of each mode."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = (
+            [{"search_mode": "vector", "size": i} for i in range(10)] +
+            [{"search_mode": "hybrid", "size": i} for i in range(10)]
+        )
+        mock_space.max_combinations = 20
+
+        settings = GAMOptSettings(max_evals=20, n_random_nodes=4)
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+
+        initial = optimizer.evaluations[:settings.n_random_nodes]
+        assert sum(1 for e in initial if e["search_mode"] == "vector") == 2
+        assert sum(1 for e in initial if e["search_mode"] == "hybrid") == 2
+
+    def test_warm_start_majority_leaves_room_for_minority_in_new_evals(self):
+        """When known obs are all majority mode, new evals cover the minority.
+
+        Mode-balanced round-robin guarantees that vector appears within the first
+        two new draws regardless of shuffle order, because there are only 2 vector
+        combos and 2 hybrid combos remaining after excluding the known observation.
+        """
         mock_space = MagicMock(spec=SearchSpace)
         mock_space.combinations = [
             {"search_mode": "hybrid", "size": 256},
@@ -926,7 +1047,9 @@ class TestStratifiedInitialSampling:
         mock_space.max_combinations = 5
 
         known = [{"search_mode": "hybrid", "size": 256, "score": 0.5}]
-        settings = GAMOptSettings(max_evals=5, n_random_nodes=3)
+        # Use a fixed random_state for reproducibility; mode-balanced guarantees
+        # vector coverage regardless, but pinning the seed makes the test explicit.
+        settings = GAMOptSettings(max_evals=5, n_random_nodes=3, random_state=42)
 
         optimizer = GAMOptimizer(
             objective_function=MagicMock(return_value=0.5),
@@ -936,73 +1059,18 @@ class TestStratifiedInitialSampling:
         )
         optimizer.evaluate_initial_random_nodes()
 
-        # 2 new evaluations needed to reach n_random_nodes=3; at least one must be vector.
-        new_evals = optimizer.evaluations[len(known) :]
+        new_evals = optimizer.evaluations[len(known):]
         assert "vector" in {e["search_mode"] for e in new_evals}
 
-    def test_warns_when_n_random_nodes_insufficient_for_coverage(self, mocker):
-        """A warning is logged when n_random_nodes is smaller than min needed for coverage."""
+    def test_sampling_is_deterministic_with_same_seed(self):
+        """Mode-balanced sampling is reproducible given the same random_state."""
         mock_space = MagicMock(spec=SearchSpace)
-        # param1 has 6 unique string values; n_random_nodes=3 < 6 → warning expected
-        mock_space.combinations = [
-            {"param1": "a", "param2": 1},
-            {"param1": "b", "param2": 2},
-            {"param1": "c", "param2": 3},
-            {"param1": "d", "param2": 4},
-            {"param1": "e", "param2": 5},
-            {"param1": "f", "param2": 6},
-        ]
-        mock_space.max_combinations = 6
-
-        mock_warn = mocker.patch("ai4rag.core.hpo.gam_opt.logger.warning")
-        settings = GAMOptSettings(max_evals=6, n_random_nodes=3)
-        optimizer = GAMOptimizer(
-            objective_function=MagicMock(return_value=0.5),
-            search_space=mock_space,
-            settings=settings,
+        mock_space.combinations = (
+            [{"search_mode": "hybrid", "size": i} for i in range(5)] +
+            [{"search_mode": "vector", "size": i} for i in range(5)]
         )
-        optimizer.evaluate_initial_random_nodes()
-
-        mock_warn.assert_called_once()
-        warning_msg = mock_warn.call_args[0][0] % mock_warn.call_args[0][1:]
-        assert "n_random_nodes=3" in warning_msg
-        assert "6" in warning_msg  # estimated minimum
-
-    def test_no_warning_when_n_random_nodes_sufficient(self, mocker):
-        """No warning when n_random_nodes covers all unique categorical values."""
-        mock_space = MagicMock(spec=SearchSpace)
-        # param1 has 2 unique string values; n_random_nodes=4 >= 2 → no warning
-        mock_space.combinations = [
-            {"search_mode": "hybrid", "size": 256},
-            {"search_mode": "hybrid", "size": 512},
-            {"search_mode": "vector", "size": 256},
-            {"search_mode": "vector", "size": 512},
-        ]
-        mock_space.max_combinations = 4
-
-        mock_warn = mocker.patch("ai4rag.core.hpo.gam_opt.logger.warning")
-        settings = GAMOptSettings(max_evals=4, n_random_nodes=4)
-        optimizer = GAMOptimizer(
-            objective_function=MagicMock(return_value=0.5),
-            search_space=mock_space,
-            settings=settings,
-        )
-        optimizer.evaluate_initial_random_nodes()
-
-        mock_warn.assert_not_called()
-
-    def test_stratification_is_deterministic_with_same_seed(self):
-        """Stratified sampling is fully reproducible given the same random_state."""
-        mock_space = MagicMock(spec=SearchSpace)
-        mock_space.combinations = [
-            {"search_mode": "hybrid", "size": 256},
-            {"search_mode": "hybrid", "size": 512},
-            {"search_mode": "hybrid", "size": 1024},
-            {"search_mode": "vector", "size": 256},
-            {"search_mode": "vector", "size": 512},
-        ]
-        mock_space.max_combinations = 5
-        settings = GAMOptSettings(max_evals=5, n_random_nodes=3, random_state=42)
+        mock_space.max_combinations = 10
+        settings = GAMOptSettings(max_evals=10, n_random_nodes=4, random_state=42)
 
         def make_optimizer():
             opt = GAMOptimizer(
@@ -1014,6 +1082,34 @@ class TestStratifiedInitialSampling:
             return [e["size"] for e in opt.evaluations]
 
         assert make_optimizer() == make_optimizer()
+
+    def test_model_mode_balanced_strategy_covers_all_triples(self):
+        """model_mode_balanced covers all (model, mode) buckets in the first N evals."""
+        mock_space = MagicMock(spec=SearchSpace)
+        fm1, fm2 = {"model_id": "fm1"}, {"model_id": "fm2"}
+        em = {"model_id": "em1"}
+        mock_space.combinations = (
+            [{"foundation_model": fm1, "embedding_model": em, "search_mode": "vector", "size": i} for i in range(3)] +
+            [{"foundation_model": fm1, "embedding_model": em, "search_mode": "hybrid", "size": i} for i in range(3)] +
+            [{"foundation_model": fm2, "embedding_model": em, "search_mode": "vector", "size": i} for i in range(3)] +
+            [{"foundation_model": fm2, "embedding_model": em, "search_mode": "hybrid", "size": i} for i in range(3)]
+        )
+        mock_space.max_combinations = 12
+
+        settings = GAMOptSettings(
+            max_evals=12, n_random_nodes=4,
+            warm_start_strategy="model_mode_balanced",
+        )
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+
+        initial = optimizer.evaluations[:settings.n_random_nodes]
+        buckets = {(e["foundation_model"]["model_id"], e["search_mode"]) for e in initial}
+        assert len(buckets) == 4
 
 
 class TestGAMOptimizerDeterminism:
@@ -1064,31 +1160,36 @@ class TestGAMOptimizerDeterminism:
         assert evals1 == evals2
         assert len(evals1) == 3
 
-    def test_gam_optimizer_different_with_different_random_state(self, mock_search_space):
-        """Test that GAMOptimizer produces different evaluation order with different random_state."""
+    def test_gam_optimizer_different_with_different_random_state(self):
+        """Different random_state values produce different within-bucket orderings."""
+        # Use a deterministic space where the two seeds are known to produce
+        # different shuffle orders.  All items share the same search_mode bucket
+        # so the only source of variation is the shuffle.
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [{"search_mode": "vector", "n": i} for i in range(6)]
+        mock_space.max_combinations = 6
 
         def deterministic_objective(params):
-            return params["param2"] / 10.0
+            return params["n"] / 10.0
 
-        # First run with random_state=42
         optimizer1 = GAMOptimizer(
             objective_function=deterministic_objective,
-            search_space=mock_search_space,
-            settings=GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=42),
+            search_space=mock_space,
+            settings=GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=0),
         )
         optimizer1.evaluate_initial_random_nodes()
-        evals1 = [e["param1"] for e in optimizer1.evaluations]
 
-        # Second run with random_state=99
         optimizer2 = GAMOptimizer(
             objective_function=deterministic_objective,
-            search_space=mock_search_space,
-            settings=GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=99),
+            search_space=mock_space,
+            settings=GAMOptSettings(max_evals=6, n_random_nodes=3, random_state=1),
         )
         optimizer2.evaluate_initial_random_nodes()
-        evals2 = [e["param1"] for e in optimizer2.evaluations]
 
-        # Should evaluate different combinations or different order
+        evals1 = [e["n"] for e in optimizer1.evaluations]
+        evals2 = [e["n"] for e in optimizer2.evaluations]
+
+        # Seeds 0 and 1 produce different orderings of 6 items — verified offline.
         assert evals1 != evals2
 
     def test_gam_full_search_deterministic_with_same_random_state(self, mock_search_space, mocker):

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -938,9 +938,10 @@ class TestGetGreedyCombinations:
         combos = [{"mode": "vector", "n": i} for i in range(6)]
         result = GAMOptimizer._get_greedy_combinations(combos, 2)
         assert len(result) == 6
-        # The non-selected items should maintain relative order
-        non_selected_n = [c["n"] for c in result[2:]]
-        assert non_selected_n == sorted(non_selected_n) or non_selected_n == list(reversed(sorted(non_selected_n))) or True  # order preserved from input
+        # Non-selected items must appear in the same relative order as in the input.
+        input_positions = {c["n"]: idx for idx, c in enumerate(combos)}
+        non_selected_positions = [input_positions[c["n"]] for c in result[2:]]
+        assert non_selected_positions == sorted(non_selected_positions)
 
 
 class TestGetBalancedCombinations:

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -1070,6 +1070,38 @@ class TestInitialSamplingStrategies:
         new_evals = optimizer.evaluations[len(known):]
         assert "vector" in {e["search_mode"] for e in new_evals}
 
+    def test_balanced_strategy_covers_non_balanced_column_values(self):
+        """'balanced' initial phase covers non-balanced column values (e.g. chunk_size).
+
+        Regression: the old full-tuple inner key created unique keys per combination,
+        making _round_robin a no-op and leaving all selected items at chunk_size=512.
+        """
+        mock_space = MagicMock(spec=SearchSpace)
+        # 2 search modes × 3 chunk_sizes × 2 methods = 12 combinations
+        mock_space.combinations = [
+            {"search_mode": mode, "chunk_size": size, "method": method}
+            for mode in ("vector", "hybrid")
+            for size in (512, 1024, 2048)
+            for method in ("recursive", "flat")
+        ]
+        mock_space.max_combinations = 12
+        settings = GAMOptSettings(
+            max_evals=12, n_random_nodes=6, random_state=64,
+            warm_start_strategy="balanced", fields_to_balance=["search_mode"],
+        )
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+        initial = optimizer.evaluations[:settings.n_random_nodes]
+        chunk_sizes_seen = {e["chunk_size"] for e in initial}
+        assert len(chunk_sizes_seen) > 1, (
+            f"Only one chunk_size ({chunk_sizes_seen}) appeared in the first "
+            f"{settings.n_random_nodes} evaluations — inner round-robin is broken."
+        )
+
     def test_greedy_strategy_covers_each_value_twice(self):
         """'greedy' strategy puts every discrete column value at least twice in first n."""
         mock_space = MagicMock(spec=SearchSpace)

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -23,7 +23,7 @@ class TestGAMOptSettings:
         assert settings.n_random_nodes == 4
         assert settings.evals_per_trial == 1
         assert settings.random_state == 64
-        assert settings.warm_start_strategy == "mode_balanced"
+        assert settings.warm_start_strategy == "random"
 
     def test_gam_opt_settings_creation_with_custom_values(self):
         """Test that GAMOptSettings can be instantiated with custom values."""
@@ -32,14 +32,16 @@ class TestGAMOptSettings:
             n_random_nodes=10,
             evals_per_trial=2,
             random_state=42,
-            warm_start_strategy="model_mode_balanced",
+            warm_start_strategy="balanced",
+            fields_to_balance=["search_mode", "foundation_model"],
         )
 
         assert settings.max_evals == 50
         assert settings.n_random_nodes == 10
         assert settings.evals_per_trial == 2
         assert settings.random_state == 42
-        assert settings.warm_start_strategy == "model_mode_balanced"
+        assert settings.warm_start_strategy == "balanced"
+        assert settings.fields_to_balance == ["search_mode", "foundation_model"]
 
     def test_gam_opt_settings_stores_n_random_nodes(self):
         """Test that GAMOptSettings stores n_random_nodes as provided."""
@@ -59,6 +61,17 @@ class TestGAMOptSettings:
         """Invalid warm_start_strategy is rejected at construction time."""
         with pytest.raises(ValueError, match="warm_start_strategy"):
             GAMOptSettings(max_evals=10, warm_start_strategy="invalid_strategy")
+
+    def test_gam_opt_settings_balanced_without_fields_raises(self):
+        """'balanced' strategy requires non-empty fields_to_balance."""
+        with pytest.raises(ValueError, match="fields_to_balance"):
+            GAMOptSettings(max_evals=10, warm_start_strategy="balanced")
+
+    def test_gam_opt_settings_all_valid_strategies(self):
+        """All three valid strategy names are accepted."""
+        GAMOptSettings(max_evals=10, warm_start_strategy="random")
+        GAMOptSettings(max_evals=10, warm_start_strategy="greedy")
+        GAMOptSettings(max_evals=10, warm_start_strategy="balanced", fields_to_balance=["search_mode"])
 
 
 class TestGAMOptimizer:
@@ -876,166 +889,165 @@ class TestPrepareTypedEncoder:
         assert not isinstance(param2_enc.classes_[0], str)
 
 
-class TestGetModeBalancedCombinations:
-    """Test the _get_mode_balanced_combinations static method."""
+class TestGetGreedyCombinations:
+    """Test the _get_greedy_combinations static method."""
 
-    def test_round_robins_between_two_modes(self):
-        """Combinations alternate between search_mode values."""
+    def test_each_string_value_appears_twice_in_first_n(self):
+        """Greedy selection puts both string values of each column in the first n."""
+        combos = [
+            {"mode": "vector", "method": "recursive"},
+            {"mode": "vector", "method": "hybrid"},
+            {"mode": "hybrid", "method": "recursive"},
+            {"mode": "hybrid", "method": "hybrid"},
+            {"mode": "vector", "method": "recursive"},
+            {"mode": "hybrid", "method": "hybrid"},
+        ]
+        result = GAMOptimizer._get_greedy_combinations(combos, 4)
+        first4_modes = [c["mode"] for c in result[:4]]
+        first4_methods = [c["method"] for c in result[:4]]
+        assert first4_modes.count("vector") >= 2
+        assert first4_modes.count("hybrid") >= 2
+        assert first4_methods.count("recursive") >= 2
+        assert first4_methods.count("hybrid") >= 2
+
+    def test_returns_all_combinations(self):
+        """All input combinations appear exactly once in output."""
+        combos = [{"mode": m, "n": i} for m in ("vector", "hybrid") for i in range(3)]
+        result = GAMOptimizer._get_greedy_combinations(combos, 4)
+        assert len(result) == 6
+        assert set(id(c) for c in result) == set(id(c) for c in combos)
+
+    def test_empty_returns_empty(self):
+        """Empty input returns empty output."""
+        assert GAMOptimizer._get_greedy_combinations([], 4) == []
+
+    def test_n_zero_returns_original(self):
+        """n=0 returns combinations unchanged."""
+        combos = [{"mode": "vector"}, {"mode": "hybrid"}]
+        result = GAMOptimizer._get_greedy_combinations(combos, 0)
+        assert result == combos
+
+    def test_no_string_columns_returns_unchanged(self):
+        """Combinations with only numeric columns are returned as-is."""
+        combos = [{"size": i} for i in range(4)]
+        result = GAMOptimizer._get_greedy_combinations(combos, 4)
+        assert result == combos
+
+    def test_rest_follows_original_shuffle_order(self):
+        """Combinations not selected greedy appear afterward in their incoming order."""
+        combos = [{"mode": "vector", "n": i} for i in range(6)]
+        result = GAMOptimizer._get_greedy_combinations(combos, 2)
+        assert len(result) == 6
+        # The non-selected items should maintain relative order
+        non_selected_n = [c["n"] for c in result[2:]]
+        assert non_selected_n == sorted(non_selected_n) or non_selected_n == list(reversed(sorted(non_selected_n))) or True  # order preserved from input
+
+
+class TestGetBalancedCombinations:
+    """Test the _get_balanced_combinations static method."""
+
+    def test_round_robins_between_two_field_values(self):
+        """Combinations alternate between the two values of the balanced field."""
         combos = (
             [{"search_mode": "vector", "n": i} for i in range(3)] +
             [{"search_mode": "hybrid", "n": i} for i in range(3)]
         )
-        result = GAMOptimizer._get_mode_balanced_combinations(combos)
+        result = GAMOptimizer._get_balanced_combinations(combos, ["search_mode"])
         assert len(result) == 6
         assert result[0]["search_mode"] != result[1]["search_mode"]
         assert result[2]["search_mode"] != result[3]["search_mode"]
 
-    def test_returns_all_combinations(self):
-        """All input combinations appear in the output."""
-        combos = (
-            [{"search_mode": "vector", "n": i} for i in range(3)] +
-            [{"search_mode": "hybrid", "n": i} for i in range(3)]
-        )
-        result = GAMOptimizer._get_mode_balanced_combinations(combos)
-        assert len(result) == 6
-
-    def test_empty_returns_empty(self):
-        """Empty input returns empty output."""
-        assert GAMOptimizer._get_mode_balanced_combinations([]) == []
-
-    def test_single_mode_preserves_order(self):
-        """A single-mode space is returned in original order."""
-        combos = [{"search_mode": "vector", "n": i} for i in range(4)]
-        result = GAMOptimizer._get_mode_balanced_combinations(combos)
-        assert [c["n"] for c in result] == [0, 1, 2, 3]
-
-    def test_missing_search_mode_key_uses_fallback_bucket(self):
-        """Combinations without search_mode are collected into a single bucket."""
-        combos = [{"n": i} for i in range(3)]
-        result = GAMOptimizer._get_mode_balanced_combinations(combos)
-        assert len(result) == 3
-
-    def test_skewed_space_first_n_alternates(self):
-        """With 6 hybrid and 2 vector, the first 4 results alternate modes."""
-        combos = (
-            [{"search_mode": "hybrid", "n": i} for i in range(6)] +
-            [{"search_mode": "vector", "n": i} for i in range(2)]
-        )
-        result = GAMOptimizer._get_mode_balanced_combinations(combos)
-        modes = [c["search_mode"] for c in result[:4]]
-        assert modes.count("vector") == 2
-        assert modes.count("hybrid") == 2
-
-
-class TestGetModelModeBalancedCombinations:
-    """Test the _get_model_mode_balanced_combinations static method."""
-
-    def test_single_model_pair_equivalent_to_mode_balanced(self):
-        """With one model pair, behaviour collapses to mode-balanced."""
-        fm = {"model_id": "fm1"}
-        em = {"model_id": "em1"}
-        combos = (
-            [{"foundation_model": fm, "embedding_model": em, "search_mode": "vector", "n": i} for i in range(3)] +
-            [{"foundation_model": fm, "embedding_model": em, "search_mode": "hybrid", "n": i} for i in range(3)]
-        )
-        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
-        assert len(result) == 6
-        assert result[0]["search_mode"] != result[1]["search_mode"]
-
-    def test_two_model_pairs_covers_all_buckets_in_first_four(self):
-        """With 2 model pairs × 2 modes = 4 buckets, each appears in first 4 results."""
+    def test_two_fields_covers_all_tuples_in_first_four(self):
+        """With 2 models × 2 modes = 4 tuples, each appears in first 4 results."""
         fm1, fm2 = {"model_id": "fm1"}, {"model_id": "fm2"}
         em = {"model_id": "em1"}
         combos = [
-            {"foundation_model": fm1, "embedding_model": em, "search_mode": "vector", "n": 0},
-            {"foundation_model": fm1, "embedding_model": em, "search_mode": "hybrid", "n": 0},
-            {"foundation_model": fm2, "embedding_model": em, "search_mode": "vector", "n": 0},
-            {"foundation_model": fm2, "embedding_model": em, "search_mode": "hybrid", "n": 0},
+            {"foundation_model": fm1, "embedding_model": em, "search_mode": "vector"},
+            {"foundation_model": fm1, "embedding_model": em, "search_mode": "hybrid"},
+            {"foundation_model": fm2, "embedding_model": em, "search_mode": "vector"},
+            {"foundation_model": fm2, "embedding_model": em, "search_mode": "hybrid"},
         ]
-        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        result = GAMOptimizer._get_balanced_combinations(combos, ["foundation_model", "search_mode"])
         assert len(result) == 4
         keys = {(c["foundation_model"]["model_id"], c["search_mode"]) for c in result}
         assert keys == {("fm1", "vector"), ("fm1", "hybrid"), ("fm2", "vector"), ("fm2", "hybrid")}
 
     def test_returns_all_combinations(self):
         """All input combinations appear in the output."""
-        fm = {"model_id": "fm1"}
-        em = {"model_id": "em1"}
         combos = (
-            [{"foundation_model": fm, "embedding_model": em, "search_mode": "vector", "n": i} for i in range(4)] +
-            [{"foundation_model": fm, "embedding_model": em, "search_mode": "hybrid", "n": i} for i in range(4)]
+            [{"search_mode": "vector", "n": i} for i in range(4)] +
+            [{"search_mode": "hybrid", "n": i} for i in range(4)]
         )
-        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        result = GAMOptimizer._get_balanced_combinations(combos, ["search_mode"])
         assert len(result) == 8
 
-    def test_empty_returns_empty(self):
+    def test_empty_fields_returns_unchanged(self):
+        """Empty fields_to_balance returns combinations unchanged."""
+        combos = [{"search_mode": "vector", "n": i} for i in range(4)]
+        result = GAMOptimizer._get_balanced_combinations(combos, [])
+        assert result == combos
+
+    def test_empty_combinations_returns_empty(self):
         """Empty input returns empty output."""
-        assert GAMOptimizer._get_model_mode_balanced_combinations([]) == []
+        assert GAMOptimizer._get_balanced_combinations([], ["search_mode"]) == []
 
     def test_string_model_values_are_keyed_directly(self):
         """Non-dict model values are converted to str for keying."""
         combos = [
-            {"foundation_model": "fm1", "embedding_model": "em1", "search_mode": "vector"},
-            {"foundation_model": "fm1", "embedding_model": "em1", "search_mode": "hybrid"},
+            {"foundation_model": "fm1", "search_mode": "vector"},
+            {"foundation_model": "fm1", "search_mode": "hybrid"},
         ]
-        result = GAMOptimizer._get_model_mode_balanced_combinations(combos)
+        result = GAMOptimizer._get_balanced_combinations(combos, ["foundation_model", "search_mode"])
         assert len(result) == 2
         assert result[0]["search_mode"] != result[1]["search_mode"]
 
 
-class TestModeBalancedInitialSampling:
-    """Test that evaluate_initial_random_nodes uses mode-balanced sampling."""
+class TestInitialSamplingStrategies:
+    """Test that evaluate_initial_random_nodes applies the correct strategy."""
 
-    def test_skewed_space_always_includes_both_modes(self):
-        """With a 3:1 hybrid/vector ratio, the initial sample always includes both modes."""
+    def test_random_strategy_evaluates_n_nodes(self):
+        """'random' strategy evaluates exactly n_random_nodes combinations."""
         mock_space = MagicMock(spec=SearchSpace)
-        mock_space.combinations = (
-            [{"search_mode": "hybrid", "size": i} for i in range(6)] +
-            [{"search_mode": "vector", "size": i} for i in range(2)]
-        )
+        mock_space.combinations = [{"search_mode": "hybrid", "size": i} for i in range(8)]
         mock_space.max_combinations = 8
-
-        settings = GAMOptSettings(max_evals=8, n_random_nodes=4)
+        settings = GAMOptSettings(max_evals=8, n_random_nodes=4, warm_start_strategy="random")
         optimizer = GAMOptimizer(
             objective_function=MagicMock(return_value=0.5),
             search_space=mock_space,
             settings=settings,
         )
         optimizer.evaluate_initial_random_nodes()
+        assert len(optimizer.evaluations) == 4
 
-        initial_evals = optimizer.evaluations[:settings.n_random_nodes]
-        modes = {e["search_mode"] for e in initial_evals}
-        assert "vector" in modes
-        assert "hybrid" in modes
-
-    def test_balanced_distribution_in_initial_nodes(self):
-        """Mode-balanced gives equal representation of each mode."""
+    def test_balanced_strategy_covers_all_tuples(self):
+        """'balanced' strategy covers all (model, mode) tuples in the first N evals."""
         mock_space = MagicMock(spec=SearchSpace)
+        fm1, fm2 = {"model_id": "fm1"}, {"model_id": "fm2"}
+        em = {"model_id": "em1"}
         mock_space.combinations = (
-            [{"search_mode": "vector", "size": i} for i in range(10)] +
-            [{"search_mode": "hybrid", "size": i} for i in range(10)]
+            [{"foundation_model": fm1, "embedding_model": em, "search_mode": "vector", "size": i} for i in range(3)] +
+            [{"foundation_model": fm1, "embedding_model": em, "search_mode": "hybrid", "size": i} for i in range(3)] +
+            [{"foundation_model": fm2, "embedding_model": em, "search_mode": "vector", "size": i} for i in range(3)] +
+            [{"foundation_model": fm2, "embedding_model": em, "search_mode": "hybrid", "size": i} for i in range(3)]
         )
-        mock_space.max_combinations = 20
-
-        settings = GAMOptSettings(max_evals=20, n_random_nodes=4)
+        mock_space.max_combinations = 12
+        settings = GAMOptSettings(
+            max_evals=12, n_random_nodes=4,
+            warm_start_strategy="balanced",
+            fields_to_balance=["foundation_model", "embedding_model", "search_mode"],
+        )
         optimizer = GAMOptimizer(
             objective_function=MagicMock(return_value=0.5),
             search_space=mock_space,
             settings=settings,
         )
         optimizer.evaluate_initial_random_nodes()
-
         initial = optimizer.evaluations[:settings.n_random_nodes]
-        assert sum(1 for e in initial if e["search_mode"] == "vector") == 2
-        assert sum(1 for e in initial if e["search_mode"] == "hybrid") == 2
+        buckets = {(e["foundation_model"]["model_id"], e["search_mode"]) for e in initial}
+        assert len(buckets) == 4
 
-    def test_warm_start_majority_leaves_room_for_minority_in_new_evals(self):
-        """When known obs are all majority mode, new evals cover the minority.
-
-        Mode-balanced round-robin guarantees that vector appears within the first
-        two new draws regardless of shuffle order, because there are only 2 vector
-        combos and 2 hybrid combos remaining after excluding the known observation.
-        """
+    def test_balanced_strategy_skewed_space_includes_minority(self):
+        """'balanced' with search_mode field covers both modes even in a skewed space."""
         mock_space = MagicMock(spec=SearchSpace)
         mock_space.combinations = [
             {"search_mode": "hybrid", "size": 256},
@@ -1045,12 +1057,9 @@ class TestModeBalancedInitialSampling:
             {"search_mode": "vector", "size": 512},
         ]
         mock_space.max_combinations = 5
-
         known = [{"search_mode": "hybrid", "size": 256, "score": 0.5}]
-        # Use a fixed random_state for reproducibility; mode-balanced guarantees
-        # vector coverage regardless, but pinning the seed makes the test explicit.
-        settings = GAMOptSettings(max_evals=5, n_random_nodes=3, random_state=42)
-
+        settings = GAMOptSettings(max_evals=5, n_random_nodes=4, random_state=42,
+                                  warm_start_strategy="balanced", fields_to_balance=["search_mode"])
         optimizer = GAMOptimizer(
             objective_function=MagicMock(return_value=0.5),
             search_space=mock_space,
@@ -1058,12 +1067,30 @@ class TestModeBalancedInitialSampling:
             known_observations=known,
         )
         optimizer.evaluate_initial_random_nodes()
-
         new_evals = optimizer.evaluations[len(known):]
         assert "vector" in {e["search_mode"] for e in new_evals}
 
+    def test_greedy_strategy_covers_each_value_twice(self):
+        """'greedy' strategy puts every string column value at least twice in first n."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = (
+            [{"search_mode": "vector", "method": "recursive", "size": i} for i in range(4)] +
+            [{"search_mode": "hybrid", "method": "hybrid", "size": i} for i in range(4)]
+        )
+        mock_space.max_combinations = 8
+        settings = GAMOptSettings(max_evals=8, n_random_nodes=4, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+        first4_modes = [e["search_mode"] for e in optimizer.evaluations[:4]]
+        assert first4_modes.count("vector") >= 2
+        assert first4_modes.count("hybrid") >= 2
+
     def test_sampling_is_deterministic_with_same_seed(self):
-        """Mode-balanced sampling is reproducible given the same random_state."""
+        """Sampling is reproducible given the same random_state."""
         mock_space = MagicMock(spec=SearchSpace)
         mock_space.combinations = (
             [{"search_mode": "hybrid", "size": i} for i in range(5)] +
@@ -1082,34 +1109,6 @@ class TestModeBalancedInitialSampling:
             return [e["size"] for e in opt.evaluations]
 
         assert make_optimizer() == make_optimizer()
-
-    def test_model_mode_balanced_strategy_covers_all_triples(self):
-        """model_mode_balanced covers all (model, mode) buckets in the first N evals."""
-        mock_space = MagicMock(spec=SearchSpace)
-        fm1, fm2 = {"model_id": "fm1"}, {"model_id": "fm2"}
-        em = {"model_id": "em1"}
-        mock_space.combinations = (
-            [{"foundation_model": fm1, "embedding_model": em, "search_mode": "vector", "size": i} for i in range(3)] +
-            [{"foundation_model": fm1, "embedding_model": em, "search_mode": "hybrid", "size": i} for i in range(3)] +
-            [{"foundation_model": fm2, "embedding_model": em, "search_mode": "vector", "size": i} for i in range(3)] +
-            [{"foundation_model": fm2, "embedding_model": em, "search_mode": "hybrid", "size": i} for i in range(3)]
-        )
-        mock_space.max_combinations = 12
-
-        settings = GAMOptSettings(
-            max_evals=12, n_random_nodes=4,
-            warm_start_strategy="model_mode_balanced",
-        )
-        optimizer = GAMOptimizer(
-            objective_function=MagicMock(return_value=0.5),
-            search_space=mock_space,
-            settings=settings,
-        )
-        optimizer.evaluate_initial_random_nodes()
-
-        initial = optimizer.evaluations[:settings.n_random_nodes]
-        buckets = {(e["foundation_model"]["model_id"], e["search_mode"]) for e in initial}
-        assert len(buckets) == 4
 
 
 class TestGAMOptimizerDeterminism:

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -1071,14 +1071,15 @@ class TestInitialSamplingStrategies:
         assert "vector" in {e["search_mode"] for e in new_evals}
 
     def test_greedy_strategy_covers_each_value_twice(self):
-        """'greedy' strategy puts every string column value at least twice in first n."""
+        """'greedy' strategy puts every discrete column value at least twice in first n."""
         mock_space = MagicMock(spec=SearchSpace)
+        # size has 2 unique values so max_unique=2, min_required=max(4,4)=4
         mock_space.combinations = (
-            [{"search_mode": "vector", "method": "recursive", "size": i} for i in range(4)] +
-            [{"search_mode": "hybrid", "method": "hybrid", "size": i} for i in range(4)]
+            [{"search_mode": "vector", "method": "recursive", "size": i} for i in range(2)] +
+            [{"search_mode": "hybrid", "method": "hybrid", "size": i} for i in range(2)]
         )
-        mock_space.max_combinations = 8
-        settings = GAMOptSettings(max_evals=8, n_random_nodes=4, warm_start_strategy="greedy")
+        mock_space.max_combinations = 4
+        settings = GAMOptSettings(max_evals=4, n_random_nodes=4, warm_start_strategy="greedy")
         optimizer = GAMOptimizer(
             objective_function=MagicMock(return_value=0.5),
             search_space=mock_space,

--- a/tests/unit/ai4rag/core/hpo/test_gam_opt.py
+++ b/tests/unit/ai4rag/core/hpo/test_gam_opt.py
@@ -1272,3 +1272,335 @@ class TestGAMOptimizerDeterminism:
         assert evals1 == evals2
         assert result1 == result2
         assert len(evals1) == 6
+
+
+class TestGreedyBalancedWarmStartAutoAdjust:
+    """Tests for the auto-adjusted warm start and fixed GAM iteration logic in greedy/balanced."""
+
+    def _make_space(self, n=8):
+        """Search space with 2 search_modes and 4 methods, totalling n combinations."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"search_mode": "vector", "method": m}
+            for m in ["a", "b", "c", "d"]
+        ] + [
+            {"search_mode": "hybrid", "method": m}
+            for m in ["a", "b", "c", "d"]
+        ]
+        mock_space.max_combinations = 8
+        return mock_space
+
+    # ------------------------------------------------------------------
+    # Auto-adjusted warm start (no ValueError when n_random_nodes < min_required)
+    # ------------------------------------------------------------------
+
+    def test_greedy_no_error_when_n_random_nodes_below_min_required(self):
+        """Greedy strategy no longer raises when n_random_nodes < min_required."""
+        mock_space = self._make_space()
+        # method has 4 unique values → max_unique=4, min_required=max(4,8)=8
+        # n_random_nodes=2 is well below 8 — should NOT raise.
+        settings = GAMOptSettings(max_evals=20, n_random_nodes=2, warm_start_strategy="greedy")
+        # Construction must succeed without ValueError.
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        assert optimizer is not None
+
+    def test_balanced_no_error_when_n_random_nodes_below_min_required(self):
+        """Balanced strategy no longer raises when n_random_nodes < min_required."""
+        mock_space = self._make_space()
+        # 2 search_mode values → n_balanced_tuples >= 2, min_required >= 4
+        settings = GAMOptSettings(
+            max_evals=20,
+            n_random_nodes=1,
+            warm_start_strategy="balanced",
+            fields_to_balance=["search_mode"],
+        )
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        assert optimizer is not None
+
+    def test_greedy_warm_start_evaluates_min_required_when_n_random_nodes_is_smaller(self):
+        """Warm start evaluates min_required nodes even when n_random_nodes < min_required."""
+        mock_space = self._make_space()
+        # method has 4 unique values → min_required = max(4, 2*4) = 8
+        # n_random_nodes=2 < 8, so effective_target=8
+        settings = GAMOptSettings(max_evals=30, n_random_nodes=2, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+        successful = sum(1 for e in optimizer.evaluations if e["score"] is not None)
+        assert successful == 8
+
+    def test_balanced_warm_start_evaluates_min_required_when_n_random_nodes_is_smaller(self):
+        """Balanced warm start evaluates min_required nodes even when n_random_nodes is smaller."""
+        mock_space = self._make_space()
+        # search_mode has 2 unique tuples; method has 4 values → min_required = max(4,2,4)=4
+        settings = GAMOptSettings(
+            max_evals=30,
+            n_random_nodes=1,
+            warm_start_strategy="balanced",
+            fields_to_balance=["search_mode"],
+        )
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluate_initial_random_nodes()
+        successful = sum(1 for e in optimizer.evaluations if e["score"] is not None)
+        assert successful >= 4
+
+    def test_compute_warm_start_effective_target_greedy(self):
+        """_compute_warm_start_effective_target respects max(n_random_nodes, min_required) for greedy."""
+        mock_space = self._make_space()
+        # method has 4 values → min_required = max(4, 8) = 8
+        settings = GAMOptSettings(max_evals=30, n_random_nodes=3, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        assert optimizer._compute_warm_start_effective_target() == 8
+
+    def test_compute_warm_start_effective_target_honours_larger_n_random_nodes(self):
+        """When n_random_nodes > min_required, effective_target uses n_random_nodes."""
+        mock_space = self._make_space()
+        # min_required=8, n_random_nodes=12 → effective_target=12
+        settings = GAMOptSettings(max_evals=30, n_random_nodes=12, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        assert optimizer._compute_warm_start_effective_target() == 12
+
+    def test_compute_warm_start_effective_target_random_unchanged(self):
+        """For random strategy, effective_target equals n_random_nodes."""
+        mock_space = self._make_space()
+        settings = GAMOptSettings(max_evals=30, n_random_nodes=3)
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        assert optimizer._compute_warm_start_effective_target() == 3
+
+    # ------------------------------------------------------------------
+    # Fixed GAM iterations: max_evals - floor(max_evals / 4)
+    # ------------------------------------------------------------------
+
+    def test_greedy_search_runs_fixed_gam_iterations(self, mocker):
+        """Greedy search runs max_evals - floor(min_required/4) GAM iterations after warm start."""
+        mock_space = MagicMock(spec=SearchSpace)
+        # search_mode has 2 unique values, method has 4, size has 4 → max_unique=4
+        # min_required = max(4, 2*4) = 8
+        # max_evals=20, n_gam_iters = 20 - (8//4) = 20 - 2 = 18
+        # Space size: 2×4×4 = 32 combinations (>8+18=26 needed)
+        mock_space.combinations = [
+            {"search_mode": m, "method": x, "size": s}
+            for m in ["vector", "hybrid"]
+            for x in ["a", "b", "c", "d"]
+            for s in [100, 200, 300, 400]
+        ]
+        mock_space.max_combinations = 32
+
+        mock_gam = MagicMock()
+        mock_gam.predict.return_value = np.array([0.5] * 32)
+        mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
+
+        settings = GAMOptSettings(max_evals=20, n_random_nodes=2, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        # effective_target = max(n_random_nodes=2, min_required=8) = 8
+        effective_warm_start = optimizer._compute_warm_start_effective_target()
+        assert effective_warm_start == 8
+
+        run_iteration_calls = []
+        original_run = optimizer._run_iteration
+
+        def counting_run():
+            run_iteration_calls.append(1)
+            original_run()
+
+        optimizer._run_iteration = counting_run
+        optimizer.search()
+
+        expected_gam_iters = 20 - (effective_warm_start // 4)  # 20 - 2 = 18
+        assert len(run_iteration_calls) == expected_gam_iters
+
+    def test_balanced_search_runs_fixed_gam_iterations(self, mocker):
+        """Balanced search runs max_evals - floor(min_required/4) GAM iterations after warm start."""
+        mock_space = MagicMock(spec=SearchSpace)
+        # search_mode has 2 unique values, method has 20 unique values
+        # min_required = max(4, 2_balanced_tuples, 20_non_balanced) = 20
+        # max_evals=12, n_gam_iters = 12 - (20//4) = 12 - 5 = 7
+        mock_space.combinations = [
+            {"search_mode": m, "method": f"x{i}"}
+            for m in ["vector", "hybrid"]
+            for i in range(20)
+        ]
+        mock_space.max_combinations = 40
+
+        mock_gam = MagicMock()
+        mock_gam.predict.return_value = np.array([0.5] * 40)
+        mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
+
+        settings = GAMOptSettings(
+            max_evals=12,
+            n_random_nodes=1,
+            warm_start_strategy="balanced",
+            fields_to_balance=["search_mode"],
+        )
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        # non_balanced "method" has 20 unique values → min_required = max(4, 2, 20) = 20
+        effective_warm_start = optimizer._compute_warm_start_effective_target()
+        assert effective_warm_start == 20
+
+        run_iteration_calls = []
+        original_run = optimizer._run_iteration
+
+        def counting_run():
+            run_iteration_calls.append(1)
+            original_run()
+
+        optimizer._run_iteration = counting_run
+        optimizer.search()
+
+        expected_gam_iters = 12 - (effective_warm_start // 4)  # 12 - 5 = 7
+        assert len(run_iteration_calls) == expected_gam_iters
+
+    # ------------------------------------------------------------------
+    # Trim to top max_evals by score
+    # ------------------------------------------------------------------
+
+    def test_trim_evaluations_to_top_keeps_best(self):
+        """_trim_evaluations_to_top retains the top n by score and discards the rest."""
+        mock_space = self._make_space()
+        settings = GAMOptSettings(max_evals=5, n_random_nodes=4, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluations = [
+            {"search_mode": "vector", "method": "a", "score": 0.9},
+            {"search_mode": "vector", "method": "b", "score": 0.3},
+            {"search_mode": "hybrid", "method": "a", "score": 0.7},
+            {"search_mode": "hybrid", "method": "b", "score": 0.5},
+            {"search_mode": "vector", "method": "c", "score": 0.1},
+            {"search_mode": "vector", "method": "d", "score": 0.8},
+            {"search_mode": "hybrid", "method": "c", "score": 0.6},
+        ]
+        optimizer._trim_evaluations_to_top(3)
+        assert len(optimizer.evaluations) == 3
+        scores = [e["score"] for e in optimizer.evaluations]
+        assert scores == [0.9, 0.8, 0.7]
+
+    def test_trim_evaluations_discards_failed_evaluations(self):
+        """_trim_evaluations_to_top drops entries with score=None."""
+        mock_space = self._make_space()
+        settings = GAMOptSettings(max_evals=5, n_random_nodes=4, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.evaluations = [
+            {"search_mode": "vector", "method": "a", "score": 0.9},
+            {"search_mode": "vector", "method": "b", "score": None},
+            {"search_mode": "hybrid", "method": "a", "score": 0.7},
+        ]
+        optimizer._trim_evaluations_to_top(5)
+        assert all(e["score"] is not None for e in optimizer.evaluations)
+        assert len(optimizer.evaluations) == 2
+
+    def test_greedy_search_when_max_evals_smaller_than_min_required(self, mocker):
+        """When max_evals < min_required, warm start still evaluates min_required nodes."""
+        mock_space = MagicMock(spec=SearchSpace)
+        # search_mode(2) × method(4) × size(4) = 32 combinations; max_unique=4
+        # min_required = max(4, 2*4) = 8; max_evals=4 < 8
+        # n_gam_iters = 4 - (8//4) = 4 - 2 = 2
+        mock_space.combinations = [
+            {"search_mode": m, "method": x, "size": s}
+            for m in ["vector", "hybrid"]
+            for x in ["a", "b", "c", "d"]
+            for s in [100, 200, 300, 400]
+        ]
+        mock_space.max_combinations = 32
+
+        mock_gam = MagicMock()
+        mock_gam.predict.return_value = np.array([0.5] * 32)
+        mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
+
+        settings = GAMOptSettings(max_evals=4, n_random_nodes=2, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=MagicMock(return_value=0.5),
+            search_space=mock_space,
+            settings=settings,
+        )
+        effective_warm_start = optimizer._compute_warm_start_effective_target()
+        assert effective_warm_start == 8  # min_required, not n_random_nodes or max_evals
+
+        run_iteration_calls = []
+        original_run = optimizer._run_iteration
+
+        def counting_run():
+            run_iteration_calls.append(1)
+            original_run()
+
+        optimizer._run_iteration = counting_run
+        optimizer.search()
+
+        # Warm start evaluated 8 nodes (min_required)
+        # GAM iterations: 4 - (8//4) = 2
+        assert len(run_iteration_calls) == 2
+        # Final evaluations trimmed to top max_evals=4
+        assert len(optimizer.evaluations) <= 4
+
+    def test_greedy_search_evaluations_trimmed_to_max_evals(self, mocker):
+        """After greedy search, evaluations are trimmed to the top max_evals by score."""
+        mock_space = MagicMock(spec=SearchSpace)
+        mock_space.combinations = [
+            {"search_mode": m, "method": f"x{i}"}
+            for m in ["vector", "hybrid"]
+            for i in range(20)
+        ]
+        mock_space.max_combinations = 40
+
+        mock_gam = MagicMock()
+        mock_gam.predict.return_value = np.array([0.5] * 40)
+        mocker.patch("ai4rag.core.hpo.gam_opt.LinearGAM", return_value=mock_gam)
+
+        call_count = [0]
+
+        def scoring_objective(params):
+            call_count[0] += 1
+            return call_count[0] * 0.01  # strictly increasing scores
+
+        settings = GAMOptSettings(max_evals=10, n_random_nodes=2, warm_start_strategy="greedy")
+        optimizer = GAMOptimizer(
+            objective_function=scoring_objective,
+            search_space=mock_space,
+            settings=settings,
+        )
+        optimizer.search()
+
+        assert len(optimizer.evaluations) <= 10
+        scores = [e["score"] for e in optimizer.evaluations]
+        assert scores == sorted(scores, reverse=True), "Evaluations should be sorted best-first"


### PR DESCRIPTION
## Description

Implements an effective warm-start strategy for the GAM-based HPO optimizer (`GamOpt`) and fixes a pgvector index creation bug.

## Motivation

The existing warm-start in `GamOpt` did not effectively seed the search space — it selected random initial nodes without accounting for coverage across discrete parameter values, causing early trials to cluster and the optimizer to explore poorly. The pgvector backend also failed to create the index correctly in some configurations.

## Changes

- **GAM warm start (core change):** Replaced the naive random node selection with a coverage-aware strategy that tracks which discrete column values have been seen and prioritizes under-represented combinations; uses round-robin balancing across buckets (`_round_robin`) to spread trials evenly across parameter value groups
- **Discrete column tracking:** Added `_get_discrete_column_values` and `_str_val` helpers to normalize model objects, dicts, and plain strings into comparable keys for coverage bookkeeping
- **Model column serialization:** Added `_serialize_dict_col` to handle model-valued DataFrame cells (both dict `{"model_id": "..."}` and object instances) before fitting the GAM, preventing type errors
- **Balanced combination fix:** Fixed off-by-one / ordering bug in the balanced combination selection
- **pgvector:** Fixed index creation when the vector store is initialized
- **Tests:** Expanded `test_gam_opt.py` with warm-start and coverage scenarios; added `test_rag_optimization.py`

## Testing

- `tests/unit/ai4rag/core/hpo/test_gam_opt.py` — extended unit tests covering warm start, round-robin balancing, discrete coverage, and model-object serialization
- `tests/unit/ai4rag/components/optimization/test_rag_optimization.py` — new tests for the optimization component

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Code follows style guide
- [ ] All checks passing
