### PR TITLE
Release 0.14.0

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0](https://github.com/IBM/ai4rag/releases/tag/v0.14.0)
+
+### Added
+- **Leaderboard** — `build_leaderboard_html()` gains an `optimization_metric_evaluator` parameter so the pinned leaderboard column resolves to the evaluator that drove optimization instead of always falling back to unitxt/custom when metric names collide across evaluators (e.g. `faithfulness`)
+
+### Changed
+- **Core** — split `ai4rag.components` into `ai4rag.utils` (pure, dependency-free business-logic helpers) and `pipelines-components` (KFP-only orchestration): `ai4rag.components.data` → `ai4rag.utils.data`, `ai4rag.components.assets_generator` → `ai4rag.utils.assets_generator` (`NotebookCell` and `create_placeholder_mapping` are no longer re-exported from the package `__init__`; import them from their submodules), `ai4rag.components.utils.{s3,maas_client}` grouped into a new `ai4rag.utils.clients` package, and `ai4rag.components.utils.docling_io` moved to `ai4rag.utils.docling_io`
+
+### Fixed
+- **Experiment** — `AI4RAGExperiment` now only includes the unitxt default metric bundle (`answer_correctness`, `faithfulness`, `context_correctness`, `overall_score`) when a unitxt evaluator is actually configured, instead of always including it regardless of active evaluators
+
+### Removed
+- **RAG optimization component** — `ai4rag.components.optimization` (`run_rag_optimization`, `OptimizationResult`) removed entirely; RAG-optimization orchestration is now a KFP-only concern living in `pipelines-components`, built on `ai4rag.core` and `ai4rag.search_space`
+- **Components** — the `ai4rag.components` package no longer exists; import from `ai4rag.utils` instead
+
+---
+
 ## [0.13.0](https://github.com/IBM/ai4rag/releases/tag/v0.13.0)
 
 ### Added


### PR DESCRIPTION
# Release v0.14.0

## Summary

This release untangles `ai4rag.components`, which had grown to mix two unrelated concerns: pure, dependency-free business logic and KFP-only pipeline orchestration. The former now lives under `ai4rag.utils` (`data`, `assets_generator`, `clients`, `docling_io`); the latter — RAG-optimization orchestration built on `ai4rag.core` and `ai4rag.search_space` — moves out of this package entirely into `pipelines-components`. Two related bugs surfaced during the move are also fixed: the unitxt default metric bundle no longer appears when no unitxt evaluator is configured, and the leaderboard's pinned optimization-metric column now resolves against the evaluator that actually drove optimization.

## Changes

### Added
- **Leaderboard** — `build_leaderboard_html()` gains an `optimization_metric_evaluator` parameter so the pinned leaderboard column resolves to the evaluator that drove optimization instead of always falling back to unitxt/custom when metric names collide across evaluators (e.g. `faithfulness`).

### Changed
- **Core** — split `ai4rag.components` into `ai4rag.utils` (pure, dependency-free business-logic helpers) and `pipelines-components` (KFP-only orchestration): `ai4rag.components.data` → `ai4rag.utils.data`, `ai4rag.components.assets_generator` → `ai4rag.utils.assets_generator` (`NotebookCell` and `create_placeholder_mapping` are no longer re-exported from the package `__init__`; import them from their submodules), `ai4rag.components.utils.{s3,maas_client}` grouped into a new `ai4rag.utils.clients` package, and `ai4rag.components.utils.docling_io` moved to `ai4rag.utils.docling_io`.

### Fixed
- **Experiment** — `AI4RAGExperiment` now only includes the unitxt default metric bundle (`answer_correctness`, `faithfulness`, `context_correctness`, `overall_score`) when a unitxt evaluator is actually configured, instead of always including it regardless of active evaluators.

### Removed
- **RAG optimization component** — `ai4rag.components.optimization` (`run_rag_optimization`, `OptimizationResult`) removed entirely; RAG-optimization orchestration is now a KFP-only concern living in `pipelines-components`, built on `ai4rag.core` and `ai4rag.search_space`.
- **Components** — the `ai4rag.components` package no longer exists; import from `ai4rag.utils` instead.

## Migration notes

This is a breaking release. Upgrading from `0.13.x` requires the following import changes:

1. **RAG optimization orchestration** — `ai4rag.components.optimization` (`run_rag_optimization`, `OptimizationResult`) is gone. This logic now lives in `pipelines-components`, built on `ai4rag.core` and `ai4rag.search_space`; migrate any direct callers there.
2. **Data helpers** — `ai4rag.components.data` → `ai4rag.utils.data`.
3. **Assets generator** — `ai4rag.components.assets_generator` → `ai4rag.utils.assets_generator`. `NotebookCell` and `create_placeholder_mapping` are no longer re-exported from the package `__init__`; import them from their submodules directly.
4. **Client / IO helpers** — `ai4rag.components.utils.s3` and `ai4rag.components.utils.maas_client` move into a new `ai4rag.utils.clients` package; `ai4rag.components.utils.docling_io` moves to `ai4rag.utils.docling_io`.
5. **Package data** — if you reference the `setuptools` package-data entry directly, it moved from `ai4rag.components.assets_generator` to `ai4rag.utils.assets_generator`.

## Checklist

- [x] `__version__` in `ai4rag/__init__.py` updated to `0.14.0`
- [x] `docs/about/changelog.md` updated
- [ ] All tests pass (`pytest`)
- [ ] Docs build successfully
