### PR TITLE
refactor(vector_store)!: switch pgvector backend from psycopg to asyncpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each config is a frozen dataclass with a `.from_env()` constructor and an `env_v
 
 ## Document processing
 
-ai4RAG uses [`docling-core`](https://github.com/docling-project/docling-core) for document representation and chunking. Documents are represented as `DoclingDocument` instances, and the `DoclingChunker` leverages docling's `HybridChunker` for structure-aware, token-aware chunking. `docling-core`, `openai`, and the vector store clients (`chromadb`, `pymilvus`, `pgvector`, `psycopg`) are all installed automatically with `ai4rag`.
+ai4RAG uses [`docling-core`](https://github.com/docling-project/docling-core) for document representation and chunking. Documents are represented as `DoclingDocument` instances, and the `DoclingChunker` leverages docling's `HybridChunker` for structure-aware, token-aware chunking. `docling-core`, `openai`, and the vector store clients (`chromadb`, `pymilvus`, `pgvector`, `asyncpg`) are all installed automatically with `ai4rag`.
 
 
 ## Quick start

--- a/ai4rag/rag/vector_store/pgvector.py
+++ b/ai4rag/rag/vector_store/pgvector.py
@@ -6,6 +6,7 @@ import asyncio
 import heapq
 import json
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -37,6 +38,20 @@ class _LoopBoundPool:
     pool: asyncpg.Pool
     loop: asyncio.AbstractEventLoop
     thread: threading.Thread
+
+
+class _InFlightTracker:
+    """Tracks calls dispatched via :meth:`PGVectorStore._run`, so :meth:`PGVectorStore.close`
+    can wait for them to drain before tearing down the event loop.
+
+    ``cond`` and ``count`` are always read and mutated together — one under the
+    other — so, like :class:`_LoopBoundPool`, they are bundled into a single
+    object rather than two separate attributes on the store.
+    """
+
+    def __init__(self) -> None:
+        self.cond = threading.Condition()
+        self.count = 0
 
 
 class PGVectorStore(BaseVectorStore):
@@ -71,6 +86,27 @@ class PGVectorStore(BaseVectorStore):
 
     _BATCH_SIZE = 1024
     _CONNECT_TIMEOUT = 10
+
+    # asyncpg has no equivalent of libpq's `keepalives_*` socket options (see the
+    # note on `_open_pool`), so a connection silently killed by an idle middlebox
+    # would otherwise surface as a hang bounded only by the OS's TCP retransmission
+    # timeout (minutes, not seconds) instead of a prompt, retryable error. Applied
+    # to both the acquire and the query on each hot-path call (see
+    # `_fetch_vector_rows`, `_fetch_keyword_rows`, `_insert_batch_async`) — never to
+    # the one-time DDL in `_create_table`/`_build_indexes`/`_drop_table`, which can
+    # legitimately take longer on a large collection and must not be cut short.
+    # Passing it to `pool.acquire()` too (not just the query itself) matters: asyncpg
+    # reuses that same budget for the connection's *release-time* cleanup (resetting
+    # session state, confirming a cancelled query) — without it, that cleanup step
+    # has no timeout of its own and could hang indefinitely on a truly dead
+    # connection, undoing the whole point of bounding the query.
+    _COMMAND_TIMEOUT = 90.0
+
+    # Shorter than asyncpg's own 300s default: proactively recycling idle pooled
+    # connections more often shrinks (but, absent a real keepalive, cannot fully
+    # close) the window in which a connection can be silently dropped while sitting
+    # idle in the pool between calls.
+    _MAX_INACTIVE_CONNECTION_LIFETIME = 60.0
 
     # search() and add_documents() may be called concurrently across threads (e.g.
     # one worker per benchmark question in query_rag(), or one per concurrent
@@ -180,6 +216,12 @@ class PGVectorStore(BaseVectorStore):
         self._table_created: bool = False
         self._db_lock = threading.Lock()
 
+        # Guards the handoff between _run() (reader) and close() (writer): close()
+        # must not stop/close the loop while another thread's _run() call is still
+        # dispatched on it. See _run() and close() for the drain protocol this
+        # implements.
+        self._inflight = _InFlightTracker()
+
     def _run(self, coro: Any) -> Any:
         """Run *coro* on the store's dedicated event loop and block for its result.
 
@@ -200,6 +242,13 @@ class PGVectorStore(BaseVectorStore):
         :meth:`_ensure_db`/:meth:`_ensure_pool` itself, so that lookup — which
         calls :meth:`_run` — always happens on the caller's thread.
 
+        Safe to call concurrently with :meth:`close`: this method and ``close()``
+        coordinate over :attr:`_inflight` so that a store closed mid-call raises
+        a clear :class:`RuntimeError` (never an ``AttributeError`` from a
+        half-torn-down ``self._db``), and ``close()`` blocks until every
+        in-flight :meth:`_run` call it can see has finished before stopping the
+        loop out from under it.
+
         Parameters
         ----------
         coro : Any
@@ -209,8 +258,63 @@ class PGVectorStore(BaseVectorStore):
         -------
         Any
             The coroutine's result.
+
+        Raises
+        ------
+        RuntimeError
+            If the store has already been closed via :meth:`close`.
         """
-        return asyncio.run_coroutine_threadsafe(coro, self._db.loop).result()
+        with self._inflight.cond:
+            db = self._db
+            if db is None:
+                coro.close()  # avoid a "coroutine was never awaited" warning
+                raise RuntimeError(f"PGVectorStore for collection {self._collection_name!r} is closed.")
+            self._inflight.count += 1
+        try:
+            return self._dispatch(db.loop, coro)
+        finally:
+            with self._inflight.cond:
+                self._inflight.count -= 1
+                if self._inflight.count == 0:
+                    self._inflight.cond.notify_all()
+
+    def _run_with_retry(self, make_coro: Callable[[], Any]) -> Any:
+        """Run a coroutine on the store's event loop, retrying once on a dropped connection.
+
+        *make_coro* is a zero-argument callable rather than a coroutine because a
+        coroutine object can only be awaited once: a retry needs a fresh one. The
+        pool discards a connection it finds broken and hands out a fresh one on
+        the next borrow, so the retry itself needs no explicit reconnect. This
+        recovers from a *transient* drop (recycled backend, dropped idle
+        connection); it deliberately does not mask a deterministic failure — an
+        operation that always kills the backend still surfaces after one retry.
+
+        Parameters
+        ----------
+        make_coro : Callable[[], Any]
+            Builds a fresh coroutine to run; called once, and again on retry.
+
+        Returns
+        -------
+        Any
+            The coroutine's result.
+        """
+        try:
+            return self._run(make_coro())
+        except asyncpg.exceptions.PostgresConnectionError as exc:
+            logger.warning("PGVector operation failed (%s); retrying once.", exc)
+            return self._run(make_coro())
+
+    @staticmethod
+    def _dispatch(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:
+        """Run *coro* on *loop* from another thread and block for its result.
+
+        Bare ``asyncio.run_coroutine_threadsafe(...).result()`` factored out so
+        :meth:`close` can dispatch the pool's shutdown coroutine onto a loop it
+        already holds a direct reference to, after :attr:`_db` has been cleared
+        and :meth:`_run` is no longer usable.
+        """
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
     def _ensure_pool(self) -> asyncpg.Pool:
         """Return the pool, opening it (and its background event loop) on the first call.
@@ -282,14 +386,10 @@ class PGVectorStore(BaseVectorStore):
         if self._config.password:
             connect_kwargs["password"] = self._config.password
 
-        # asyncpg has no equivalent of libpq's `keepalives_*` connection options,
-        # so a long idle gap between calls (e.g. during a slow embedding step) is
-        # no longer covered by TCP keepalives. A connection dropped that way
-        # surfaces as a PostgresConnectionError on next use, which
-        # _insert_batch_with_retry already retries once.
         return await asyncpg.create_pool(
             min_size=self._MIN_POOL_SIZE,
             max_size=self._config.pool_max_size,
+            max_inactive_connection_lifetime=self._MAX_INACTIVE_CONNECTION_LIFETIME,
             init=self._configure_connection,
             **connect_kwargs,
         )
@@ -588,20 +688,31 @@ class PGVectorStore(BaseVectorStore):
         # for every other concurrent search()/add_documents() on this store.
         embedding = self.embedding_model.embed_query(query)
         pool = self._ensure_db()
-        rows = self._run(self._fetch_vector_rows(pool, embedding, k))
+        rows = self._run_with_retry(lambda: self._fetch_vector_rows(pool, embedding, k))
+        results = self._vector_rows_to_results(rows)
+        if include_scores:
+            return results
+        return [chunk for chunk, _ in results]
 
+    def _vector_rows_to_results(self, rows: list[asyncpg.Record]) -> list[tuple[AI4RAGChunk, float]]:
+        """Convert raw dense-search rows into chunks paired with relevance scores."""
         results: list[tuple[AI4RAGChunk, float]] = []
         for content_text, metadata, distance in rows:
             score = self._distance_to_score(float(distance))
             chunk = AI4RAGChunk(text=content_text, metadata=self._parse_metadata(metadata))
             results.append((chunk, score))
-        if include_scores:
-            return results
-        return [chunk for chunk, _ in results]
+        return results
 
     async def _fetch_vector_rows(self, pool: asyncpg.Pool, embedding: list[float], k: int) -> list[asyncpg.Record]:
         """Run the dense similarity query and return the raw matching rows."""
-        async with pool.acquire() as conn:
+        # `acquire(timeout=...)` matters beyond bounding the wait for a free slot: asyncpg
+        # records it as the connection holder's budget for the *release-time* cleanup this
+        # `async with` triggers on exit (resetting session state, awaiting confirmation of a
+        # cancelled query) — see PoolConnectionHolder.release() in asyncpg/pool.py. Without it,
+        # that cleanup step defaults to no timeout at all, so a query that times out on a truly
+        # dead connection could still hang indefinitely at release, right where _COMMAND_TIMEOUT
+        # was meant to prevent exactly that.
+        async with pool.acquire(timeout=self._COMMAND_TIMEOUT) as conn:
             return await conn.fetch(
                 f"""
                 SELECT content_text, metadata, embedding {self._distance_operator} $1::vector AS distance
@@ -611,6 +722,7 @@ class PGVectorStore(BaseVectorStore):
                 """,
                 embedding,
                 k,
+                timeout=self._COMMAND_TIMEOUT,
             )
 
     def _search_keyword(self, query: str, k: int) -> list[tuple[AI4RAGChunk, float]]:
@@ -632,8 +744,11 @@ class PGVectorStore(BaseVectorStore):
             Matched chunks paired with their ``ts_rank`` scores.
         """
         pool = self._ensure_db()
-        rows = self._run(self._fetch_keyword_rows(pool, query, k))
+        rows = self._run_with_retry(lambda: self._fetch_keyword_rows(pool, query, k))
+        return self._keyword_rows_to_results(rows)
 
+    def _keyword_rows_to_results(self, rows: list[asyncpg.Record]) -> list[tuple[AI4RAGChunk, float]]:
+        """Convert raw keyword-search rows into chunks paired with ``ts_rank`` scores."""
         results: list[tuple[AI4RAGChunk, float]] = []
         for content_text, metadata, score in rows:
             chunk = AI4RAGChunk(text=content_text, metadata=self._parse_metadata(metadata))
@@ -642,7 +757,9 @@ class PGVectorStore(BaseVectorStore):
 
     async def _fetch_keyword_rows(self, pool: asyncpg.Pool, query: str, k: int) -> list[asyncpg.Record]:
         """Run the full-text query and return the raw matching rows."""
-        async with pool.acquire() as conn:
+        # See the matching comment in _fetch_vector_rows: the acquire-time timeout also
+        # bounds this connection's release-time cleanup, not just the wait for a free slot.
+        async with pool.acquire(timeout=self._COMMAND_TIMEOUT) as conn:
             return await conn.fetch(
                 f"""
                 SELECT content_text, metadata, ts_rank(tokenized_content, plainto_tsquery('english', $1)) AS score
@@ -653,7 +770,26 @@ class PGVectorStore(BaseVectorStore):
                 """,
                 query,
                 k,
+                timeout=self._COMMAND_TIMEOUT,
             )
+
+    async def _fetch_hybrid_rows(
+        self, pool: asyncpg.Pool, embedding: list[float], query: str, k: int
+    ) -> tuple[list[asyncpg.Record], list[asyncpg.Record]]:
+        """Run the dense and keyword row fetches concurrently and return both raw row sets.
+
+        The two queries are independent (different WHERE/ORDER BY clauses, no
+        shared state) and each borrows its own connection from *pool*, so
+        :func:`asyncio.gather` runs them concurrently on the shared event loop
+        instead of one waiting on the other's round trip — this coroutine is
+        dispatched as a single :meth:`_run` call for exactly that reason; two
+        separate ``_run`` calls from the caller thread would serialize them
+        again by blocking on the first's result before issuing the second.
+        """
+        return await asyncio.gather(
+            self._fetch_vector_rows(pool, embedding, k),
+            self._fetch_keyword_rows(pool, query, k),
+        )
 
     @staticmethod
     def _parse_metadata(metadata: dict | None) -> dict:
@@ -686,9 +822,11 @@ class PGVectorStore(BaseVectorStore):
     ) -> list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]:
         """Run a hybrid dense + full-text search with in-memory fusion.
 
-        Runs the dense and keyword searches independently, fuses their per-chunk
-        score maps with :class:`WeightedInMemoryAggregator`, and keeps the top
-        ``k`` results.
+        Runs the dense and keyword *database* queries concurrently — as a single
+        :func:`asyncio.gather` dispatched through one :meth:`_run` call, since the
+        keyword lookup has no dependency on the vector lookup or the embedding
+        step — then fuses their per-chunk score maps with
+        :class:`WeightedInMemoryAggregator` and keeps the top ``k`` results.
 
         Parameters
         ----------
@@ -711,10 +849,18 @@ class PGVectorStore(BaseVectorStore):
         list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]
             Fused chunks, optionally paired with their scores.
         """
-        vector_results = self._search_vector(query, k, include_scores=True)
-        keyword_results = self._search_keyword(query, k)
+        # embed_query() runs here, on the caller's own thread, for the same reason
+        # given in _search_vector — and because the vector fetch below needs the
+        # embedding before it can be dispatched at all.
+        embedding = self.embedding_model.embed_query(query)
+        pool = self._ensure_db()
+        vector_rows, keyword_rows = self._run_with_retry(lambda: self._fetch_hybrid_rows(pool, embedding, query, k))
         chunk_map, combined_scores = self._fuse_results(
-            vector_results, keyword_results, ranker_strategy, ranker_k, ranker_alpha
+            self._vector_rows_to_results(vector_rows),
+            self._keyword_rows_to_results(keyword_rows),
+            ranker_strategy,
+            ranker_k,
+            ranker_alpha,
         )
 
         top_k_items = heapq.nlargest(k, combined_scores.items(), key=lambda x: x[1])
@@ -812,7 +958,9 @@ class PGVectorStore(BaseVectorStore):
         for idx in range(0, len(values), batch_size):
             self._insert_batch_with_retry(pool, values[idx : idx + batch_size])
 
-    def _insert_batch(self, pool: asyncpg.Pool, batch: list[tuple[str, dict, list[float], str, str]]) -> None:
+    async def _insert_batch_async(
+        self, pool: asyncpg.Pool, batch: list[tuple[str, dict, list[float], str, str]]
+    ) -> None:
         """Upsert a single batch of rows into the table.
 
         The trailing text of each row feeds ``to_tsvector`` for the full-text
@@ -826,12 +974,9 @@ class PGVectorStore(BaseVectorStore):
             Rows to upsert, each as ``(id, metadata, embedding, content text,
             text to tokenize)``.
         """
-        self._run(self._insert_batch_async(pool, batch))
-
-    async def _insert_batch_async(
-        self, pool: asyncpg.Pool, batch: list[tuple[str, dict, list[float], str, str]]
-    ) -> None:
-        async with pool.acquire() as conn:
+        # See the matching comment in _fetch_vector_rows: the acquire-time timeout also
+        # bounds this connection's release-time cleanup, not just the wait for a free slot.
+        async with pool.acquire(timeout=self._COMMAND_TIMEOUT) as conn:
             await conn.executemany(
                 f"""
                 INSERT INTO {self._quoted_table()} (id, metadata, embedding, content_text, tokenized_content)
@@ -843,6 +988,7 @@ class PGVectorStore(BaseVectorStore):
                     tokenized_content = EXCLUDED.tokenized_content
                 """,
                 batch,
+                timeout=self._COMMAND_TIMEOUT,
             )
 
     def _insert_batch_with_retry(
@@ -856,17 +1002,20 @@ class PGVectorStore(BaseVectorStore):
         no explicit reconnect. This recovers from *transient* drops (recycled backend,
         middlebox); it deliberately does not mask a deterministic failure — a batch that
         always kills the backend still surfaces after one retry.
+
+        Kept distinct from the generic :meth:`_run_with_retry` so the retry log line can
+        report the batch size; behaviorally identical otherwise.
         """
         try:
-            self._insert_batch(pool, batch)
+            self._run(self._insert_batch_async(pool, batch))
         except asyncpg.exceptions.PostgresConnectionError as exc:
             logger.warning("PGVector insert failed (%s); retrying batch of %d rows.", exc, len(batch))
-            self._insert_batch(pool, batch)
+            self._run(self._insert_batch_async(pool, batch))
 
     def clean_collection(self) -> None:
         """Drop the PostgreSQL table."""
         pool = self._ensure_pool()
-        self._run(self._drop_table(pool))
+        self._run_with_retry(lambda: self._drop_table(pool))
 
     async def _drop_table(self, pool: asyncpg.Pool) -> None:
         async with pool.acquire() as conn:
@@ -879,12 +1028,22 @@ class PGVectorStore(BaseVectorStore):
         immediately, rather than dispatching onto a loop that has already
         stopped — which would hang forever waiting for a callback the stopped
         loop can never run.
+
+        Safe to call while another thread is mid-:meth:`_run`: :attr:`_db` is
+        cleared up front (under :attr:`_inflight`) so no *new* call can start,
+        but the loop and pool are only stopped once every call that already
+        started has finished — see :meth:`_run`. A call that started before
+        this method clears :attr:`_db` still completes normally; one that
+        starts after gets a clear ``RuntimeError`` instead of racing the teardown.
         """
-        if self._db is None:
-            return
-        db = self._db
-        self._run(db.pool.close())
+        with self._inflight.cond:
+            if self._db is None:
+                return
+            db = self._db
+            self._db = None
+            while self._inflight.count > 0:
+                self._inflight.cond.wait()
+        self._dispatch(db.loop, db.pool.close())
         db.loop.call_soon_threadsafe(db.loop.stop)
         db.thread.join()
         db.loop.close()
-        self._db = None

--- a/ai4rag/rag/vector_store/pgvector.py
+++ b/ai4rag/rag/vector_store/pgvector.py
@@ -2,14 +2,15 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
+import asyncio
 import heapq
 import json
 import threading
+from dataclasses import dataclass
 from typing import Any
 
-import psycopg
-from pgvector.psycopg import register_vector
-from psycopg_pool import ConnectionPool
+import asyncpg
+from pgvector.asyncpg import register_vector
 
 from ai4rag import logger
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
@@ -22,11 +23,35 @@ from ai4rag.rag.vector_store.utils import iter_unique_chunks, resolve_embedding_
 __all__ = ["PGVectorStore"]
 
 
+@dataclass(frozen=True)
+class _LoopBoundPool:
+    """A pool bundled with the background event loop/thread it is bound to.
+
+    asyncpg's ``Pool``/``Connection`` objects are only usable from the event
+    loop that created them, so these three always come into being together (in
+    :meth:`PGVectorStore._open_pool_sync`) and are torn down together (in
+    :meth:`PGVectorStore.close`); grouping them keeps that invariant obvious
+    and avoids three separately-nullable attributes on the store.
+    """
+
+    pool: asyncpg.Pool
+    loop: asyncio.AbstractEventLoop
+    thread: threading.Thread
+
+
 class PGVectorStore(BaseVectorStore):
     """Vector store backed by PostgreSQL with the ``pgvector`` extension.
 
     Supports pure vector search and hybrid search (dense vector + tsvector
     full-text) with RRF or weighted reranking via in-memory fusion.
+
+    Driven by ``asyncpg`` rather than ``psycopg``: asyncpg speaks the Postgres
+    wire protocol itself instead of wrapping the ``libpq`` C library, so it
+    ships as a normal self-contained wheel with no system ``libpq`` dependency
+    and none of ``psycopg[binary]``'s bundled-OpenSSL conflicts. Every public
+    method here stays synchronous (matching :class:`BaseVectorStore` and every
+    other backend) by dispatching onto one dedicated background event loop —
+    see :meth:`_run` — so callers never need to know asyncpg is involved.
 
     Parameters
     ----------
@@ -49,11 +74,13 @@ class PGVectorStore(BaseVectorStore):
 
     # search() and add_documents() may be called concurrently across threads (e.g.
     # one worker per benchmark question in query_rag(), or one per concurrent
-    # request in a deployed service), and a single shared psycopg connection is
-    # not safe for concurrent use. The pool starts at _MIN_POOL_SIZE and grows
-    # lazily up to the caller-supplied config.pool_max_size, so a fully concurrent
-    # caller never queues for a slot as long as pool_max_size covers its own
-    # concurrency (see PGVectorConfig.pool_max_size).
+    # request in a deployed service), and a single shared connection is not safe
+    # for concurrent use. The pool starts at _MIN_POOL_SIZE and grows lazily up to
+    # the caller-supplied config.pool_max_size, so a fully concurrent caller never
+    # queues for a slot as long as pool_max_size covers its own concurrency (see
+    # PGVectorConfig.pool_max_size). asyncpg's pool lives on one event loop shared
+    # by every caller thread (see _run), which is exactly what lets those threads'
+    # DB calls interleave concurrently instead of serializing on the loop.
     _MIN_POOL_SIZE = 1
 
     # pgvector caps HNSW (and IVFFlat) indexes on the ``vector`` type at 2000
@@ -148,17 +175,45 @@ class PGVectorStore(BaseVectorStore):
 
         # Pool and table are created lazily on first DB access so that
         # add_documents() can embed documents (the slow step) before any
-        # connection is opened.  For the *first* add_documents() call this
-        # eliminates idle connections accumulating TCP keepalive timeouts
-        # during embedding.  Subsequent calls rely on pool.check() (called
-        # after embed_documents in add_documents) to recycle stale connections
-        # before the batch insert.  _db_lock guards one-time pool + table init.
-        self._pool: ConnectionPool | None = None
+        # connection is opened. _db_lock guards one-time loop/pool/table init.
+        self._db: _LoopBoundPool | None = None
         self._table_created: bool = False
         self._db_lock = threading.Lock()
 
-    def _ensure_pool(self) -> ConnectionPool:
-        """Return the pool, opening it on the first call — does not create the table.
+    def _run(self, coro: Any) -> Any:
+        """Run *coro* on the store's dedicated event loop and block for its result.
+
+        asyncpg's ``Pool``/``Connection`` objects are bound to the event loop that
+        created them and are not safe to drive from arbitrary threads directly, so
+        every DB-touching coroutine is dispatched here instead of via
+        ``asyncio.run()`` (which would tear the pool down again after each call).
+        Multiple caller threads (e.g. one per question in ``query_rag()``) can call
+        this concurrently: each dispatches onto the same loop, where asyncpg's pool
+        multiplexes them across its connections exactly as it did across threads
+        with ``psycopg_pool.ConnectionPool``.
+
+        Must only be called from a thread other than the loop's own — calling it
+        from a coroutine already running on the loop would deadlock, since that
+        thread would be blocked waiting for a result the loop can never produce
+        while it is blocked. Every async helper method in this class receives an
+        already-opened ``pool``/``conn`` as an argument rather than calling
+        :meth:`_ensure_db`/:meth:`_ensure_pool` itself, so that lookup — which
+        calls :meth:`_run` — always happens on the caller's thread.
+
+        Parameters
+        ----------
+        coro : Any
+            The coroutine to run.
+
+        Returns
+        -------
+        Any
+            The coroutine's result.
+        """
+        return asyncio.run_coroutine_threadsafe(coro, self._db.loop).result()
+
+    def _ensure_pool(self) -> asyncpg.Pool:
+        """Return the pool, opening it (and its background event loop) on the first call.
 
         Use this when only a connection is needed and the table is not required
         (e.g. :meth:`clean_collection`, which drops the table unconditionally).
@@ -166,18 +221,84 @@ class PGVectorStore(BaseVectorStore):
 
         Thread-safe via double-checked locking.
         """
-        if self._pool is not None:
-            return self._pool
+        if self._db is not None:
+            return self._db.pool
         with self._db_lock:
-            if self._pool is None:
-                self._pool = self._open_pool()
-        return self._pool  # type: ignore[return-value]
+            if self._db is None:
+                self._db = self._open_pool_sync()
+        return self._db.pool
 
-    def _ensure_db(self) -> ConnectionPool:
+    def _open_pool_sync(self) -> _LoopBoundPool:
+        """Start the background event loop and open the pool on it.
+
+        asyncpg's ``Pool``/``Connection`` objects are bound to the loop that
+        creates them, so this store keeps one dedicated event loop alive on a
+        background thread for its whole lifetime (see :meth:`_run`), rather than
+        opening a new loop per call. If opening the pool fails (e.g. bad
+        credentials or an unreachable host), the loop and thread just started
+        for this attempt are torn down before the error is raised, so a retried
+        call — after the caller fixes the problem — does not leak the failed
+        attempt's thread.
+
+        Returns
+        -------
+        _LoopBoundPool
+            The opened pool bundled with the event loop/thread it is bound to.
+        """
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True, name=f"pgvector-{self._collection_name}")
+        thread.start()
+        try:
+            pool = asyncio.run_coroutine_threadsafe(self._open_pool(), loop).result()
+        except BaseException:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join()
+            loop.close()
+            raise
+        return _LoopBoundPool(pool=pool, loop=loop, thread=thread)
+
+    async def _open_pool(self) -> asyncpg.Pool:
+        """Open the asyncpg pool backing this store.
+
+        Every physical connection the pool creates — at startup, to grow the
+        pool under concurrent load, or to replace one it has closed — is
+        configured identically via *init*: the ``vector``/``jsonb`` type codecs
+        are registered and the ``pgvector`` extension is ensured, so no caller
+        ever sees an unconfigured connection regardless of pool churn.
+
+        Returns
+        -------
+        asyncpg.Pool
+            The opened pool, sized between :attr:`_MIN_POOL_SIZE` and
+            ``self._config.pool_max_size``.
+        """
+        connect_kwargs: dict[str, Any] = {
+            "host": self._config.host,
+            "port": self._config.port,
+            "database": self._config.dbname,
+            "user": self._config.user,
+            "timeout": self._CONNECT_TIMEOUT,
+        }
+        if self._config.password:
+            connect_kwargs["password"] = self._config.password
+
+        # asyncpg has no equivalent of libpq's `keepalives_*` connection options,
+        # so a long idle gap between calls (e.g. during a slow embedding step) is
+        # no longer covered by TCP keepalives. A connection dropped that way
+        # surfaces as a PostgresConnectionError on next use, which
+        # _insert_batch_with_retry already retries once.
+        return await asyncpg.create_pool(
+            min_size=self._MIN_POOL_SIZE,
+            max_size=self._config.pool_max_size,
+            init=self._configure_connection,
+            **connect_kwargs,
+        )
+
+    def _ensure_db(self) -> asyncpg.Pool:
         """Return the pool, opening it and creating the table on the first call.
 
         Calls :meth:`_ensure_pool` for the pool, then creates the backing table
-        once under :attr:`_db_lock`.  Concurrent callers all return the same
+        once under :attr:`_db_lock`. Concurrent callers all return the same
         pool; the table is created exactly once.
 
         Lock ordering: :attr:`_db_lock` only (no nesting with
@@ -188,72 +309,35 @@ class PGVectorStore(BaseVectorStore):
         if not self._table_created:
             with self._db_lock:
                 if not self._table_created:
-                    self._create_table(pool)
+                    self._run(self._create_table(pool))
                     self._table_created = True
         return pool
 
-    def _open_pool(self) -> ConnectionPool:
-        """Open the connection pool backing this store.
-
-        Every physical connection the pool creates — at startup, to grow the
-        pool under concurrent load, or to replace one the pool has detected as
-        broken — is configured identically via *configure*: the ``vector`` type
-        adapter is registered and the ``pgvector`` extension is ensured, so no
-        caller ever sees an unconfigured connection regardless of pool churn.
-
-        Returns
-        -------
-        ConnectionPool
-            The opened pool, sized between :attr:`_MIN_POOL_SIZE` and
-            ``self._config.pool_max_size``. Called by :meth:`_ensure_db` on the
-            first DB access, which also calls :meth:`_create_table` immediately
-            after — so a misconfigured connection fails fast on the first
-            database operation.
-        """
-        connect_kwargs: dict[str, Any] = {
-            "host": self._config.host,
-            "port": self._config.port,
-            "dbname": self._config.dbname,
-            "user": self._config.user,
-            "autocommit": True,
-            "connect_timeout": self._CONNECT_TIMEOUT,
-            # Keep idle connections alive through NAT/firewall middleboxes so a long
-            # embed-then-insert cycle is not silently dropped mid-batch.
-            "keepalives": 1,
-            "keepalives_idle": 30,
-            "keepalives_interval": 10,
-            "keepalives_count": 5,
-        }
-        if self._config.password:
-            connect_kwargs["password"] = self._config.password
-
-        return ConnectionPool(
-            kwargs=connect_kwargs,
-            min_size=self._MIN_POOL_SIZE,
-            max_size=self._config.pool_max_size,
-            configure=self._configure_connection,
-            timeout=self._CONNECT_TIMEOUT,
-            open=True,
-        )
-
     @staticmethod
-    def _configure_connection(conn: psycopg.Connection) -> None:
-        """Prepare one physical connection for use: register the vector adapter and ensure the extension.
+    async def _configure_connection(conn: asyncpg.Connection) -> None:
+        """Prepare one physical connection for use.
 
-        Passed to :class:`ConnectionPool` as its ``configure`` callback, so the
-        pool invokes it on every connection it creates — at startup, when
-        growing the pool, or when replacing one it found broken — rather than
-        this store calling it once itself.
+        Passed to :func:`asyncpg.create_pool` as its ``init`` callback, so it
+        runs on every connection the pool creates — at startup, when growing the
+        pool, or when replacing one it closed — rather than this store calling it
+        once itself.
+
+        The extension must be created *before* :func:`register_vector`: the
+        latter looks up the ``vector`` type's OID, which does not exist until
+        the extension has been created at least once. ``jsonb`` gets its own
+        codec so ``metadata`` round-trips as a plain ``dict`` — asyncpg, unlike
+        psycopg, does not decode ``jsonb`` to ``dict`` by default.
 
         Parameters
         ----------
-        conn : psycopg.Connection
+        conn : asyncpg.Connection
             A newly opened, not-yet-pooled connection.
         """
-        register_vector(conn)
-        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        await register_vector(conn)
+        await conn.set_type_codec("jsonb", schema="pg_catalog", encoder=json.dumps, decoder=json.loads, format="text")
 
-    def _create_table(self, pool: ConnectionPool) -> None:
+    async def _create_table(self, pool: asyncpg.Pool) -> None:
         """Create the backing table if it does not already exist.
 
         The table maps one-to-one to the collection name and holds the chunk id,
@@ -263,8 +347,8 @@ class PGVectorStore(BaseVectorStore):
         metadata. ``content_text`` is the sole source of truth for chunk text —
         it is not also duplicated inside ``metadata``.
         """
-        with pool.connection() as conn:
-            conn.execute(f"""
+        async with pool.acquire() as conn:
+            await conn.execute(f"""
                 CREATE TABLE IF NOT EXISTS {self._quoted_table()} (
                     id TEXT PRIMARY KEY,
                     metadata JSONB,
@@ -290,8 +374,8 @@ class PGVectorStore(BaseVectorStore):
         so the flag check is guarded by :attr:`_indexes_lock` with the standard double-checked
         pattern: without it, two threads can both see ``False``, and both race to run the
         DDL. PostgreSQL's ``IF NOT EXISTS`` is not atomic across concurrent sessions — the
-        loser doesn't silently no-op, it raises a real ``UniqueViolation`` on the system
-        catalog. The lock prevents that race for this instance; the ``UniqueViolation``
+        loser doesn't silently no-op, it raises a real ``UniqueViolationError`` on the system
+        catalog. The lock prevents that race for this instance; the ``UniqueViolationError``
         catch below is a second line of defense for a collection shared across instances
         (e.g. reused by another trial), where no Python-level lock can help.
 
@@ -310,60 +394,75 @@ class PGVectorStore(BaseVectorStore):
             if self._indexes_built:
                 return
 
+            pool = self._ensure_db()
             hnsw_idx = f"idx_{self._collection_name}_hnsw"
             gin_idx = f"idx_{self._collection_name}_gin"
-            with self._ensure_db().connection() as conn:
-                # Each statement is guarded independently, not by one shared try/except:
-                # under autocommit there is no transaction spanning them, so a race lost on
-                # one index must not skip creating the other.
-                if self._embedding_dimension <= self._MAX_INDEXABLE_DIMENSION:
-                    self._create_index_ignoring_race(
-                        conn,
-                        f"""
-                        CREATE INDEX IF NOT EXISTS {hnsw_idx}
-                        ON {self._quoted_table()} USING hnsw (embedding {self._index_ops})
-                        """,
-                    )
-                else:
-                    logger.info(
-                        "Skipping HNSW index for %s: embedding dimension %d exceeds "
-                        "pgvector's %d-dimension limit; search will use an exact "
-                        "sequential scan.",
-                        self._collection_name,
-                        self._embedding_dimension,
-                        self._MAX_INDEXABLE_DIMENSION,
-                    )
-                self._create_index_ignoring_race(
-                    conn,
-                    f"""
-                    CREATE INDEX IF NOT EXISTS {gin_idx}
-                    ON {self._quoted_table()} USING gin (tokenized_content)
-                    """,
-                )
+            self._run(self._build_indexes(pool, hnsw_idx, gin_idx))
 
             self._indexes_built = True
             logger.info("PGVector indexes ready: %s", self._collection_name)
 
-    def _create_index_ignoring_race(self, conn: psycopg.Connection, index_sql: str) -> None:
+    async def _build_indexes(self, pool: asyncpg.Pool, hnsw_idx: str, gin_idx: str) -> None:
+        """Issue the HNSW (if indexable) and GIN index DDL on one connection.
+
+        Parameters
+        ----------
+        pool : asyncpg.Pool
+            Pool to borrow the connection from.
+        hnsw_idx : str
+            Name for the HNSW index.
+        gin_idx : str
+            Name for the GIN full-text index.
+        """
+        async with pool.acquire() as conn:
+            # Each statement is guarded independently, not by one shared try/except:
+            # each is its own implicit transaction, so a race lost on one index must
+            # not skip creating the other.
+            if self._embedding_dimension <= self._MAX_INDEXABLE_DIMENSION:
+                await self._create_index_ignoring_race(
+                    conn,
+                    f"""
+                    CREATE INDEX IF NOT EXISTS {hnsw_idx}
+                    ON {self._quoted_table()} USING hnsw (embedding {self._index_ops})
+                    """,
+                )
+            else:
+                logger.info(
+                    "Skipping HNSW index for %s: embedding dimension %d exceeds "
+                    "pgvector's %d-dimension limit; search will use an exact "
+                    "sequential scan.",
+                    self._collection_name,
+                    self._embedding_dimension,
+                    self._MAX_INDEXABLE_DIMENSION,
+                )
+            await self._create_index_ignoring_race(
+                conn,
+                f"""
+                CREATE INDEX IF NOT EXISTS {gin_idx}
+                ON {self._quoted_table()} USING gin (tokenized_content)
+                """,
+            )
+
+    async def _create_index_ignoring_race(self, conn: asyncpg.Connection, index_sql: str) -> None:
         """Run a ``CREATE INDEX IF NOT EXISTS`` statement, tolerating a concurrent creator.
 
         PostgreSQL's ``IF NOT EXISTS`` is not atomic across concurrent sessions: two
         sessions that both see the index absent can both attempt to create it, and the
-        loser gets a real ``UniqueViolation`` on the system catalog rather than a silent
-        no-op. That outcome means the index now exists (created by the winner), which is
-        exactly what this method is trying to achieve, so it is swallowed rather than
-        raised.
+        loser gets a real ``UniqueViolationError`` on the system catalog rather than a
+        silent no-op. That outcome means the index now exists (created by the winner),
+        which is exactly what this method is trying to achieve, so it is swallowed
+        rather than raised.
 
         Parameters
         ----------
-        conn : psycopg.Connection
+        conn : asyncpg.Connection
             Connection to execute *index_sql* on.
         index_sql : str
             A ``CREATE INDEX IF NOT EXISTS ...`` statement.
         """
         try:
-            conn.execute(index_sql)
-        except psycopg.errors.UniqueViolation:
+            await conn.execute(index_sql)
+        except asyncpg.exceptions.UniqueViolationError:
             logger.info(
                 "PGVector index for %s was created concurrently elsewhere; continuing.",
                 self._collection_name,
@@ -483,18 +582,13 @@ class PGVectorStore(BaseVectorStore):
         list[AI4RAGChunk] | list[tuple[AI4RAGChunk, float]]
             Matched chunks, optionally paired with their scores.
         """
+        # embed_query() is a synchronous, network-bound call: it runs here, on the
+        # caller's own thread, before anything is dispatched to the shared event
+        # loop. Doing it inside the coroutine instead would block that one loop
+        # for every other concurrent search()/add_documents() on this store.
         embedding = self.embedding_model.embed_query(query)
-
-        with self._ensure_db().connection() as conn:
-            rows = conn.execute(
-                f"""
-                SELECT content_text, metadata, embedding {self._distance_operator} %s::vector AS distance
-                FROM {self._quoted_table()}
-                ORDER BY distance
-                LIMIT %s
-                """,
-                (embedding, k),
-            ).fetchall()
+        pool = self._ensure_db()
+        rows = self._run(self._fetch_vector_rows(pool, embedding, k))
 
         results: list[tuple[AI4RAGChunk, float]] = []
         for content_text, metadata, distance in rows:
@@ -504,6 +598,20 @@ class PGVectorStore(BaseVectorStore):
         if include_scores:
             return results
         return [chunk for chunk, _ in results]
+
+    async def _fetch_vector_rows(self, pool: asyncpg.Pool, embedding: list[float], k: int) -> list[asyncpg.Record]:
+        """Run the dense similarity query and return the raw matching rows."""
+        async with pool.acquire() as conn:
+            return await conn.fetch(
+                f"""
+                SELECT content_text, metadata, embedding {self._distance_operator} $1::vector AS distance
+                FROM {self._quoted_table()}
+                ORDER BY distance
+                LIMIT $2
+                """,
+                embedding,
+                k,
+            )
 
     def _search_keyword(self, query: str, k: int) -> list[tuple[AI4RAGChunk, float]]:
         """Run a PostgreSQL full-text (keyword) search.
@@ -523,17 +631,8 @@ class PGVectorStore(BaseVectorStore):
         list[tuple[AI4RAGChunk, float]]
             Matched chunks paired with their ``ts_rank`` scores.
         """
-        with self._ensure_db().connection() as conn:
-            rows = conn.execute(
-                f"""
-                SELECT content_text, metadata, ts_rank(tokenized_content, plainto_tsquery('english', %s)) AS score
-                FROM {self._quoted_table()}
-                WHERE tokenized_content @@ plainto_tsquery('english', %s)
-                ORDER BY score DESC
-                LIMIT %s
-                """,
-                (query, query, k),
-            ).fetchall()
+        pool = self._ensure_db()
+        rows = self._run(self._fetch_keyword_rows(pool, query, k))
 
         results: list[tuple[AI4RAGChunk, float]] = []
         for content_text, metadata, score in rows:
@@ -541,17 +640,32 @@ class PGVectorStore(BaseVectorStore):
             results.append((chunk, float(score)))
         return results
 
+    async def _fetch_keyword_rows(self, pool: asyncpg.Pool, query: str, k: int) -> list[asyncpg.Record]:
+        """Run the full-text query and return the raw matching rows."""
+        async with pool.acquire() as conn:
+            return await conn.fetch(
+                f"""
+                SELECT content_text, metadata, ts_rank(tokenized_content, plainto_tsquery('english', $1)) AS score
+                FROM {self._quoted_table()}
+                WHERE tokenized_content @@ plainto_tsquery('english', $1)
+                ORDER BY score DESC
+                LIMIT $2
+                """,
+                query,
+                k,
+            )
+
     @staticmethod
-    def _parse_metadata(metadata: dict | str | None) -> dict:
+    def _parse_metadata(metadata: dict | None) -> dict:
         """Normalize a ``metadata`` column value into a plain dict.
 
-        psycopg auto-decodes ``JSONB`` into a ``dict`` on most drivers, but a
-        defensive ``json.loads`` fallback keeps this correct if a connection
-        ever returns the raw JSON string instead.
+        The ``jsonb`` codec registered in :meth:`_configure_connection` decodes
+        the column to a ``dict`` (or ``None`` for SQL ``NULL``) on every
+        connection this store's pool hands out.
 
         Parameters
         ----------
-        metadata : dict | str | None
+        metadata : dict | None
             Raw value read from the ``metadata`` column.
 
         Returns
@@ -559,9 +673,7 @@ class PGVectorStore(BaseVectorStore):
         dict
             The chunk's metadata, or ``{}`` when none was stored.
         """
-        if isinstance(metadata, dict):
-            return metadata
-        return json.loads(metadata) if metadata else {}
+        return metadata or {}
 
     def _search_hybrid(
         self,
@@ -686,22 +798,21 @@ class PGVectorStore(BaseVectorStore):
         if not documents:
             return
 
+        # embed_documents() is a synchronous, network-bound call: it runs here, on
+        # the caller's own thread, before anything is dispatched to the shared
+        # event loop (see the matching note in _search_vector).
         embeddings = self.embedding_model.embed_documents([doc.text for doc in documents])
+        pool = self._ensure_db()
 
-        # Recycle any connections that went stale during the (potentially long)
-        # embedding step before borrowing one for the batch insert.
-        self._ensure_db().check()
-
-        values: list[tuple[str, str, list[float], str, str]] = []
+        values: list[tuple[str, dict, list[float], str, str]] = []
         for doc, embedding in iter_unique_chunks(documents, embeddings):
-            metadata_json = json.dumps(doc.metadata)
-            values.append((doc.chunk_id, metadata_json, embedding, doc.text, doc.text))
+            values.append((doc.chunk_id, doc.metadata, embedding, doc.text, doc.text))
 
         batch_size = kwargs.get("batch_size", self._BATCH_SIZE)
         for idx in range(0, len(values), batch_size):
-            self._insert_batch_with_retry(values[idx : idx + batch_size])
+            self._insert_batch_with_retry(pool, values[idx : idx + batch_size])
 
-    def _insert_batch(self, batch: list[tuple[str, str, list[float], str, str]]) -> None:
+    def _insert_batch(self, pool: asyncpg.Pool, batch: list[tuple[str, dict, list[float], str, str]]) -> None:
         """Upsert a single batch of rows into the table.
 
         The trailing text of each row feeds ``to_tsvector`` for the full-text
@@ -709,15 +820,22 @@ class PGVectorStore(BaseVectorStore):
 
         Parameters
         ----------
-        batch : list[tuple[str, str, list[float], str, str]]
-            Rows to upsert, each as ``(id, metadata JSON, embedding, content
-            text, text to tokenize)``.
+        pool : asyncpg.Pool
+            Pool to borrow the connection from.
+        batch : list[tuple[str, dict, list[float], str, str]]
+            Rows to upsert, each as ``(id, metadata, embedding, content text,
+            text to tokenize)``.
         """
-        with self._ensure_db().connection() as conn, conn.cursor() as cur:
-            cur.executemany(
+        self._run(self._insert_batch_async(pool, batch))
+
+    async def _insert_batch_async(
+        self, pool: asyncpg.Pool, batch: list[tuple[str, dict, list[float], str, str]]
+    ) -> None:
+        async with pool.acquire() as conn:
+            await conn.executemany(
                 f"""
                 INSERT INTO {self._quoted_table()} (id, metadata, embedding, content_text, tokenized_content)
-                VALUES (%s, %s::jsonb, %s::vector, %s, to_tsvector('english', %s))
+                VALUES ($1, $2::jsonb, $3::vector, $4, to_tsvector('english', $5))
                 ON CONFLICT (id) DO UPDATE SET
                     embedding = EXCLUDED.embedding,
                     metadata = EXCLUDED.metadata,
@@ -727,7 +845,9 @@ class PGVectorStore(BaseVectorStore):
                 batch,
             )
 
-    def _insert_batch_with_retry(self, batch: list[tuple[str, str, list[float], str, str]]) -> None:
+    def _insert_batch_with_retry(
+        self, pool: asyncpg.Pool, batch: list[tuple[str, dict, list[float], str, str]]
+    ) -> None:
         """Insert one batch, retrying once on a dropped connection.
 
         The ``ON CONFLICT`` upsert makes the retry idempotent even when the first attempt
@@ -738,17 +858,33 @@ class PGVectorStore(BaseVectorStore):
         always kills the backend still surfaces after one retry.
         """
         try:
-            self._insert_batch(batch)
-        except psycopg.OperationalError as exc:
+            self._insert_batch(pool, batch)
+        except asyncpg.exceptions.PostgresConnectionError as exc:
             logger.warning("PGVector insert failed (%s); retrying batch of %d rows.", exc, len(batch))
-            self._insert_batch(batch)
+            self._insert_batch(pool, batch)
 
     def clean_collection(self) -> None:
         """Drop the PostgreSQL table."""
-        with self._ensure_pool().connection() as conn:
-            conn.execute(f"DROP TABLE IF EXISTS {self._quoted_table()} CASCADE")
+        pool = self._ensure_pool()
+        self._run(self._drop_table(pool))
+
+    async def _drop_table(self, pool: asyncpg.Pool) -> None:
+        async with pool.acquire() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {self._quoted_table()} CASCADE")
 
     def close(self) -> None:
-        """Close the connection pool."""
-        if self._pool is not None:
-            self._pool.close()
+        """Close the connection pool and stop the store's background event loop.
+
+        Idempotent: a second call sees :attr:`_db` already ``None`` and returns
+        immediately, rather than dispatching onto a loop that has already
+        stopped — which would hang forever waiting for a callback the stopped
+        loop can never run.
+        """
+        if self._db is None:
+            return
+        db = self._db
+        self._run(db.pool.close())
+        db.loop.call_soon_threadsafe(db.loop.stop)
+        db.thread.join()
+        db.loop.close()
+        self._db = None

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -29,7 +29,7 @@ This installs the core package with all required dependencies.
 Using `"@main"` will download and install latest version of `ai4rag`.
 If you want to use specific version, please use e.g. `"@v0.1.1"`
 
-Vector store clients — `chromadb`, `pymilvus`, `pgvector`, and `psycopg` — are core dependencies and install automatically.
+Vector store clients — `chromadb`, `pymilvus`, `pgvector`, and `asyncpg` — are core dependencies and install automatically.
 No extra step is needed to use Chroma, Milvus, or PostgreSQL/pgvector as a vector store.
 
 !!! note "OCR and audio ingestion"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
   "multiprocess>=0.70",
   "openai~=2.53.0",
   "pandas==2.2.*",
+  "asyncpg>=0.29",
   "pgvector~=0.5.0",
-  "psycopg[binary,pool]>=3.1",
   "pydantic==2.11.*",
   "pygam~=0.12.0",
   "pymilvus~=3.0.1",
@@ -64,11 +64,20 @@ dev = [
   "ipykernel",
 ]
 
-test = ["ai4rag[text-extraction]", "pytest", "pytest-cov", "pytest-mock", "psutil", "nbformat"]
+test = [
+  "ai4rag[text-extraction]",
+  "pytest",
+  "pytest-cov",
+  "pytest-mock",
+  "psutil",
+  "nbformat",
+]
 
 code_check = ["pylint", "black", "isort"]
 
-text-extraction = ["docling-slim[standard,format-opendocument,format-audio]~=2.107.0"]
+text-extraction = [
+  "docling-slim[standard,format-opendocument,format-audio]~=2.107.0",
+]
 
 docs = [
   "mkdocs~=1.6.0",
@@ -119,12 +128,6 @@ disable = [
   "import-outside-toplevel",
   "broad-exception-caught",
 ]
-# psycopg's connection type cannot be introspected by astroid: `connect()` is an
-# overloaded classmethod returning `Self`, and importing `pgvector.psycopg`
-# (whose API is annotated with `Connection[Any]`) poisons the inference to an
-# anonymous class, yielding spurious no-member errors on every `execute`/`cursor`
-# call. Skip member checks for objects typed as coming from psycopg.
-ignored-modules = ["psycopg"]
 max-line-length = 120
 max-args = 8
 max-positional-arguments = 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,4 @@ max-line-length = 120
 max-args = 8
 max-positional-arguments = 8
 max-attributes = 10
+max-module-lines = 1100

--- a/tests/integration/vector_store/test_pgvector.py
+++ b/tests/integration/vector_store/test_pgvector.py
@@ -29,12 +29,16 @@ pytestmark = pytest.mark.skipif(
 
 def _table_exists(store: PGVectorStore) -> bool:
     """Return whether the store's backing table currently exists in the database."""
+
     # ``to_regclass`` resolves a relation name to its OID, or NULL if it does not
     # exist — a non-throwing existence check. The collection name IS the table
-    # name; ``_quoted_table`` supplies the safely-quoted identifier.
-    with store._pool.connection() as conn:
-        row = conn.execute("SELECT to_regclass(%s)", (store._quoted_table(),)).fetchone()
-    return row is not None and row[0] is not None
+    # name; ``_quoted_table`` supplies the safely-quoted identifier. Routed through
+    # store._run() since the pool's connections belong to the store's own event loop.
+    async def _check() -> object:
+        async with store._db.pool.acquire() as conn:
+            return await conn.fetchval("SELECT to_regclass($1)", store._quoted_table())
+
+    return store._run(_check()) is not None
 
 
 @pytest.mark.pgvector
@@ -114,11 +118,13 @@ class TestPGVectorIntegration:
 
 def _index_names(store: PGVectorStore) -> set[str]:
     """Return the names of every index currently defined on the store's table."""
-    with store._pool.connection() as conn:
-        rows = conn.execute(
-            "SELECT indexname FROM pg_indexes WHERE tablename = %s", (store.collection_name,)
-        ).fetchall()
-    return {row[0] for row in rows}
+
+    async def _fetch() -> list:
+        async with store._db.pool.acquire() as conn:
+            return await conn.fetch("SELECT indexname FROM pg_indexes WHERE tablename = $1", store.collection_name)
+
+    rows = store._run(_fetch())
+    return {row["indexname"] for row in rows}
 
 
 @pytest.mark.pgvector

--- a/tests/unit/ai4rag/rag/vector_store/test_get_vector_store.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_get_vector_store.py
@@ -109,8 +109,8 @@ class TestGetVectorStoreMilvus:
 class TestGetVectorStorePGVector:
     """Test suite for get_vector_store with PGVector provider."""
 
-    @patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
-    def test_pgvector_returns_vector_store(self, mock_pool_cls, mock_embedding_model):
+    @patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool")
+    def test_pgvector_returns_vector_store(self, mock_create_pool, mock_embedding_model):
         config = PGVectorConfig()
 
         vector_store = get_vector_store(

--- a/tests/unit/ai4rag/rag/vector_store/test_pgvector.py
+++ b/tests/unit/ai4rag/rag/vector_store/test_pgvector.py
@@ -2,17 +2,17 @@
 # Copyright IBM Corp. 2026
 # SPDX-License-Identifier: Apache-2.0
 # -----------------------------------------------------------------------------
-import json
+import asyncio
 import threading
-import time
 from dataclasses import replace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import psycopg
+import asyncpg
 import pytest
 
 from ai4rag.rag.chunking.chunk import AI4RAGChunk
 from ai4rag.rag.vector_store.config import PGVectorConfig
+from ai4rag.rag.vector_store.pgvector import PGVectorStore
 
 
 class _MockEmbeddingModel:
@@ -51,31 +51,69 @@ def pgvector_config():
     return PGVectorConfig(host="localhost", port=5432, dbname="testdb", user="testuser")
 
 
-def _conn_from(mock_pool_cls):
-    """Return the connection mock yielded by ``with self._pool.connection() as conn:``.
+@pytest.fixture(autouse=True)
+def _close_stores_after_test():
+    """Track every PGVectorStore created in a test and close() it on teardown.
 
-    ``pool.connection()`` is a fixed mock, so every call within a test — across
-    however many ``with`` blocks the store opens — resolves to this same object,
-    letting tests assert against one accumulated ``conn.execute.call_args_list``.
+    Unlike the old psycopg_pool-based store — entirely replaced by the
+    ``mock_pool_cls`` patch below, so opening it never touched real resources —
+    this store opens a *real* background thread and event loop the moment a
+    test triggers its first DB access (``asyncpg.create_pool`` is mocked, but
+    the loop/thread machinery around it lives in ``PGVectorStore`` itself, not
+    in asyncpg). Without closing each instance, every test that touches the DB
+    would leak one daemon thread for the rest of the process.
     """
-    pool = mock_pool_cls.return_value
-    return pool.connection.return_value.__enter__.return_value
+    created: list[PGVectorStore] = []
+    original_init = PGVectorStore.__init__
+
+    def _tracking_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        created.append(self)
+
+    with patch.object(PGVectorStore, "__init__", _tracking_init):
+        yield
+    for store in created:
+        store.close()
 
 
-@patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
+def _conn_from(mock_create_pool):
+    """Return the connection mock yielded by ``async with pool.acquire() as conn:``.
+
+    ``pool`` (``mock_create_pool.return_value``) is itself an ``AsyncMock`` —
+    every descendant attribute of an ``AsyncMock`` defaults to ``AsyncMock`` too,
+    so ``pool.acquire`` would otherwise be async and ``pool.acquire()`` would
+    return a bare coroutine instead of the awaitable *and* async-context-manager
+    object the real ``asyncpg.Pool.acquire()`` returns. Resetting it to a plain
+    ``MagicMock`` restores that: ``__aenter__``/``__aexit__`` are auto-async on
+    any ``MagicMock`` regardless, which is all ``async with pool.acquire() as
+    conn:`` needs. ``pool.acquire()`` is then a fixed mock, so every call within
+    a test — across however many ``async with`` blocks the store opens —
+    resolves to this same ``conn``, letting tests assert against one
+    accumulated ``conn.execute.call_args_list``. ``execute``/``fetch``/
+    ``executemany`` are likewise reset to plain ``AsyncMock`` (not inherited,
+    ordinary named attributes) so calling them returns an awaitable coroutine.
+    """
+    pool = mock_create_pool.return_value
+    pool.acquire = MagicMock()
+    conn = pool.acquire.return_value.__aenter__.return_value
+    conn.execute = AsyncMock()
+    conn.fetch = AsyncMock()
+    conn.executemany = AsyncMock()
+    return conn
+
+
+@patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool", new_callable=AsyncMock)
 class TestPGVectorStoreInit:
 
-    def test_creates_table_on_first_db_access_not_at_init(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_creates_table_on_first_db_access_not_at_init(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config)
 
         # Pool and table creation are deferred until the first DB operation so
         # that embed_documents() runs without any idle connections open.
         executed_at_init = " ".join(str(c) for c in conn.execute.call_args_list)
         assert "CREATE TABLE" not in executed_at_init
-        assert mock_pool_cls.call_count == 0
+        assert mock_create_pool.call_count == 0
 
         # First DB access (e.g. add_documents) triggers pool open + table creation.
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
@@ -87,22 +125,16 @@ class TestPGVectorStoreInit:
         assert "USING gin" not in executed_after
         assert store.collection_name.startswith("ai4rag_")
 
-    def test_reuses_collection_name(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_reuses_collection_name(self, mock_create_pool, mock_embedding, pgvector_config):
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_my_col")
         assert store.collection_name == "ai4rag_my_col"
 
-    def test_invalid_distance_metric_raises(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_invalid_distance_metric_raises(self, mock_create_pool, mock_embedding, pgvector_config):
         with pytest.raises(ValueError, match="Unsupported distance metric"):
             PGVectorStore(mock_embedding, pgvector_config, distance_metric="hamming")
 
-    def test_embedding_dimension_over_limit_logs_warning_and_proceeds(self, mock_pool_cls, pgvector_config, caplog):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
-        conn = _conn_from(mock_pool_cls)
+    def test_embedding_dimension_over_limit_logs_warning_and_proceeds(self, mock_create_pool, pgvector_config, caplog):
+        conn = _conn_from(mock_create_pool)
 
         with caplog.at_level("WARNING"):
             store = PGVectorStore(_HighDimEmbedding(), pgvector_config)
@@ -110,17 +142,15 @@ class TestPGVectorStoreInit:
         # Warning is emitted at construction time; pool + table are still deferred.
         assert store.collection_name.startswith("ai4rag_")
         assert any("exceeds pgvector's" in record.message for record in caplog.records)
-        mock_pool_cls.assert_not_called()
+        mock_create_pool.assert_not_called()
 
         # Trigger DB access; the table DDL must use the actual dimension.
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
-        mock_pool_cls.assert_called_once()
+        mock_create_pool.assert_called_once()
         executed = " ".join(str(c) for c in conn.execute.call_args_list)
         assert "vector(3072)" in executed
 
-    def test_embedding_dimension_at_limit_allowed(self, mock_pool_cls, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_embedding_dimension_at_limit_allowed(self, mock_create_pool, pgvector_config):
         class _LimitDimEmbedding:
             model_id = "limit-embedding"
             params = {"embedding_dimension": 2000}
@@ -131,7 +161,7 @@ class TestPGVectorStoreInit:
             def embed_query(self, query):
                 return [0.1] * 2000
 
-        conn = _conn_from(mock_pool_cls)
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(_LimitDimEmbedding(), pgvector_config)
         # Trigger DB access to materialise the table DDL.
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
@@ -140,83 +170,76 @@ class TestPGVectorStoreInit:
         executed = " ".join(str(c) for c in conn.execute.call_args_list)
         assert "vector(2000)" in executed
 
-    def test_password_passed_to_pool_kwargs(self, mock_pool_cls, mock_embedding):
+    def test_password_passed_to_pool_kwargs(self, mock_create_pool, mock_embedding):
         cfg = PGVectorConfig(host="h", port=5432, dbname="d", user="u", password="secret")
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+        _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, cfg, collection_name="ai4rag_c")
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
-        connect_kwargs = mock_pool_cls.call_args.kwargs["kwargs"]
+        connect_kwargs = mock_create_pool.call_args.kwargs
         assert connect_kwargs["password"] == "secret"
 
-    def test_no_password_skips_kwarg(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_no_password_skips_kwarg(self, mock_create_pool, mock_embedding, pgvector_config):
+        _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
-        connect_kwargs = mock_pool_cls.call_args.kwargs["kwargs"]
+        connect_kwargs = mock_create_pool.call_args.kwargs
         assert "password" not in connect_kwargs
 
-    def test_pool_sized_for_concurrent_search(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_pool_sized_for_concurrent_search(self, mock_create_pool, mock_embedding, pgvector_config):
+        _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
-        pool_kwargs = mock_pool_cls.call_args.kwargs
+        pool_kwargs = mock_create_pool.call_args.kwargs
         assert pool_kwargs["min_size"] == PGVectorStore._MIN_POOL_SIZE
         assert pool_kwargs["max_size"] == pgvector_config.pool_max_size
-        assert pool_kwargs["configure"] == PGVectorStore._configure_connection
+        assert pool_kwargs["init"] == PGVectorStore._configure_connection
 
-    def test_pool_max_size_follows_config(self, mock_pool_cls, mock_embedding, pgvector_config):
+    def test_pool_max_size_follows_config(self, mock_create_pool, mock_embedding, pgvector_config):
         """A caller-supplied ``pool_max_size`` — e.g. sized to its own query concurrency —
-        must reach ``ConnectionPool`` verbatim, not the class's historical default."""
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+        must reach ``create_pool`` verbatim, not the class's historical default."""
+        _conn_from(mock_create_pool)
         cfg = replace(pgvector_config, pool_max_size=25)
         store = PGVectorStore(mock_embedding, cfg, collection_name="ai4rag_c")
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
-        pool_kwargs = mock_pool_cls.call_args.kwargs
+        pool_kwargs = mock_create_pool.call_args.kwargs
         assert pool_kwargs["max_size"] == 25
 
 
 class TestConfigureConnection:
-    """Unit tests for the pool's per-connection setup, in isolation from ConnectionPool itself.
+    """Unit tests for the pool's per-connection setup, in isolation from asyncpg's pool itself.
 
-    ConnectionPool is a third-party dependency responsible for actually invoking
-    ``configure`` on each connection it creates; that behaviour is its own
-    library's concern, not ours to re-verify. These tests instead call
+    asyncpg's ``Pool`` is a third-party dependency responsible for actually invoking
+    ``init`` on each connection it creates; that behaviour is its own library's
+    concern, not ours to re-verify. These tests instead call
     ``_configure_connection`` directly to check that *our* setup logic is correct.
     """
 
-    @patch("ai4rag.rag.vector_store.pgvector.register_vector")
+    @patch("ai4rag.rag.vector_store.pgvector.register_vector", new_callable=AsyncMock)
     def test_registers_vector_adapter_and_ensures_extension(self, mock_register_vector):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
+        conn = MagicMock()
+        conn.execute = AsyncMock()
+        conn.set_type_codec = AsyncMock()
 
-        conn_execute_calls = []
+        asyncio.run(PGVectorStore._configure_connection(conn))
 
-        class _Conn:
-            def execute(self, sql):
-                conn_execute_calls.append(sql)
-
-        conn = _Conn()
-        PGVectorStore._configure_connection(conn)
-
+        # The extension must be created before register_vector() looks up its OID.
+        create_extension_call = conn.execute.call_args_list[0]
+        assert "CREATE EXTENSION" in create_extension_call.args[0]
         mock_register_vector.assert_called_once_with(conn)
-        assert any("CREATE EXTENSION" in sql for sql in conn_execute_calls)
+        conn.set_type_codec.assert_called_once()
+        assert conn.set_type_codec.call_args.args[0] == "jsonb"
 
 
-@patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
+@patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool", new_callable=AsyncMock)
 class TestPGVectorStoreSearch:
 
-    def _make_store(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def _make_store(self, mock_create_pool, mock_embedding, pgvector_config):
         return PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_test_col")
 
-    def test_indexes_built_lazily_on_first_search(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
-        conn.execute.return_value.fetchall.return_value = []
+    def test_indexes_built_lazily_on_first_search(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
+        conn.fetch.return_value = []
 
         # No index DDL has run yet after construction.
         assert "hnsw" not in " ".join(str(c) for c in conn.execute.call_args_list)
@@ -229,17 +252,14 @@ class TestPGVectorStoreSearch:
 
         # A second search must not re-issue the index DDL (guarded by _indexes_built).
         conn.execute.reset_mock()
-        conn.execute.return_value.fetchall.return_value = []
         store.search("query", k=1)
         assert "hnsw" not in " ".join(str(c) for c in conn.execute.call_args_list)
 
-    def test_high_dimension_search_skips_hnsw_builds_gin(self, mock_pool_cls, pgvector_config):
+    def test_high_dimension_search_skips_hnsw_builds_gin(self, mock_create_pool, pgvector_config):
         """Above pgvector's 2000-dim limit, HNSW is skipped but GIN and search still work."""
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
-        conn = _conn_from(mock_pool_cls)
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(_HighDimEmbedding(), pgvector_config, collection_name="ai4rag_highdim")
-        conn.execute.return_value.fetchall.return_value = [("hello", {}, 0.5)]
+        conn.fetch.return_value = [("hello", {}, 0.5)]
 
         results = store.search("query", k=1)
 
@@ -248,13 +268,11 @@ class TestPGVectorStoreSearch:
         assert "USING gin" in executed
         assert results[0].text == "hello"
 
-    def test_high_dimension_hybrid_search_still_fuses(self, mock_pool_cls, pgvector_config):
+    def test_high_dimension_hybrid_search_still_fuses(self, mock_create_pool, pgvector_config):
         """Hybrid fusion is independent of the embedding dimension/index tier."""
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
-        conn = _conn_from(mock_pool_cls)
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(_HighDimEmbedding(), pgvector_config, collection_name="ai4rag_highdim_hybrid")
-        conn.execute.return_value.fetchall.return_value = [("hello", {}, 0.5)]
+        conn.fetch.return_value = [("hello", {}, 0.5)]
 
         results = store.search("query", k=1, search_mode="hybrid", ranker_strategy="rrf")
 
@@ -262,29 +280,29 @@ class TestPGVectorStoreSearch:
         assert results[0].text == "hello"
 
     def test_ensure_indexes_is_thread_safe_under_concurrent_search(
-        self, mock_pool_cls, mock_embedding, pgvector_config
+        self, mock_create_pool, mock_embedding, pgvector_config
     ):
         """search() is called from multiple threads at once (see query_rag's ThreadPoolExecutor).
 
         Regression test: without a lock around the ``_indexes_built`` check-then-act,
         concurrent threads all observe it as False and all race to run
         ``CREATE INDEX IF NOT EXISTS``, which PostgreSQL does not make atomic across
-        sessions — the loser raises a real UniqueViolation instead of a silent no-op.
+        sessions — the loser raises a real UniqueViolationError instead of a silent
+        no-op.
         """
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
-        def _slow_execute(*_args, **_kwargs):
-            # A real CREATE INDEX/SELECT round-trip takes real time, during which the
-            # GIL is released and other threads run. Sleeping here reproduces that
+        async def _slow_execute(*_args, **_kwargs):
+            # A real CREATE INDEX/SELECT round-trip takes real time, during which
+            # other coroutines on the shared loop run. Sleeping here reproduces that
             # window against a mocked connection, which otherwise returns instantly and
             # never gives concurrent threads a chance to interleave on the race.
-            time.sleep(0.02)
-            result = MagicMock()
-            result.fetchall.return_value = []
-            return result
+            await asyncio.sleep(0.02)
+            return "CREATE INDEX"
 
         conn.execute.side_effect = _slow_execute
+        conn.fetch.return_value = []
 
         barrier = threading.Barrier(8)
         errors = []
@@ -308,41 +326,39 @@ class TestPGVectorStoreSearch:
         # The DDL must have run exactly once in total, not once per thread.
         assert executed.count("CREATE INDEX IF NOT EXISTS") == 2  # one HNSW + one GIN statement
 
-    def test_create_index_ignoring_race_swallows_unique_violation(self, mock_pool_cls, mock_embedding, pgvector_config):
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_create_index_ignoring_race_swallows_unique_violation(
+        self, mock_create_pool, mock_embedding, pgvector_config
+    ):
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
         conn = MagicMock()
-        conn.execute.side_effect = psycopg.errors.UniqueViolation("already exists")
+        conn.execute = AsyncMock(side_effect=asyncpg.exceptions.UniqueViolationError("already exists"))
 
-        store._create_index_ignoring_race(conn, "CREATE INDEX IF NOT EXISTS idx ...")  # must not raise
+        asyncio.run(store._create_index_ignoring_race(conn, "CREATE INDEX IF NOT EXISTS idx ..."))  # must not raise
 
-    def test_create_index_ignoring_race_reraises_other_errors(self, mock_pool_cls, mock_embedding, pgvector_config):
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_create_index_ignoring_race_reraises_other_errors(self, mock_create_pool, mock_embedding, pgvector_config):
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
         conn = MagicMock()
-        conn.execute.side_effect = psycopg.OperationalError("connection dropped")
+        conn.execute = AsyncMock(side_effect=asyncpg.exceptions.PostgresConnectionError("connection dropped"))
 
-        with pytest.raises(psycopg.OperationalError):
-            store._create_index_ignoring_race(conn, "CREATE INDEX IF NOT EXISTS idx ...")
+        with pytest.raises(asyncpg.exceptions.PostgresConnectionError):
+            asyncio.run(store._create_index_ignoring_race(conn, "CREATE INDEX IF NOT EXISTS idx ..."))
 
-    def test_vector_search(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_vector_search(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
-        conn.execute.return_value.fetchall.return_value = [
-            ("hello", {}, 0.5),
-        ]
+        conn.fetch.return_value = [("hello", {}, 0.5)]
 
         results = store.search("query", k=1)
         assert len(results) == 1
         assert isinstance(results[0], AI4RAGChunk)
         assert results[0].text == "hello"
 
-    def test_vector_search_with_scores(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_vector_search_with_scores(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
-        conn.execute.return_value.fetchall.return_value = [
-            ("hello", {}, 0.5),
-        ]
+        conn.fetch.return_value = [("hello", {}, 0.5)]
 
         results = store.search("query", k=1, include_scores=True)
         assert len(results) == 1
@@ -350,41 +366,29 @@ class TestPGVectorStoreSearch:
         assert chunk.text == "hello"
         assert score == pytest.approx(2.0)  # 1/0.5
 
-    def test_vector_search_metadata_as_json_string_is_parsed(self, mock_pool_cls, mock_embedding, pgvector_config):
-        """Defensive fallback: some drivers/paths may hand back the JSONB column as raw text."""
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_vector_search_null_metadata_defaults_to_empty_dict(
+        self, mock_create_pool, mock_embedding, pgvector_config
+    ):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
-        conn.execute.return_value.fetchall.return_value = [
-            ("hello", '{"document_id": "d1"}', 0.5),
-        ]
-
-        results = store.search("query", k=1)
-        assert results[0].metadata == {"document_id": "d1"}
-
-    def test_vector_search_null_metadata_defaults_to_empty_dict(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
-
-        conn.execute.return_value.fetchall.return_value = [("hello", None, 0.5)]
+        conn.fetch.return_value = [("hello", None, 0.5)]
 
         results = store.search("query", k=1)
         assert results[0].metadata == {}
 
-    def test_inner_product_scores_preserve_ranking(self, mock_pool_cls, mock_embedding):
+    def test_inner_product_scores_preserve_ranking(self, mock_create_pool, mock_embedding):
         """The ``<#>`` operator returns the *negative* inner product (a signed value):
         more similar rows have a more negative distance. A ``1 / distance`` transform
         would be non-monotonic and invert that ranking, so the store must negate the
         distance instead, restoring "higher score = more relevant".
         """
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
         cfg = PGVectorConfig(host="localhost", port=5432, dbname="testdb", user="testuser")
-        conn = _conn_from(mock_pool_cls)
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, cfg, distance_metric="inner_product", collection_name="ai4rag_ip")
 
         # Rows arrive already ordered by distance ASC: -0.9 (most similar) before -0.2.
-        conn.execute.return_value.fetchall.return_value = [
+        conn.fetch.return_value = [
             ("closer", {}, -0.9),
             ("farther", {}, -0.2),
         ]
@@ -397,114 +401,105 @@ class TestPGVectorStoreSearch:
         assert results[0][1] > results[1][1]
 
 
-@patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
+@patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool", new_callable=AsyncMock)
 class TestPGVectorStoreValidation:
 
-    def _make_store(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def _make_store(self, mock_create_pool, mock_embedding, pgvector_config):
         return PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_test_col")
 
-    def test_invalid_search_mode(self, mock_pool_cls, mock_embedding, pgvector_config):
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_invalid_search_mode(self, mock_create_pool, mock_embedding, pgvector_config):
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
         with pytest.raises(ValueError, match="Invalid search_mode"):
             store.search("q", k=1, search_mode="full_text")
 
-    def test_ranker_strategy_on_vector_mode(self, mock_pool_cls, mock_embedding, pgvector_config):
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_ranker_strategy_on_vector_mode(self, mock_create_pool, mock_embedding, pgvector_config):
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
         with pytest.raises(ValueError, match="only valid when search_mode='hybrid'"):
             store.search("q", k=1, search_mode="vector", ranker_strategy="rrf")
 
-    def test_hybrid_without_strategy(self, mock_pool_cls, mock_embedding, pgvector_config):
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_hybrid_without_strategy(self, mock_create_pool, mock_embedding, pgvector_config):
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
         with pytest.raises(ValueError, match="ranker_strategy must be set"):
             store.search("q", k=1, search_mode="hybrid")
 
 
-@patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
+@patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool", new_callable=AsyncMock)
 class TestPGVectorStoreAddDocuments:
 
-    def _make_store(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def _make_store(self, mock_create_pool, mock_embedding, pgvector_config):
         return PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_test_col")
 
-    def test_add_documents(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_add_documents(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
         docs = [AI4RAGChunk(text="hello", metadata={"document_id": "d1"})]
         store.add_documents(docs)
 
-        cursor = conn.cursor.return_value.__enter__.return_value
-        cursor.executemany.assert_called_once()
-        batch = cursor.executemany.call_args[0][1]
-        chunk_id, metadata_json, embedding, content_text, tokenize_text = batch[0]
+        conn.executemany.assert_called_once()
+        batch = conn.executemany.call_args.args[1]
+        chunk_id, metadata, embedding, content_text, tokenize_text = batch[0]
         assert chunk_id == docs[0].chunk_id
         assert content_text == "hello"
         assert tokenize_text == "hello"
-        assert json.loads(metadata_json) == {"document_id": "d1"}
+        assert metadata == {"document_id": "d1"}
 
-    def test_add_empty_documents(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_add_empty_documents(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
         store.add_documents([])
-        cursor = conn.cursor.return_value.__enter__.return_value
-        cursor.executemany.assert_not_called()
+        conn.executemany.assert_not_called()
 
-    def test_deduplicates_by_chunk_id(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_deduplicates_by_chunk_id(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
         chunk = AI4RAGChunk(text="same text", metadata={"document_id": "d1"})
         store.add_documents([chunk, chunk])
 
-        cursor = conn.cursor.return_value.__enter__.return_value
-        call_args = cursor.executemany.call_args
-        assert len(call_args[0][1]) == 1
+        call_args = conn.executemany.call_args
+        assert len(call_args.args[1]) == 1
 
-    def test_insert_retries_once_on_operational_error(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
-        cursor = conn.cursor.return_value.__enter__.return_value
+    def test_insert_retries_once_on_operational_error(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
         # First attempt hits a dropped backend; the pool hands out a working
         # connection (still the same mock here) on the retry.
-        cursor.executemany.side_effect = [psycopg.OperationalError("server closed the connection"), None]
+        conn.executemany.side_effect = [
+            asyncpg.exceptions.PostgresConnectionError("server closed the connection"),
+            None,
+        ]
 
         store.add_documents([AI4RAGChunk(text="hello", metadata={"document_id": "d1"})])
 
-        assert cursor.executemany.call_count == 2  # failed once, retried once
+        assert conn.executemany.call_count == 2  # failed once, retried once
 
-    def test_insert_does_not_mask_deterministic_failure(self, mock_pool_cls, mock_embedding, pgvector_config):
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
-        conn = _conn_from(mock_pool_cls)
-        cursor = conn.cursor.return_value.__enter__.return_value
-        cursor.executemany.side_effect = psycopg.OperationalError("always fails")
+    def test_insert_does_not_mask_deterministic_failure(self, mock_create_pool, mock_embedding, pgvector_config):
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
+        conn = _conn_from(mock_create_pool)
+        conn.executemany.side_effect = asyncpg.exceptions.PostgresConnectionError("always fails")
 
-        with pytest.raises(psycopg.OperationalError):
+        with pytest.raises(asyncpg.exceptions.PostgresConnectionError):
             store.add_documents([AI4RAGChunk(text="hello", metadata={"document_id": "d1"})])
 
-        assert cursor.executemany.call_count == 2  # one retry, then the error surfaces
+        assert conn.executemany.call_count == 2  # one retry, then the error surfaces
 
-    def test_custom_batch_size_splits_inserts(self, mock_pool_cls, mock_embedding, pgvector_config):
-        conn = _conn_from(mock_pool_cls)
-        store = self._make_store(mock_pool_cls, mock_embedding, pgvector_config)
+    def test_custom_batch_size_splits_inserts(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
+        store = self._make_store(mock_create_pool, mock_embedding, pgvector_config)
 
         docs = [AI4RAGChunk(text=f"doc {i}", metadata={"document_id": f"d{i}"}) for i in range(5)]
         store.add_documents(docs, batch_size=2)
 
-        cursor = conn.cursor.return_value.__enter__.return_value
-        assert cursor.executemany.call_count == 3  # 2 + 2 + 1
+        assert conn.executemany.call_count == 3  # 2 + 2 + 1
 
 
-@patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
+@patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool", new_callable=AsyncMock)
 class TestPGVectorStoreCleanAndClose:
 
-    def test_clean_collection(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
-        conn = _conn_from(mock_pool_cls)
+    def test_clean_collection(self, mock_create_pool, mock_embedding, pgvector_config):
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_to_drop")
 
         store.clean_collection()
@@ -515,33 +510,41 @@ class TestPGVectorStoreCleanAndClose:
         drop_calls = [c for c in conn.execute.call_args_list if "DROP TABLE" in str(c)]
         assert len(drop_calls) == 1
 
-    def test_close(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_close(self, mock_create_pool, mock_embedding, pgvector_config):
+        _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
         store.add_documents([AI4RAGChunk(text="x", metadata={})])
-        pool = mock_pool_cls.return_value
+        pool = mock_create_pool.return_value
+        pool.close = AsyncMock()
 
         store.close()
         pool.close.assert_called_once()
+        assert store._db is None
 
-    def test_close_before_any_db_access_is_safe(self, mock_pool_cls, mock_embedding, pgvector_config):
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_close_before_any_db_access_is_safe(self, mock_create_pool, mock_embedding, pgvector_config):
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
         store.close()  # pool was never opened — must not raise
-        mock_pool_cls.return_value.close.assert_not_called()
+        mock_create_pool.return_value.close.assert_not_called()
+
+    def test_close_is_idempotent(self, mock_create_pool, mock_embedding, pgvector_config):
+        """A second close() must not hang trying to dispatch onto the already-stopped loop."""
+        _conn_from(mock_create_pool)
+        store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
+        store.add_documents([AI4RAGChunk(text="x", metadata={})])
+        pool = mock_create_pool.return_value
+        pool.close = AsyncMock()
+
+        store.close()
+        store.close()  # must return immediately, not raise or hang
+        pool.close.assert_called_once()
 
 
-@patch("ai4rag.rag.vector_store.pgvector.ConnectionPool")
+@patch("ai4rag.rag.vector_store.pgvector.asyncpg.create_pool", new_callable=AsyncMock)
 class TestPGVectorStoreConcurrentInit:
     """Verify that concurrent first DB accesses initialise pool and table exactly once."""
 
-    def test_pool_opened_exactly_once_under_concurrent_access(self, mock_pool_cls, mock_embedding, pgvector_config):
-        import threading
-
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
+    def test_pool_opened_exactly_once_under_concurrent_access(self, mock_create_pool, mock_embedding, pgvector_config):
+        _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
         barrier = threading.Barrier(8)
         errors: list[Exception] = []
@@ -560,14 +563,12 @@ class TestPGVectorStoreConcurrentInit:
             t.join()
 
         assert not errors, f"Concurrent _ensure_db raised: {errors}"
-        assert mock_pool_cls.call_count == 1, "Pool must be opened exactly once"
+        assert mock_create_pool.call_count == 1, "Pool must be opened exactly once"
 
-    def test_table_created_exactly_once_under_concurrent_access(self, mock_pool_cls, mock_embedding, pgvector_config):
-        import threading
-
-        from ai4rag.rag.vector_store.pgvector import PGVectorStore
-
-        conn = _conn_from(mock_pool_cls)
+    def test_table_created_exactly_once_under_concurrent_access(
+        self, mock_create_pool, mock_embedding, pgvector_config
+    ):
+        conn = _conn_from(mock_create_pool)
         store = PGVectorStore(mock_embedding, pgvector_config, collection_name="ai4rag_c")
         barrier = threading.Barrier(8)
         errors: list[Exception] = []

--- a/uv.lock
+++ b/uv.lock
@@ -436,30 +436,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.87"
+version = "1.43.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/0c/b14374e9458030076cd22ff9381cf86d170f31b648fd901db1d88011094b/boto3-1.43.87.tar.gz", hash = "sha256:8d9521c7c292194b8ce9fb61043d52e45cdba29b5f690981f3eb5e75103ba57d", size = 112691, upload-time = "2026-09-02T19:23:13.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/d7b6ca0c2c21722c12b6ecc942ff3e2304c40f00724182500236616c4236/boto3-1.43.88.tar.gz", hash = "sha256:b3d03fba8ace049de27e3a6ed69b25a55d752f49d563394985e805ed5f0a0a74", size = 112730, upload-time = "2026-09-03T19:24:05.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/a9/7dd7cc1a2387f3c78f66e49682957b7e7d590706dc6552d108b48125022d/boto3-1.43.87-py3-none-any.whl", hash = "sha256:671cf88a353f887774603980898bc34249d05a994e1c5e24aba4f4e1bbef0951", size = 140026, upload-time = "2026-09-02T19:23:12.044Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/04/b024d6c8ba2ae18ebaf6597981069a6f51d97ab64d769d466936f1454954/boto3-1.43.88-py3-none-any.whl", hash = "sha256:62efee681fefc9b14244d66ab66ead11dd4a32fec0a54ac9f23106003ef210ca", size = 140024, upload-time = "2026-09-03T19:24:04.27Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.87"
+version = "1.43.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c4/64ebb159810a9840c57659f3ed98439bbc5680dc9708e3b08212deea301a/botocore-1.43.87.tar.gz", hash = "sha256:928598e7275fa70385d7f694d60d59afe115a0b914cc699dbf3eb60954c23bf1", size = 16064894, upload-time = "2026-09-02T19:23:08.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/16/8944ffdbd6df92c463b77e933bae41a46fb1ec903c48a286e855761ce115/botocore-1.43.88.tar.gz", hash = "sha256:3c8a6e2292f05c590c5d5299934dd23c81d19a2b6dd70b9eb724f79bd432d04f", size = 16072325, upload-time = "2026-09-03T19:24:01.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/5c/f15aa7a5da42fc85254f0150df7d377bb965b0c130c68f9701fba88e0df4/botocore-1.43.87-py3-none-any.whl", hash = "sha256:01e1e2255a8f4b959c19b210d74a5a916d13841c0344ceee15d8a3eaa4daa892", size = 15755750, upload-time = "2026-09-02T19:23:05.937Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b0/2981d533ebf7f93a3fa8493fb243e11225f31ad5ae36f3259fe7215d9141/botocore-1.43.88-py3-none-any.whl", hash = "sha256:1b59b6d74fb77b0c3934014b6693d56da4a9a172edb9454f9a5f711b4b3f7353", size = 15765383, upload-time = "2026-09-03T19:23:57.936Z" },
 ]
 
 [[package]]
@@ -1273,14 +1273,14 @@ wheels = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.75.2"
+version = "1.75.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
 ]
 
 [[package]]
@@ -1844,16 +1844,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.18"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/e9/0e5425e522b624d7c5c0911957b467b82890b36b0099bf727951f2ee3059/langchain-1.3.18.tar.gz", hash = "sha256:74ce99294f6f2c82ee64c3df39daa6a22085ee1449a718065b3604a88d78bf4d", size = 637052, upload-time = "2026-08-27T17:33:12.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/5d/0ef368fdcf5df08a394787196fb7a80f473a9c7b3fc4cd2e3b53a7a5853d/langchain-1.4.0.tar.gz", hash = "sha256:08da122a439f738f4c09a5158cfa3d2c1d8bea2d0bde7fbbf4aeb4d7f7fd9d80", size = 729354, upload-time = "2026-09-03T16:59:32.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/04/374f6014ed6959dbdab92962c2b09e4d0223ed6a82f65694870b46d2c13f/langchain-1.3.18-py3-none-any.whl", hash = "sha256:f29cbef985848e5cfff5398f3c8c1568994a3a6f2a8f4fa720df30b6e0668b9c", size = 148007, upload-time = "2026-08-27T17:33:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/92/fa/7da07d9977a5e292ef602c1bb911514ff8206e85dc09a66961874345d57a/langchain-1.4.0-py3-none-any.whl", hash = "sha256:af1dc0161d30944a52ec7844d9bf890d0497b12ec0703069f3503b4003cbbac3", size = 161534, upload-time = "2026-09-03T16:59:31.154Z" },
 ]
 
 [[package]]
@@ -2424,15 +2424,15 @@ name = "mlx-whisper"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "mlx", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "more-itertools", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "numba", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "numpy", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "scipy", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "tiktoken", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "torch", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "huggingface-hub" },
+    { name = "mlx" },
+    { name = "more-itertools" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "tiktoken" },
+    { name = "torch" },
+    { name = "tqdm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/b7/a35232812a2ccfffcb7614ba96a91338551a660a0e9815cee668bf5743f0/mlx_whisper-0.4.3-py3-none-any.whl", hash = "sha256:6b82b6597a994643a3e5496c7bc229a672e5ca308458455bfe276e76ae024489", size = 890544, upload-time = "2025-08-29T14:56:13.815Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,8 +4,7 @@ requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
     "python_full_version >= '3.13' and sys_platform != 'darwin'",
-    "python_full_version < '3.13' and sys_platform == 'darwin'",
-    "python_full_version < '3.13' and sys_platform != 'darwin'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -30,6 +29,7 @@ wheels = [
 name = "ai4rag"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncpg" },
     { name = "boto3" },
     { name = "chromadb" },
     { name = "docling-slim", extra = ["feat-chunking"] },
@@ -39,7 +39,6 @@ dependencies = [
     { name = "openai" },
     { name = "pandas" },
     { name = "pgvector" },
-    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pygam" },
     { name = "pymilvus" },
@@ -98,6 +97,7 @@ requires-dist = [
     { name = "ai4rag", extras = ["docs"], marker = "extra == 'dev'" },
     { name = "ai4rag", extras = ["test"], marker = "extra == 'dev'" },
     { name = "ai4rag", extras = ["text-extraction"], marker = "extra == 'test'" },
+    { name = "asyncpg", specifier = ">=0.29" },
     { name = "beautifulsoup4", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'code-check'" },
     { name = "boto3", specifier = ">=1.28" },
@@ -120,7 +120,6 @@ requires-dist = [
     { name = "pandas", specifier = "==2.2.*" },
     { name = "pgvector", specifier = "~=0.5.0" },
     { name = "psutil", marker = "extra == 'test'" },
-    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.1" },
     { name = "pydantic", specifier = "==2.11.*" },
     { name = "pygam", specifier = "~=0.12.0" },
     { name = "pylint", marker = "extra == 'code-check'" },
@@ -241,15 +240,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d
 
 [[package]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", hash = "sha256:b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e", size = 276504, upload-time = "2026-09-02T21:46:36.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", hash = "sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99", size = 131908, upload-time = "2026-09-02T21:46:35.485Z" },
 ]
 
 [[package]]
@@ -286,6 +285,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
 ]
 
 [[package]]
@@ -413,30 +436,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.86"
+version = "1.43.87"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/a0/b8693637bee21e266a52f3e1b8bb9fe4897934aa62c55cc132f8721c1b8f/boto3-1.43.86.tar.gz", hash = "sha256:aca7b5d7f31a90ad37bec773552ec9bfb57e0029c9aa0f0f4d51d5bf9607b1c4", size = 112685, upload-time = "2026-09-01T19:24:02.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/0c/b14374e9458030076cd22ff9381cf86d170f31b648fd901db1d88011094b/boto3-1.43.87.tar.gz", hash = "sha256:8d9521c7c292194b8ce9fb61043d52e45cdba29b5f690981f3eb5e75103ba57d", size = 112691, upload-time = "2026-09-02T19:23:13.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/dd/f4874f7bab882a778178b03965b1474c63f2e8bd2eea5dd714f06b0e8713/boto3-1.43.86-py3-none-any.whl", hash = "sha256:94543a5ce482df8bb6a0bf8a944bf5ccf6625889b1df0d7886dfc3311ebd4169", size = 140026, upload-time = "2026-09-01T19:24:00.638Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a9/7dd7cc1a2387f3c78f66e49682957b7e7d590706dc6552d108b48125022d/boto3-1.43.87-py3-none-any.whl", hash = "sha256:671cf88a353f887774603980898bc34249d05a994e1c5e24aba4f4e1bbef0951", size = 140026, upload-time = "2026-09-02T19:23:12.044Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.86"
+version = "1.43.87"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/77/0ed1c398b7d3aa5d02c1b15df32a049e07961339fe41640af1440079c2f7/botocore-1.43.86.tar.gz", hash = "sha256:0e943c77ab6a54aaaf4d57e6026ede5c3dca341af71ce91f71849a6eae9d5dbf", size = 16059433, upload-time = "2026-09-01T19:23:57.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/c4/64ebb159810a9840c57659f3ed98439bbc5680dc9708e3b08212deea301a/botocore-1.43.87.tar.gz", hash = "sha256:928598e7275fa70385d7f694d60d59afe115a0b914cc699dbf3eb60954c23bf1", size = 16064894, upload-time = "2026-09-02T19:23:08.777Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/59/eb95d57ea576feaf1693f5e914f9f27ff9961429cf9ecbc85cef610a6d84/botocore-1.43.86-py3-none-any.whl", hash = "sha256:4efc7fbd6e7616edbd55623bb585a044906149b9a5d3d8558420506526e5a5ac", size = 15751556, upload-time = "2026-09-01T19:23:54.013Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5c/f15aa7a5da42fc85254f0150df7d377bb965b0c130c68f9701fba88e0df4/botocore-1.43.87-py3-none-any.whl", hash = "sha256:01e1e2255a8f4b959c19b210d74a5a916d13841c0344ceee15d8a3eaa4daa892", size = 15755750, upload-time = "2026-09-02T19:23:05.937Z" },
 ]
 
 [[package]]
@@ -444,7 +467,7 @@ name = "build"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt' and sys_platform != 'darwin'" },
+    { name = "colorama", marker = "(python_full_version < '3.13' and os_name == 'nt') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
@@ -710,7 +733,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -721,10 +744,10 @@ wheels = [
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.8.0"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/b1/ef21259ec74fe0b265ed201379de1d0ef7c14178313ee03705952f1b7093/cuda_pathfinder-1.8.0-py3-none-any.whl", hash = "sha256:c44e574dc997fae2814721d1ae97d0fd6db76db82decbe9b753bf75de53f515e", size = 62539, upload-time = "2026-08-27T21:33:03.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e6/22df83f82f9bc26cb1c42265cf14d34d4908dba2a0f261bd7b28244acb00/cuda_pathfinder-1.8.1-py3-none-any.whl", hash = "sha256:ae0137ff9e56ea97499bcbf54f5f2778ec25f3266715ac86da192a795af982a8", size = 62552, upload-time = "2026-09-02T16:55:28.64Z" },
 ]
 
 [[package]]
@@ -882,7 +905,7 @@ wheels = [
 
 [[package]]
 name = "docling-core"
-version = "2.93.0"
+version = "2.94.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
@@ -899,9 +922,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/33/e30a27d8da4ce3414cce522ec31fcbc842430141b60424c1ea99c903d3e2/docling_core-2.93.0.tar.gz", hash = "sha256:0bdf6f42b0c83ca4dcd3916e6d1fbcfdc87168d93f192e00a1d2b0c55d5357d4", size = 363160, upload-time = "2026-09-01T10:47:45.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/4d/d51f349cf945b74256ff82af3cae5c91d01a7deecf1c564372ac821d97c8/docling_core-2.94.1.tar.gz", hash = "sha256:830dc840b2edde03b6e49529bba61975b5d72a4000181b34d632a4dcd19e2e6c", size = 369033, upload-time = "2026-09-03T11:26:55.12Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/e2/3edceae55162002a8f9484436e0fbfc589bd26b2a98af677d4a9780a3134/docling_core-2.93.0-py3-none-any.whl", hash = "sha256:5c0b9df0d4f5a969928968484b4736a4201b61d41f5132ce9fbcba00a50be5e8", size = 296557, upload-time = "2026-09-01T10:47:43.65Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/5e/7a67d59fbd4132c7e53bb9da6f74fe81393ce140405f020aabd32a6b1b89/docling_core-2.94.1-py3-none-any.whl", hash = "sha256:b7399ce466dcc8735b7981918f39525c01fce981eefbc6f46ee291c1feeea0dc", size = 299193, upload-time = "2026-09-03T11:26:53.531Z" },
 ]
 
 [package.optional-dependencies]
@@ -917,7 +940,7 @@ chunking = [
 
 [[package]]
 name = "docling-ibm-models"
-version = "3.15.0"
+version = "3.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
@@ -934,14 +957,14 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/17/6ff282d494a6d2f4299ca2edb2d4f353ff46f4512868284565ad77e0221e/docling_ibm_models-3.15.0.tar.gz", hash = "sha256:bea2c97a65657e6343877126c8c9a815599724edae6eda63df55e612276c2d3a", size = 105732, upload-time = "2026-08-28T07:04:10.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/25/84166f5751d7837612138966669019a4ef67c09bf6d3ef8d3cc1aa0e6268/docling_ibm_models-3.13.2.tar.gz", hash = "sha256:195e02dd119df34d2ce5f76ac614da82825851013e4898db7b0468cdf8740a3d", size = 98655, upload-time = "2026-04-23T11:04:23.517Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/ca/a74621564f89f0e37223e5037f280cb0cc2b6c473f22451febb12d5ef63f/docling_ibm_models-3.15.0-py3-none-any.whl", hash = "sha256:5220773b8731c269b4edf3e0b02dd1703aff22721d84c40773af8f39da421db5", size = 95702, upload-time = "2026-08-28T07:04:08.844Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/fc/584f75ca31aa6694fed5338ecb54dc4c8341704b1e5b7b6a4528651f12fa/docling_ibm_models-3.13.2-py3-none-any.whl", hash = "sha256:5fa0838bf15a4e06d2fcb686d756a6f4c329ea0a8820d085f06d07abe96269ed", size = 94013, upload-time = "2026-04-23T11:04:22.227Z" },
 ]
 
 [[package]]
 name = "docling-parse"
-version = "7.16.0"
+version = "7.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docling-core" },
@@ -949,18 +972,18 @@ dependencies = [
     { name = "pydantic" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/ee/83a4fb9926b0fb0185b30797a98027a8e433284a0bf16396c11fb85a09b6/docling_parse-7.16.0.tar.gz", hash = "sha256:870e781f7b7d1403d1168bf860c19fd2ab5ddb42335c60a1927673fa8fc615e2", size = 6963225, upload-time = "2026-08-25T15:49:04.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/86/4f3626af40ecf63df55b942927166764cd9953ea09de3323e6bf11202b82/docling_parse-7.17.0.tar.gz", hash = "sha256:21768a5d76b2a6d35dc5ca4d505f3e82dec59e6496a57d86dca43297b4566420", size = 6977090, upload-time = "2026-09-02T20:29:38.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e3/02e6e02eef860e276587c90896dd86d897e1150bf984c6135f4ab61f9352/docling_parse-7.16.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cb173b447806ff3a4af3c06936e9585dc201b3ecbb958aebde37a2725471675f", size = 9762630, upload-time = "2026-08-25T15:48:36.814Z" },
-    { url = "https://files.pythonhosted.org/packages/25/70/3702dd16141ac8e45548d3f09d2e66c373a96ffc871086a0bb022caa81de/docling_parse-7.16.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2c2bf844d567f729aa2a48f22b3c4f5d7e5a7db6b6b3a9ec07b45cf31d4ce3e", size = 10286523, upload-time = "2026-08-25T15:48:38.495Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/cb/cece74107282ce7cfe00d14ce5a33d2056aed689a34d20965be4779972da/docling_parse-7.16.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ab71b6b9d1085b08ca2a3529356ae3122e56a8be693a32d37e996ae88c6fe866", size = 10686779, upload-time = "2026-08-25T15:48:40.223Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b3/52068732b63eae2cbae779d057c311e0010e761e5853ad233080cf201a53/docling_parse-7.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:f1abfe050b670bcb25c7bcefc5d876bc3561949c1bff177e8a8a3d8d6f217314", size = 11746880, upload-time = "2026-08-25T15:48:42.089Z" },
-    { url = "https://files.pythonhosted.org/packages/23/09/2ceda924e1581c4b9fbec47d1343e0e64078ef89a314383dca2f604e6b48/docling_parse-7.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:da0483decd77d9a967c54e751107c36a3c3bae186e989f81339dff5037f0a7fe", size = 9051750, upload-time = "2026-08-25T15:48:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b3/1a4b65a60e0cd11d4512c55e81c03a4f5f6c7c08ed6f78fb703e983aa4b0/docling_parse-7.16.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c3b4d67da75631a28252bf574023e4a45fdd422603ea07cf73a8e70074547436", size = 9762652, upload-time = "2026-08-25T15:48:45.716Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fa/0b1a0ce72403002080231708f753cbbfbef22385b336bfd5f2252a96fe54/docling_parse-7.16.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e2bebe14d3ce0b6e7f256f2e4bbc7f2405dc9ddc91bbc5031dcba07bf97d9b8", size = 10286719, upload-time = "2026-08-25T15:48:47.483Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/67/fe434aeb6d58bf3a69bdbcfee7b52633ec2cfad5e28ce7862d3d910f31c7/docling_parse-7.16.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ab9b9deefd347166d670f894d27f697bf2d213a51e526516dc9ff44e0c19b5a", size = 10686793, upload-time = "2026-08-25T15:48:49.073Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/79/97d07a4a056f540d7224720eb1cbdd606fe5f825d7954b5b574cf872efb8/docling_parse-7.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:b4dc06844b775014bbf9a8f2d830d6700a47b2ec13c62a4ee61a2c9382fe4dca", size = 11746783, upload-time = "2026-08-25T15:48:50.855Z" },
-    { url = "https://files.pythonhosted.org/packages/42/eb/61492ee31917fdcc35117c0b5053626b81084b68cc1345e779e2428c6e08/docling_parse-7.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:4dad04e693ec3d120885249a097dc61b0823f01b0a99c52696828b9eb6649e0b", size = 9051766, upload-time = "2026-08-25T15:48:52.558Z" },
+    { url = "https://files.pythonhosted.org/packages/26/59/316d60193d2af38592c1f8b90b7d06966eae6d2599695024a792a5b77ca6/docling_parse-7.17.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:adb40747c28843ad3fbe41f9551d588ee9f6e663416040dad58855fb35aed218", size = 9768309, upload-time = "2026-09-02T20:28:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/01/265814cb26068a30e422276ce633a8e8e217ac120efca12152de4f7741ef/docling_parse-7.17.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce61e82dc52576b81b84c88300e25edf6af160a614ec307611a0a8646b93279e", size = 10293585, upload-time = "2026-09-02T20:28:59.554Z" },
+    { url = "https://files.pythonhosted.org/packages/47/52/0a5babc269e4903389ac2e7b711a02d8add6f224af6315533ec5afd7dce4/docling_parse-7.17.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6343051318ed76ed86ea34f8c1f937cea72cd7ddcf2d97220cc351f99f02802a", size = 10697732, upload-time = "2026-09-02T20:29:02.172Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/db/6ebb0da5ca1efd0e603bbaa48bfe327c96f544fdacbaf37867c3cb097d4c/docling_parse-7.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:4d8a523de79705ab325ed71b7bc8823478c919f0ff7151b1a50f303bed05c213", size = 11754536, upload-time = "2026-09-02T20:29:05.157Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/70/3b63d43ed7ea5d2eaef77a1626f6dfa5d2a9b0a64c4719f027a33245ba2a/docling_parse-7.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:14153776cf5d22bc38e3948c828ab020fc026e8fece8ee9d702d6a8240a4991a", size = 9061592, upload-time = "2026-09-02T20:29:07.689Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/9c900d7599d9e7c3987901f76ab81d6039a655beb232b9eb903ab9f9ee2b/docling_parse-7.17.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ee6352a24b26d11492cc1e57759f19318dc42ab866fa6de3cd1ee245729c04c2", size = 9768325, upload-time = "2026-09-02T20:29:10.886Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/54/b134fb5f901612e84c08c36501f19c6ff874d0d58d2a99c230df112216f4/docling_parse-7.17.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:edca5f6d63fea1f53e5fa6584ff5549e698f35a52778d66fef02e104340f5a74", size = 10293815, upload-time = "2026-09-02T20:29:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c1/06373dd2ca4600347bb551a08b53812b30c9fb7bed594cf24b8db9c2d43b/docling_parse-7.17.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ec263ef4b5bdd92665ce8f26db3321daff00bc9276c5667af50d101f31e8ee2", size = 10698022, upload-time = "2026-09-02T20:29:15.858Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/10b398a9ec1bc8ae7d6fbdc16e39f46ad33cb3f6045a80cffca3b89b85cc/docling_parse-7.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:48d3fb853c4f548d4c6be2a13436d98fed427aa4ff10c4ce9ead7fc6f1d43e0d", size = 11754451, upload-time = "2026-09-02T20:29:18.773Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ee/f8a21496fe380c67b6cbfc783452334c308ac99586c83ab6c9e2b63c965d/docling_parse-7.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:2ee55fc0615cbda8c97db81ef58d81a1a2e1e9ac3f9c0e1052aedcf294f58efe", size = 9061589, upload-time = "2026-09-02T20:29:21.567Z" },
 ]
 
 [[package]]
@@ -1457,7 +1480,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.29.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1470,9 +1493,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/35/42316e8f6908b6d21bc8df017cc6efba94fb5edbf99b64e28dd142325e20/huggingface_hub-1.29.0.tar.gz", hash = "sha256:6ebb385a581435325cf6d5c5b233d5d4bc91175834d99fd65dae14379b36e9ad", size = 963121, upload-time = "2026-08-27T12:18:37.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/97/2eb4abaa5b969ed385066a0496a3823b3ff467fc1082e2202955f1867d60/huggingface_hub-1.30.0.tar.gz", hash = "sha256:e6a6120bc8c8e2723d03648434ee247088cceb55ba7067e7d34d692cad5fdb57", size = 964291, upload-time = "2026-09-03T10:05:14.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/a5/47c2ea9b228ccbcba8467e9a64823146e8ebbad29855e591d8f5eedcc9c7/huggingface_hub-1.29.0-py3-none-any.whl", hash = "sha256:b00f7782afc14db4bc6572763810a635bdfbab8623d957bfb553bd18e03852cd", size = 795768, upload-time = "2026-08-27T12:18:35.431Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/3e45bbe0dd48f4e56b1d46649d342de853cd1c7e815323472ab62687f153/huggingface_hub-1.30.0-py3-none-any.whl", hash = "sha256:96ae0a8e99a234374a6fe43e989ebd21c04640b91ab2927e7e5773ba1131ca59", size = 796795, upload-time = "2026-09-03T10:05:12.21Z" },
 ]
 
 [[package]]
@@ -2045,46 +2068,46 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "6.1.2"
+version = "6.1.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/a9/970b8fa0ecc4fbf1dfaed0d89bbc1fc1421b25ec26a2038c91e872dc6c8e/lxml-6.1.2.tar.gz", hash = "sha256:1055241852f2b02068af4a625a5d32c087db193c12251928af2562ecd2239f18", size = 4210626, upload-time = "2026-08-19T04:58:15.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/ad/28ecd7cb894d172f3c9c80a075eeeb2017ac62e3632cee05a5f9493547eb/lxml-6.1.3.tar.gz", hash = "sha256:45222d94ddd511536f3b2f7d9deae3b2339b4ce0f075f1ca25703b07cad9dd21", size = 4211198, upload-time = "2026-09-02T14:48:02.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/a4/55eb54507073089ab27743c5da2113c84f0d0b1715b33175fdd943c9652d/lxml-6.1.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7d506bdba580ecb1a6ad2e2b5c49445e66d3e1f95894885739094393a1aad237", size = 8602111, upload-time = "2026-08-19T04:58:28.017Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bf/6332f45d78da385bb01d5cac3fe4acda19f025d1307cbc7ad538355fecbb/lxml-6.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12acd337d2821cb8b9247dfe4b7aa2f2769a3df5ae8511b7e550df42b8f4d3c3", size = 4638376, upload-time = "2026-08-19T04:58:41.181Z" },
-    { url = "https://files.pythonhosted.org/packages/68/e0/21fba0fe74d417fbe976903ae6bc77e92cdce01aae7b636abd87756f4588/lxml-6.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5078ff51e6316c0f75ea8127c2cd24374747fb351f62fb93d1761f8ae5a04a40", size = 4939689, upload-time = "2026-08-19T04:58:48.526Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e5/ce3e885264fdd0bdcb6b49c1ea1842f94281b39e4ff956099e8d57532c60/lxml-6.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9477e14217c212e6023c994a71a1a349db19b0e10fd5bf189666b281ae63b1fd", size = 5105185, upload-time = "2026-08-19T04:59:15.533Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b6/990a8446c488c70fa25681e150de94b7bf2eaaf387e374d195ab3c8faafb/lxml-6.1.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:261d98065326676d7253882db0198d0aa06748d7ee0443367acf10b148273f99", size = 5011863, upload-time = "2026-08-19T04:59:50.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6a/f70f41363dae27e3bfd6224b128f5ba150874bd32ca4938552930ffa33b0/lxml-6.1.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0666943ee1576fa890a6dc6316ef42e8241b5dd56f67bc5475acb2ac298c6ca9", size = 5638234, upload-time = "2026-08-19T05:00:00.802Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/a65b64f34d556925faef2c4f14167d58c571bc15a3e1f2bba71138830562/lxml-6.1.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04cf9e3f4ee9cab9d9ba05401bef8668840fa9620fcd4d8e85a2d2fd0b0fa960", size = 5244532, upload-time = "2026-08-19T05:00:07.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/a9/471552e015e954fc9d960aa27c3d67ebf489683d03f033399a790417c67c/lxml-6.1.2-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:9429d2371d406344ed1da5b5686d9412e74137c07b0171278368ff704f470ed5", size = 5358194, upload-time = "2026-08-19T05:00:22.747Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/0f/bc6248fbec2cc416f102b1267f1567e07510f6fa909bbe8cd2a22d6fb78e/lxml-6.1.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:eff128ffdc093cc6317955934ad9751105d37ed8dbca3ff4ccd751af6be37185", size = 4704432, upload-time = "2026-08-19T05:00:51.115Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/3f/cec859f50e63f1fa338fab43d2362d7543e1237f2475960d8ab0769de0eb/lxml-6.1.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ba58574d710b82ead7cbedea01cac3e110bc3ef82d4731519b74a2c11f7cf5e9", size = 5255038, upload-time = "2026-08-19T05:00:58.895Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/d9/2ced0cf2967115f92a1b8b3ae6bd18763abc3ebef88c98cf25145fda396c/lxml-6.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:52f6d4dff133c9778a24e9a2cfc1608930b15869866171aacc5131b5a418a003", size = 5054481, upload-time = "2026-08-19T05:01:10.096Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/f5/4f07386d3c88673daeec3b8cc09a2a4d39fa01c1fc49009791b0746d97fa/lxml-6.1.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8807998c1023d1e9d60e02500f90e85a0752dbc0b670989806bba87b82dd5b42", size = 4785535, upload-time = "2026-08-19T05:01:18.909Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/5a/f4fe3ecbc189f48fba2547c5db5c940a10151d3e86b856a60a533a77e816/lxml-6.1.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:2170d0a280c877b6e2dc6738217db947be35dd8cf09ca458b355aa1bab2a9e70", size = 5655337, upload-time = "2026-08-19T05:01:41.324Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c4/f586aa1bf27bfbace2dfdbb704da5c52f0bdece8ee440c8fb4946c940b2e/lxml-6.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c67f3c1278f942e97d8665c2a690324aaea5137de16f056583a21f0ac706177f", size = 5245778, upload-time = "2026-08-19T05:01:45.227Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a1/677494bbaef4d6db5e4633af817414f478865850b55c03ae4bf70fa7b8ca/lxml-6.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:093fbf547d0f3ca02705381f795a050fbb58988be4aac7f79f99f280c4082313", size = 5267274, upload-time = "2026-08-19T05:01:57.687Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/71/b71425b8764d4cb7c92eb970483be7d5610dce2a6316242b5aaae7d260be/lxml-6.1.2-cp312-cp312-win32.whl", hash = "sha256:be365ce8d2d411cf2fb573747684b4fd470fa6224e0094d9d5a21155acc369d3", size = 3602563, upload-time = "2026-08-19T05:02:01.837Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/fb/909584e16d2148c1a252cc2c32dd99fe0e2682459c586d3d7a192e74a0ae/lxml-6.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:b97153ca609b434b712ddfb92cd6af101a7045a7724c542258bd4727a344472f", size = 4005965, upload-time = "2026-08-19T05:02:07.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/8d/41207c9212caad0b52749e34739fb9bfab67486729f52a8fe9bd9266fee6/lxml-6.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:7feb72424f19a893ae4f3373c7aae821b1aacb6076b708915c651f0683a97c49", size = 3666641, upload-time = "2026-08-19T05:02:11.3Z" },
-    { url = "https://files.pythonhosted.org/packages/61/2a/e9651f47a31a60b5cae031abc23391ed9aa30c8fc07571d1a38f58d6d770/lxml-6.1.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:351318f5c0eb7fcab5b4fdb507c6f88fb2c4b5e67784c7e5911448c91fffb5d4", size = 8590165, upload-time = "2026-08-19T04:58:40.489Z" },
-    { url = "https://files.pythonhosted.org/packages/61/87/a8098abaf35118767d1703b84c98940a5d833064e0eca39a00ecfe9840ab/lxml-6.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0edde95e4b4278dcc0175eda06dc8aa2631ad9f83ae5dbdbc4f0925e200b0b0", size = 4632474, upload-time = "2026-08-19T04:58:47.465Z" },
-    { url = "https://files.pythonhosted.org/packages/93/cc/fe74d1def7f4fb967c4a825608a074d4dbdbb871b0d6bd59c6ed07d67868/lxml-6.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8326e24ae6c3a6bfb03fa8b4793f9a5d804c125228aa067f652b0428e31b87c", size = 4936196, upload-time = "2026-08-19T04:59:03.477Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/ad/b96e6ca926e26726a99aa643602aac7411ecc1731ddb1b25af8cc57edfcd/lxml-6.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7c534ed898413f439b048130011e99a4245ee13d62d431f6b4f7f2484d02a93a", size = 5093290, upload-time = "2026-08-19T04:59:17.498Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/84/616f5d3b7cd086fcfba3e5add6fccda67f976c1c753ae9ed7bbd317cb9be/lxml-6.1.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e37fe49fe2d5aa40a2cb1cc8176673ad7de0d124e6f4a509d9318f5979c7871", size = 4998767, upload-time = "2026-08-19T04:59:28.385Z" },
-    { url = "https://files.pythonhosted.org/packages/80/88/d5b453a8d083483c9442ad7f5ac5c560796022eb5c80d60b65d75e449236/lxml-6.1.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9b52ea73a37fc64aa3357ff8607801d46dd170506d3cf8253a91a1d91639d4f9", size = 5626717, upload-time = "2026-08-19T04:59:40.045Z" },
-    { url = "https://files.pythonhosted.org/packages/71/45/31e5aa4d4bae024908ba1d03480c7425cf027a28b7e5c88d1b7202bd80cc/lxml-6.1.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8b9a92652e75e7731309ea51db5dee892eef414ce70a6ec3441e5d36bf5189f", size = 5232330, upload-time = "2026-08-19T04:59:46.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5a/2627912420df8b2d31ba3014da5539f15ec85add01d42048864ffefda516/lxml-6.1.2-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:9088da25ecd609965f838d89fda0465a905b48f4dd90331db9845518f2177372", size = 5347054, upload-time = "2026-08-19T04:59:52.762Z" },
-    { url = "https://files.pythonhosted.org/packages/16/86/54ac0f529b22a8f12313726dd49e12961bb46471d9028cc28d2a29408f0b/lxml-6.1.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:0349321a0537d4fdbebb2af06dd1b64676132c72e2ae250de8cdb58f8c43019c", size = 4707275, upload-time = "2026-08-19T05:00:04.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/42/ffcdc6e4519be90df907cdae7e88409efb25d823ae4de8846f737dae1884/lxml-6.1.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b20440e578d269c5e8a722ab602ddd0f0cedb8b080006b3f936da9991a593d3b", size = 5240071, upload-time = "2026-08-19T05:00:19.604Z" },
-    { url = "https://files.pythonhosted.org/packages/68/49/5b1d7ab35f013f1127ec48f3108319f58b65b00d5cb26f215adbe86eadfb/lxml-6.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7766e525282dd38fd89567311323e441996eb958e8e816d16b38f782e3aecd2a", size = 5050356, upload-time = "2026-08-19T05:00:27.968Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/57/1cf049d054189b55c8fe8012269234f6602256949b69cd3ba80608a88219/lxml-6.1.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9221442682c27417f10fe11184ea4cce174b25ab52465570b1f3ee3f85f320fa", size = 4780394, upload-time = "2026-08-19T05:00:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ad/064488a8fa60e639fd773e421a18bf17541d02a95fbf36238ad7c65f69d4/lxml-6.1.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:75530642d8471327e691ab9b0513a5f9c77f38871014ceda40f51bb51765c0a1", size = 5645854, upload-time = "2026-08-19T05:03:42.697Z" },
-    { url = "https://files.pythonhosted.org/packages/85/bb/120e56f3cf1c149bb3b014278fb86d0a6dd552403981081f0ee0a0a57be7/lxml-6.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:678e35f1cbca98f55107511ee21a60568535c950f3c2371819bd64504c980d20", size = 5231132, upload-time = "2026-08-19T05:03:45.466Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/2c/7d49aab893c128671a3276580074cce4c002896145b8dd2893da79633bca/lxml-6.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c2bae42b3a09f977330a08f4a8fe72aec58c4bdb89069d3fe7272a71d885881", size = 5256076, upload-time = "2026-08-19T05:03:48.092Z" },
-    { url = "https://files.pythonhosted.org/packages/72/28/ddea3aa1fa9acfd384fe34d4a2a93eecc07541dd2d922fa9b140c60d8014/lxml-6.1.2-cp313-cp313-win32.whl", hash = "sha256:5848f3de6a8de8a93cff9f068134393ff5fa69ac2a04399f7d49cd67c61c348c", size = 3602177, upload-time = "2026-08-19T05:03:50.571Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/7a/96bac167538748cae2544335855f812fa33e49a9a67bc8b8520dcbd592bd/lxml-6.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:6cb0c87421946030b92b558be416852780a912454e3dcba0998e4497c9c588d5", size = 4004117, upload-time = "2026-08-19T05:03:53.074Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/24/9498fa3c84135956e5ef55ea4d8bd11e999e381f7f210fb6f8c6a980ef03/lxml-6.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:648861c19b775b89ebefa14586f85090b10163367476d77f242c4131c835ce73", size = 3665412, upload-time = "2026-08-19T05:03:55.621Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1f/a180b57d9eeabaab77f9d5aa30356898ea749c4795596a8f66d1eb6bef2e/lxml-6.1.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c0710ac085a157b593c38fbcacd950f15c4afa8e2057527185875ab302752bc", size = 8602094, upload-time = "2026-09-02T14:47:26.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/070c92013a1c029a602b03560d68772313d918268667fa993da7961759c9/lxml-6.1.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:623c8799c17128753c65699f1c3aa32402657393a9ad6db09ed8b98ddf76611d", size = 4638308, upload-time = "2026-09-02T14:47:29.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1c/722e88883173097a1a375153e3c2447eba3060d0231522cf6596e99f4195/lxml-6.1.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f683dc6300317700025e41d89a43e0276692ded16113a3c43eab704d605c58e5", size = 4939696, upload-time = "2026-09-02T14:47:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/db/36/aa413bc214dc4f785ad2b2ddd8cc99aae7062d49ab155e91e6011af00daf/lxml-6.1.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:379f8a75cf6eb7eef0af074b55f49ab73b868388a98de14646abcdfa4564bb11", size = 5105247, upload-time = "2026-09-02T14:47:36.734Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a0/a1f7f1313795bfec67b77f01ef3b1128d49f2d7f66a8413fa55d47f4e25f/lxml-6.1.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b37772102d44bb6628186accca3a121b1fa3a6b3d97518a8c29a5229ca4c0d0a", size = 5011915, upload-time = "2026-09-02T14:47:39.846Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/78/840e7e3f1d0cc7a5cfac5d8505b97e25b6427fd774ac4bae672aaebfb4b5/lxml-6.1.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddcf547bea2aee967d6a77779376a45e77e610e8465147a1f3d7e20d539d6e32", size = 5638175, upload-time = "2026-09-02T14:47:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/20/e022dbc6b4753a9bc9fc5fb28a27163430c1731b9913997f6544c1b2518c/lxml-6.1.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:909f4e927bb051f7740d6367285fc60cdcfdaf0258c2dba4ff5ba7eadadc250c", size = 5244675, upload-time = "2026-09-02T14:47:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/83/82cde81d2b5eb38d1539fdfdf318abdd014a7e604f4df01c9cd3deb18f2a/lxml-6.1.3-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:a5c18810318303ce9afb3f95e2ddb54834f96fa699a8600433fd5a93dcf44c56", size = 5358205, upload-time = "2026-09-02T14:47:50.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a1/f3b057371c8cb29f2a9c9c44ea320592446e40b74a4b0af68c3d8e65bc73/lxml-6.1.3-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:3e42265103fb385d8642a78672edf376c6f7e1d3598a7a4f9cb1278f2f6b5f6f", size = 4704495, upload-time = "2026-09-02T14:47:53.251Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/230eb28be5d412152ffc3c679b51fe1aeede5a53f3a8eb6e9748f2f4754f/lxml-6.1.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:21402998e4b78e7cce237d2788841aaa21ac9a4d1574d04dc2d12ee41ae807b5", size = 5255117, upload-time = "2026-09-02T14:47:55.963Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/18/1969f56763af24ce42ea156007b0b2d73fddea552e283b2010416394f0f4/lxml-6.1.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:38fc4e4e4e084e0bd491949482527d406788045c546d4f8789e93fc527b91385", size = 5054424, upload-time = "2026-09-02T14:47:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d4/2a90acc1f6fabaa3a8db9340437822bd8d041b205d626a4b3e8621aaa390/lxml-6.1.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5609efdb0d3c95499c00046bc53648b3482ec2175b5503d6e611b3f0555dc71d", size = 4785572, upload-time = "2026-09-02T14:48:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1e/b90e845b1dcd0f2f3f26b98283d857f25909223aacd265eee032c34ab8b1/lxml-6.1.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:97ce49699d87ebf8aad631b55d65b33219a4f1bfefbbf5bff19dc9af160aeaf9", size = 5656516, upload-time = "2026-09-02T14:48:03.419Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ab/0a1b802c57f3fba5c4efd77d5c6b78adaa8f7b681f0c90456b140fe8bf6c/lxml-6.1.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:48542c9acba9ff9450bd18d871d2c2c8787fdb283572b623d206f1b927cd7d9e", size = 5245982, upload-time = "2026-09-02T14:48:06.109Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ee/2c016fbceb3778137459292538d9dfa7e3ad9070fe409c15254ddd90d2cc/lxml-6.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c55e71a9b1db1f107efb60da49c093689b74c5c31a708e5379e2fd9439d4fbb5", size = 5267340, upload-time = "2026-09-02T14:48:08.374Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b1/736d18fd6f0835761923b7bac1f0c27d60c1200384e9093f05d8c5100525/lxml-6.1.3-cp312-cp312-win32.whl", hash = "sha256:b3ff39654f0ce6ebd4db154211136dbe7e8157bcc3bed2344c87f32c7c6ecb6c", size = 3602606, upload-time = "2026-09-02T14:48:10.384Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/6ed903e4e6278a020c8a6f0dbbe78030d041840a6b4a64ea441a1e414077/lxml-6.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:3e9a00d1c2c30936f7add097c41afc5da6556c580909104aafd382cac92a855c", size = 4005999, upload-time = "2026-09-02T14:48:12.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1b/7bcebb7b6332cb3ae85e9c13b139adb6f23f75c71d84041c56a5005d9a29/lxml-6.1.3-cp312-cp312-win_arm64.whl", hash = "sha256:1aeca87830c4fe649dcf93fe2b059525b71c72587f21be4ae4af7103082a79fa", size = 3666631, upload-time = "2026-09-02T14:48:14.567Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/3ef45db776baea068044c799bbba68f3ca00a440c0e930a17c572f3d9639/lxml-6.1.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3a48093cdb058a93af842ede9703520e810b05dcd0fc6d7190a06376c3bfb6bd", size = 8590357, upload-time = "2026-09-02T14:48:17.413Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a5/eee2fc77eee5ea68e4a4334b1def1781a3beaeefd3d98e81b4a38dc447b7/lxml-6.1.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:887c021d9a977cff89cb273047c1352997b772a8908a25c21836861f69b92be1", size = 4632616, upload-time = "2026-09-02T14:48:20.745Z" },
+    { url = "https://files.pythonhosted.org/packages/35/42/df27b56848acd29d8a720acc28977911aab36f2a09df4208d5502e887415/lxml-6.1.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:611a51e61c92f62345a50b0035df6fc0d678f9299f33728826d831598862f59d", size = 4936186, upload-time = "2026-09-02T14:48:22.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/8d/8a7b91df0b54d09d25f5f44885d6b3e0a6d6643a8c070191580318d20c42/lxml-6.1.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b477912f42c5c33405a10c759d22f80cf5af043ae02d95b9d8e5e5bc555739ed", size = 5093324, upload-time = "2026-09-02T14:48:25.132Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/8f340ddcd43790332fb0de8a26628d571a492da3300cd191821698407c96/lxml-6.1.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cffe18571ccc51d742cd08cbb3f8b756de9311d18c7ea98f5d92f37b8fb60c2", size = 4998850, upload-time = "2026-09-02T14:48:27.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c1/9c5bb572f1f09ec9e4322bd4a4e9f4ad48347fc56ef94cf4df58a5279dc8/lxml-6.1.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75cc6569e86be5785b6188ef1642670c6adbc984e81ec35e224842ecd9eefcc8", size = 5626813, upload-time = "2026-09-02T14:48:29.61Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7d/8bf1fd8bae8247743968bb76d027a1ac5bd2c4b44495fba6a71b30d10706/lxml-6.1.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d85dfab42dd672f87a7f76e9de7172962aee69fa12044f0d6e1a23cbd53fb80e", size = 5232385, upload-time = "2026-09-02T14:48:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2e/6cef69ed81cb7df0d03b0dd09d08e6e2cf5061a743ff6f42f0b741548e9b/lxml-6.1.3-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:42632b4024ab24a6b488f559ac851312509888b6b80ae2aa11cf29a646a0d245", size = 5347088, upload-time = "2026-09-02T14:48:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e1/8e5fd8ddc8c7d685badb0f2db149e3c9da84eefc2827c01c658df2c4e3cb/lxml-6.1.3-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:febd35ef45f603c2d74b74655efdbf45e14f55fc0aef4ac82b663ca829b283e0", size = 4707227, upload-time = "2026-09-02T14:48:36.62Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7e/00041382a11be40a88bf405ebff11c8efabd3de79f2691e1638b1c47a8a0/lxml-6.1.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a43b3bdf11e477dc7770609d3477316f974354dfc8425d596f64f471cc8daf6e", size = 5240208, upload-time = "2026-09-02T14:48:38.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fe/316538b5cff0936fa63d45d421c655730fcbb5a28dcac728c175083002bc/lxml-6.1.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d582042c69857c364e8153de6e18e0da9b7b515a6a8113caf69a6ec8e0520f2", size = 5050271, upload-time = "2026-09-02T14:48:41.213Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/91/455bcccb3ac725373007344d351151810cd19762d1673b64b811f4359a42/lxml-6.1.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8e49a646acfab83c68974f4aa1d0a2acca9e88d7d627ae0fc13201b14b76d310", size = 4780433, upload-time = "2026-09-02T14:48:43.779Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f6/580440e2f52cf00bba5c5e1080bfa88cdfcde73be71a11d95170ddbb663f/lxml-6.1.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0dee106e9aa97fb00541b1ed7827070564d0549c3d3fba8920e6b20fd980f748", size = 5645928, upload-time = "2026-09-02T14:48:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/dc/d123c1f244306543d545f62443f794959e4f1ea709fe100f8740d514e74a/lxml-6.1.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:dd5e90f34cffcfed97f36cf066325773d2b6021c60c29942e53a18b028501b1d", size = 5231184, upload-time = "2026-09-02T14:48:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/3c/fe55b2bd5c6113c906511cd88f6a470195c5fbff1124f19970ab706c3477/lxml-6.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d9b3e7d71bf6acff341233417abbdface29c647e3113892d9aaedc02eb4aa2bc", size = 5255814, upload-time = "2026-09-02T14:48:50.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a7/485df55acf55dc35e4ca89d2f48f03889e5a3241826b18b85102b32ce9d8/lxml-6.1.3-cp313-cp313-win32.whl", hash = "sha256:160fcf381f76c3aeac28a756bec44f48942a8f7245a87aa28e3a523b4d90cd87", size = 3602214, upload-time = "2026-09-02T14:48:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/e46a7702bd95e9043291f7c3539b6184cba66f96cea9936f20939b284eeb/lxml-6.1.3-cp313-cp313-win_amd64.whl", hash = "sha256:e477aca0bc0d19f3b4ae9e4f2a1cfd687c31bf772d78734910658186b40b2477", size = 4004091, upload-time = "2026-09-02T14:48:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/154c78e20479a43916e63f19cb720d83f44f024b03228be44c92d9a97b24/lxml-6.1.3-cp313-cp313-win_arm64.whl", hash = "sha256:b1cc980905221a5d8b3c476330730b3adb40ff80add71ffbdb6215ba055656f1", size = 3665468, upload-time = "2026-09-02T14:48:57.703Z" },
 ]
 
 [[package]]
@@ -2401,15 +2424,15 @@ name = "mlx-whisper"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "mlx" },
-    { name = "more-itertools" },
-    { name = "numba" },
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "tiktoken" },
-    { name = "torch" },
-    { name = "tqdm" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "mlx", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "more-itertools", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "numba", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "scipy", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "tiktoken", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "torch", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "python_full_version < '3.13' or sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/b7/a35232812a2ccfffcb7614ba96a91338551a660a0e9815cee668bf5743f0/mlx_whisper-0.4.3-py3-none-any.whl", hash = "sha256:6b82b6597a994643a3e5496c7bc229a672e5ca308458455bfe276e76ae024489", size = 890544, upload-time = "2025-08-29T14:56:13.815Z" },
@@ -2682,7 +2705,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2718,14 +2741,14 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-cu13"
-version = "9.20.0.48"
+version = "9.24.0.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/30/7c257e3d5cb4fecb147b93895c66e29c93f8e76d74b45bb418ff0587c4ec/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a6812a554a1ff0413e9c52b84c26c050380649ab9615f9c16bded368ce9f421f", size = 650976863, upload-time = "2026-07-02T16:23:39.248Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ba/791cffd048fe5b044e620df55267e3e95c0e6e07d50b41e377c03dfc910f/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:71f181cd810e90f9b6023b01186fe82d13d65f0ec098581ee201d39fad769e4b", size = 553099438, upload-time = "2026-07-02T16:27:42.58Z" },
 ]
 
 [[package]]
@@ -2733,7 +2756,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2763,9 +2786,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2777,7 +2800,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.13' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2795,11 +2818,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.29.7"
+version = "2.30.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/21/a73174c6157101bdf1ffc22b517f76ff0082613989dd9bc8f43e8034caac/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:ca786ffa5a647c75d4d1f5cc72a6c4f537947e2ba8823d7c8aaf768e7a7b9f77", size = 215983881, upload-time = "2026-06-09T03:23:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/34/c500f90c7ae641b8e0f98965b36b8a7ac79cc8b296e8d251fe3eb592ee54/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:cefa7fdb9710efd0f39c5f1be1d61ff6fc9a996c451265bd7fbdcf9455ed4b50", size = 215965170, upload-time = "2026-06-09T03:23:39.73Z" },
 ]
 
 [[package]]
@@ -3370,68 +3393,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "psycopg"
-version = "3.3.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
-]
-
-[package.optional-dependencies]
-binary = [
-    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
-]
-pool = [
-    { name = "psycopg-pool" },
-]
-
-[[package]]
-name = "psycopg-binary"
-version = "3.3.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/83/ba396428a4fb6b70f0dd41315ad86a2c14441b7214afd47b2d49cb450b78/psycopg_binary-3.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25105f9b46bdf2a30fcb67f56976ed66f6855941ae16bc024192609b917d493c", size = 4700169, upload-time = "2026-08-31T22:41:39.712Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/56/b23c5978e55cf4effdc5a3e13a17d69a580a487993e01b7c3768dd24281c/psycopg_binary-3.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0249c3e960cdee686000eb77169fb6590105c05bacc37e057ccdffdcd8e6ebde", size = 4763037, upload-time = "2026-08-31T22:41:47.571Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/d8/b41108bfe194b4098076c8b873b05ec2ca9582445eccfd9075970d7b948e/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5698ab5941a4d138c30fef858588e651fe7d583280cd6e41832825ad9e747750", size = 5546232, upload-time = "2026-08-31T22:41:55.817Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d1/0f244dfef389e52e9dc3056f2a9033d1f6901e97d24d9a9c8b836e32ab6b/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:682a17a57415c3ca1731eec018ed031f012ffcb81ba74806eb219cb396065672", size = 5227752, upload-time = "2026-08-31T22:42:03.776Z" },
-    { url = "https://files.pythonhosted.org/packages/31/88/a4781365f09807fb91435e2d00096f3f6ae5d06bce15ef3c3c385dc22772/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2a61e8147902771df7efe14062a3c8736347850d0d8befcf048235752504f2e", size = 6824658, upload-time = "2026-08-31T22:42:13.263Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f1/072c4a46287644694731b3e40fab120ebacf6d153cce7ebf7a5b208f5561/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f7e1e45aad410e20de45df2b159df68ff6c8dbf47a3501f806c4489b27f4ad2b", size = 5061439, upload-time = "2026-08-31T22:42:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/d6/1776a95c16941b8bbce89407cc7cf9ea3fd557efb503a40873c9e2b6394f/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c09775c549b40b274206e1b043c5e5b5af39666e85c98382a30bd05d23ab677b", size = 4588586, upload-time = "2026-08-31T22:42:25.23Z" },
-    { url = "https://files.pythonhosted.org/packages/82/64/44ec87b9a74faebe966856307b65c0d35ee6321ce509cdd0e8d6a3f5338b/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:cf0e5e63ee86098299c673992053d556c489ba9ae6aca6cb6e24d16a8e0b09e6", size = 4265161, upload-time = "2026-08-31T22:42:31.864Z" },
-    { url = "https://files.pythonhosted.org/packages/24/88/cf181df5651395a80afc520f5fefac72beb035c0c9d58ab7fcc880c9b221/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c065531e8c1815276f50dbfa283e3a7f022671414cdda6fa9a16794dd53b28f9", size = 3998727, upload-time = "2026-08-31T22:42:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/43/1e/c72a1107647db4bb3f534c7fe1b57b1957d9c099e795f5aa81f4a2e0c312/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:df9853b832b7b916e02ef68e0d5403a7dab2d5c1ddfe94f22b1b155eb862622f", size = 4310119, upload-time = "2026-08-31T22:42:46.403Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8d/452620608cafff164737e20b42ebffee8151b865ee171ba0d6692a560a44/psycopg_binary-3.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:35885e333020fc152d27bea1a494bef13b2e68f6fd92b6229015e93539152008", size = 3648197, upload-time = "2026-08-31T22:42:51.575Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1c/e718752cc63cf4e99e4a10fd36e3a3364dabdd0819484a24c0d79fbb9685/psycopg_binary-3.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6e85d50b87257fb117675a19ee59daa7bf9a57f6431500adf7059df799232ef4", size = 4704421, upload-time = "2026-08-31T22:42:59.564Z" },
-    { url = "https://files.pythonhosted.org/packages/af/cf/a0e748e27c09b92738e4460582d121ba1908be3e36791e150f435e54b332/psycopg_binary-3.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5becd311f9af8d180bad372f51fb2252fd02cb2073056e2b170c9274f95fe7f", size = 4765054, upload-time = "2026-08-31T22:43:05.421Z" },
-    { url = "https://files.pythonhosted.org/packages/39/62/0cbac0266d56c94dd1f702d9af2b5d54bf80b6e658048f4f2c5bd63dd7e3/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:19e5bf9872dbd164c220567fd385ba2309c7d9df1541f78343510c6b0f36a1b7", size = 5547137, upload-time = "2026-08-31T22:43:11.768Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/3a/73c6f8871f38fc07a9c0b4cbc9467beb116a2783cecf87dfa53900a396dc/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb3b3bffebfe07110730626e76238161124f35ac87b748d663316a28d22f58b0", size = 5227577, upload-time = "2026-08-31T22:43:20.767Z" },
-    { url = "https://files.pythonhosted.org/packages/59/7b/9f17b9f4d297b774dc574199c4dcd02dadc32a00c4056265918de5c70635/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2111f880add40fb03c60556069ad68e884a0908a74d2debafc603caf93b73552", size = 6824606, upload-time = "2026-08-31T22:43:33.698Z" },
-    { url = "https://files.pythonhosted.org/packages/94/86/d84dadd94a004dbbb43ce0579f1f766fdc6b8cbef745090e24bea77b5283/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:40505676b1526b9ea387dace034040a8c8b0bcf984cd6bd4720a2ab15e813586", size = 5060854, upload-time = "2026-08-31T22:43:42.258Z" },
-    { url = "https://files.pythonhosted.org/packages/30/d0/e5078be2c7d2490c0d6cd4cb7b3601aec44be2fa8b3fe927e9419b06004f/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5816472e3bb05615f33a741e0835043d1f4bf9709ff30d2f4aed71815cfc6b5e", size = 4589511, upload-time = "2026-08-31T22:43:50.012Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/01/08dfb5b18fa482e025864fd91a022310d0782c42e4cf5dda5d0e010b6790/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:358748fc4c8ccdc0e2bdf55420494930e19c3ade586ea9c3a6de3dad1f897311", size = 4268144, upload-time = "2026-08-31T22:43:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/88/b9/cb01dc1d63f3241b49b2ca7fb9f98d0f5c76127f0dbb9440635a6ad0233e/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1ef2e498be47800f6202b9a2304c22646325ca6d54001b7c785bcfdb24a1e8ab", size = 4001036, upload-time = "2026-08-31T22:44:04.429Z" },
-    { url = "https://files.pythonhosted.org/packages/95/49/7c17dd832c05b380562ff2ff5f6ab2bcaeca8b7fff2c2b355854368a5bdb/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88e01aa2e938a45655a8a5213fc3a44ba78cb4cab8a569b3e0bcb3d1d0eaba16", size = 4313112, upload-time = "2026-08-31T22:44:12.446Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/2c/b0b2f887185d6a2ec0b3bef948cc07656d2d1a5d96fa7f2bb03f6ef06ca4/psycopg_binary-3.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:ba466011569297114449df9d523438e1adeedf3e4f31ffb78e897ec3fef3076b", size = 3647313, upload-time = "2026-08-31T22:44:19.139Z" },
-]
-
-[[package]]
-name = "psycopg-pool"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -4526,28 +4487,29 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/1e/bc6587c5ab643b2e17776cace9070a2ae73549c86bffac9934a600bf3c31/tokenizers-0.23.2.tar.gz", hash = "sha256:7f0f085686b9de0d0079e6f874ae053600db64c5d13049e0bbc0119926d25aac", size = 385745, upload-time = "2026-09-03T08:55:42.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
-    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
-    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
-    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
-    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ed/8a443528baa6fac8dfe8c3b75b038c63ac92bb539bcabe311e227c718173/tokenizers-0.23.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:85a9a357a3764aecc904ee76bdaf8cf1ad8e5a67a1b929a487c4a39b49ed0e90", size = 3148852, upload-time = "2026-09-03T08:55:30.874Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/22da045a91732384d3a3771816bf188dc5a1f702c32e635afa7c679c0bef/tokenizers-0.23.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:986670e43691469dcee610ea0f846f91a8f84e91fc6f7a48d4c064414c0ec2bf", size = 3101593, upload-time = "2026-09-03T08:55:28.587Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/8f569ed49372a3ed8e57099bd515055fd48d7c95912c4307cda6973c2168/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37039b5dfc4af84eb3ef0a92f4307e28936c8f9adccba2629d36f652e9bf7a2", size = 3516830, upload-time = "2026-09-03T08:55:14.741Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/de/e2f14c8919d5bf51874051d00d6c7b7e0e8bde6c6a2dbeddda7f642896ff/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b7e37ba198f24150f523e1242e83c4970de4a525480586be5dcc24d9add32c5", size = 3407975, upload-time = "2026-09-03T08:55:16.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bd/93c69152d02ef06ce47aed8b2bf4952dcf733c935a62791873932b2934d9/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43e4f2071e3cc8d5d86421c874aebc82659bb51a68bcdef5a0da75ee89511ccb", size = 3748165, upload-time = "2026-09-03T08:55:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b7/56b84b80bc96942bba8eb23751a9e8a1fce4faaf4390425e7083f721c98c/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325fee2e0418a9dc6c9ecf736a5f5f0db7875183ace9549ae339da76f7a1fbb7", size = 4024165, upload-time = "2026-09-03T08:55:18.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/0175e216f005c2fe08238292663aa41e4c802b216e71047a69a0e9fc6fa3/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:950d7c9426fa72406a0ffeacdbc0bb9985f5db20eb8b263f29c79aaf83105703", size = 3591899, upload-time = "2026-09-03T08:55:22.752Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/ca6b93c7820df123b2662a9469e8facc826ccc94e98fdd0d615f6431e73a/tokenizers-0.23.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41c2f84d172449b4dadb9cdc508e3e364076613c35b16e76ecfe47a60d1e3305", size = 3386843, upload-time = "2026-09-03T08:55:26.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/4f9106d317b14a80aefea9f0e3a8d07ef25f856a7607eb7f5ab894281fcb/tokenizers-0.23.2-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:12f0835dc2ee694746a76adf7b1567d4346a4a502ebe93fb1f5f80ea49799b78", size = 3577314, upload-time = "2026-09-03T08:55:20.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/6a/1552b70fb0d9ab074fd3fc961435d01364e79c9058481822c3af6e8d402c/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eb2f9c8a24da020ea8c11a01a19c1c2547912d92121ae4a01cfbca46125dee40", size = 9967367, upload-time = "2026-09-03T08:55:33.188Z" },
+    { url = "https://files.pythonhosted.org/packages/06/01/3ccb3a956c7528b2507b8a9714155c4baf86af593039db6ea375dd0c96c3/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f486f402f6f9abee5bb032553736813af0c710a86b2e0ca592634c55cea1f835", size = 9811886, upload-time = "2026-09-03T08:55:35.642Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/7038e612d48bda1599457f712f6bd3854eae1a9dc9c13aa47f835349db48/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:bef235815a067b2648caf6dcc7a71091b0b0fff9ee8057f6451eb9335fae52ef", size = 10146224, upload-time = "2026-09-03T08:55:38.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d8/8e9e4e0b287a338d8f88976729628c9d22e8a54cfaf9777018a7f7cb58a0/tokenizers-0.23.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5c56bda1511921587789163e524d196ed8284174ac23abd7685d5ea8da6c4718", size = 10256304, upload-time = "2026-09-03T08:55:40.977Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1f/c79a01f671a49728ebb0b61f7ff9ea45663b66cab40bc0858e9859b25c16/tokenizers-0.23.2-cp310-abi3-win32.whl", hash = "sha256:debf978920d93ba9c219bd67cc4bbfaf912c9039e41e7a28b91ec15e3728c95a", size = 2592809, upload-time = "2026-09-03T08:55:48.02Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f7/0a69ac6b82dbccf3f71add938a161c497952749294b8dd6dfe03a819dc40/tokenizers-0.23.2-cp310-abi3-win_amd64.whl", hash = "sha256:2e96f5699d5249c9c64aa8412e044f727aae3a4098cf830f9901ec1afc361cde", size = 2863236, upload-time = "2026-09-03T08:55:46.193Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b0/dee84cb44175be1b4c35bd2f770727494e78f0bb38e571a623ade94dbebb/tokenizers-0.23.2-cp310-abi3-win_arm64.whl", hash = "sha256:e49c394456dd9985787fec76132438ba3fb8911f857b1bf3d40119f9292d41aa", size = 2729352, upload-time = "2026-09-03T08:55:44.345Z" },
 ]
 
 [[package]]
@@ -4561,7 +4523,7 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.13.0"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
@@ -4580,19 +4542,19 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
-    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/17/76/bb4770f56cf6d8971671dbcbb7493e5a6a15ad2825f4e359b02c27c38297/torch-2.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c1f844f1c750e87df4b68bc3afbc0e2b0c7ef19d7b8f666e48bdcf6a0c4f0056", size = 127303200, upload-time = "2026-09-02T13:43:20.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/ec44bacf2c8886b85ba4ca2285e8b09f2dff5d9c99e6a031326954082cb5/torch-2.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ada340e62591d06a2bcc2d68170f20f45f0b0665d372dc510a8ed7eb3b1d609a", size = 454010251, upload-time = "2026-09-02T13:44:24.927Z" },
+    { url = "https://files.pythonhosted.org/packages/15/71/49399acd41f750a906c686bd23c08a2001ccb8dd25f2971003c2ed89c1dd/torch-2.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fecffb58f51fd643d213acd68da21cc3fc19bea05a3bc64b4ee55128f47a4963", size = 554620488, upload-time = "2026-09-02T13:44:49.442Z" },
+    { url = "https://files.pythonhosted.org/packages/be/16/9489b137112040f9911d7527e452854f21cc4e499ce0da79864e6a7451a7/torch-2.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:cad84f41bbdf3dcf333ce394aeeaf25237c4d94fd6b659ba5eb813c829978823", size = 124114011, upload-time = "2026-09-02T13:43:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/40/0db773452c2a62b37761d3f418acf933d381f9e87077036fb57c2a386c37/torch-2.14.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9d4b1022a5d9b71282ec67ad0d9e7235870096b8a246dc1c32d6ea1fc83dc998", size = 127311393, upload-time = "2026-09-02T13:43:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/13/36/537fd9da2adad49e7b2bb20741398625bee548493158274e87369a8eed56/torch-2.14.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:731b9ebdea402b8b1996d4c2ae613b16660e559b19e47bdc45d970568bc91c53", size = 454010525, upload-time = "2026-09-02T13:45:03.719Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f1/39bd13b21f57d1982b7f3ddf663f01c7266e2957714880744eba9e8c8d11/torch-2.14.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:84bf384779a10c02fc3c6bdbab71a9cb66b0dd93c652d1ed5d6dfc0cb37e5962", size = 554619993, upload-time = "2026-09-02T13:45:28.209Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a8/683d9c44737554b67ca76dd2db4f42258a0f014246cb511293e51e0154bd/torch-2.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0e7cf18cb0d8bd666b6120932e29c7aef3502b61a08b44da4839580c539a7cdb", size = 124113865, upload-time = "2026-09-02T13:44:33.705Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.28.0"
+version = "0.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -4600,14 +4562,14 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/4c/95233776e2def960e5abb7a07931230a545f43717a56a1e1140162033598/torchvision-0.28.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5cf78ebc401ce64ae19b8c55de866bb836797d559a4de9c25ccbe74cfa642d3a", size = 7842127, upload-time = "2026-07-08T16:07:53.446Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e4/e9b2495d0d57b9f60d63c57d0a910410a81b4b073bf70917bef815291119/torchvision-0.28.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:028a3d481b37d785605620d7cdad897064c5a55bae2aa1f2658766333e291940", size = 7675040, upload-time = "2026-07-08T16:07:58.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9c/55ed9cb6dfe3ee9c837df5cd0e758372e5829aa38b8dd71343aa632cc4e2/torchvision-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:87dc16b2df427c1318ad335f1e2be2b3b15b2cf20f7934c83b0505a48425ee5d", size = 4085785, upload-time = "2026-07-08T16:07:50.928Z" },
-    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/40beacd53809194f5259e590d1afaeaa8ad57da15f77c646e6560bcc4616/torchvision-0.28.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bb6dd6918460ed89cc7644adcc2402991474d6933cf1ce92b390641cb233fddf", size = 7797014, upload-time = "2026-07-08T16:07:43.04Z" },
-    { url = "https://files.pythonhosted.org/packages/32/db/062cdb5a84380a60439775311fff34d89229760d2a50680393dc18699956/torchvision-0.28.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad7b3a439265cc3739a4ab5b4c998c0e38ea99c0ee7ca4dea35c5d0b099ec237", size = 7674669, upload-time = "2026-07-08T16:07:38.91Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/a6/b4081e2d04e1541abf82785ac9e5178a494c19330391f551356c8c18b7b3/torchvision-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:7e9dd6f60d6e15f8dc27d4f877fdb6002fc70d70272412135f1c2ff9cfa08d3b", size = 4157380, upload-time = "2026-07-08T16:07:40.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d2/9daad500db2ab880eca0f0a569afd73e1afdd49f22c94560c85546dd87c2/torchvision-0.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:994687b818cac0e6d34cb407a41458e2c3262cb7db927465841c9522ba7ebb92", size = 1813740, upload-time = "2026-09-02T13:47:03.933Z" },
+    { url = "https://files.pythonhosted.org/packages/41/14/702cd035fab1b8dfe944d06827cc4628c3b18e5d7ddaa676bf72c9be1c2c/torchvision-0.29.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b7a736eaa6b2e22476c95ceb62986d195f3e600cdd7d196d7329aa2dfc951994", size = 7586112, upload-time = "2026-09-02T13:47:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/3cf1992414fd712af4865ae5f8f5758d9003c1ed82624908d54f7afb4342/torchvision-0.29.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0e631a2f8b24732672d35224d2574ff89a78d56bef5364ef6094a625fa5f1771", size = 7430773, upload-time = "2026-09-02T13:47:07.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a8/59152b945c09840f582c40e38aa4128777625af7f2883ce2d77133f96a46/torchvision-0.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:0e3b99c62f7f095153887330c2c60c9ebc2da84dfbe08eea564a41ec361629cf", size = 1376791, upload-time = "2026-09-02T13:47:11.283Z" },
+    { url = "https://files.pythonhosted.org/packages/81/56/4e122b6b59269cb2e6a8f7ef969cff7b1eca1499c48784805ad156d3720b/torchvision-0.29.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:28a3964a9e6db34354d4ca440d2c2038deeef24e7219e8d6f49d9d174f44830c", size = 1813739, upload-time = "2026-09-02T13:47:08.63Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/da/1418b42ed642521262d2b276ffb698772f06827202dca9065a66824f69bf/torchvision-0.29.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:83db0299170502b038640444214c99d7b54bad72db447f0554deb8d2c4f02f94", size = 7523336, upload-time = "2026-09-02T13:47:09.769Z" },
+    { url = "https://files.pythonhosted.org/packages/34/78/afa8f85e1f3cb276202ad3af9e36765feee1f0c5ec2942d8522b321e5afc/torchvision-0.29.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:942a3b3fb4e981e1abb7846679ee3882dfc733533a30b68df0dadf6c06f238a9", size = 7430683, upload-time = "2026-09-02T13:47:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1e/72fa361d60e46b4f003ebdc68508467f46d4ef1011650a80258b40d7cf46/torchvision-0.29.0-cp313-cp313-win_amd64.whl", hash = "sha256:ebf54f6744556ebd8d7b5f9b6515e2060e5d3156723970dc257bf093f63b2170", size = 1376791, upload-time = "2026-09-02T13:47:12.471Z" },
 ]
 
 [[package]]
@@ -4650,7 +4612,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.8.1"
+version = "5.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4663,9 +4625,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/e6/4134ea2fbea322cddc7ffc94a0d8ee47fe32ce8e876b320cd37d88edfc4d/transformers-5.8.1.tar.gz", hash = "sha256:4dd5b6de4105725104d84fd6abd74b305f4debfc251b38c648ee5dd087cf543b", size = 8532019, upload-time = "2026-05-13T03:21:57.234Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/2e/ba418680ab901dae269360bb8642485eae04f1af91ee2ebb8bd6f3607305/transformers-5.16.1.tar.gz", hash = "sha256:17b0eac726ddc55e84ac58946063e0c6d37fd000c456b581f050ea0f4e822869", size = 9650542, upload-time = "2026-08-26T14:48:58.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/b1/8be7e7ef0b5200491312201918b6125ef9c9df9dd0f0240ccef9ac824e6b/transformers-5.8.1-py3-none-any.whl", hash = "sha256:5340fb95962162cdfdae5cc91d7f8fedd92ed75216c1154c5e1f590fcf56dd0e", size = 10632882, upload-time = "2026-05-13T03:21:52.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4d/ee3728674c0bbc637bb4af88ccf0be697f92e4e90b55f5dc110c44d61b61/transformers-5.16.1-py3-none-any.whl", hash = "sha256:2f2d5b98a5ad3718713653734298fa620754ed683702a635ebb587df3ed29c7e", size = 12080592, upload-time = "2026-08-26T14:48:55.083Z" },
 ]
 
 [[package]]
@@ -4757,13 +4719,13 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.7.1"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
-    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
-    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/87/07/0f8cd8e8db0472334253efdaaab3d0819fea27aa99bf0e7f1aeea4ceb5ae/triton-3.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9c404c69ed4a39e8ec632eaf6b9fe058a060bf98979c177f6ef666f06bb8d50", size = 226474486, upload-time = "2026-08-28T16:08:18.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/09/b7012e5bfae67640f268aa584caa80fe1674f6b0da949046b679972c33e3/triton-3.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e91ffa46d095b252248297292dd22bcbacd53a125a0c2eefbbbf74925a320bc3", size = 247972921, upload-time = "2026-08-28T15:55:53.157Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/4c564374bcdadb166fccbf3e45aee0d4a473f88d341761bd2fefe3b8e8c1/triton-3.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7004666652f500ed854a86988e4b3d69d247188b5d2092b5df1e44f4a954099", size = 226476793, upload-time = "2026-08-28T16:08:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b6/3394d5548404c1cabd1dadadd28d0b3f9478db1dff8180da53bb3f0a1e19/triton-3.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f0497218e26b7d79773ad9c2a3fa3b539ee69f587a13fac2e552b1d322a8015", size = 247975122, upload-time = "2026-08-28T15:56:04.112Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
psycopg needs a libpq binding in every install mode: bundled (`[binary]`, which statically ships its own libpq/OpenSSL and can conflict with an OpenSSL already loaded by another dependency), compiled (`[c]`, needs a compiler and libpq headers at install time), or system-provided (plain `psycopg`, needs libpq installed on the target machine at runtime — the failure mode that motivated this change). asyncpg reimplements the Postgres wire protocol itself and uses Python's own `ssl` module, so it ships as a normal wheel with no libpq dependency in any form, matching ai4rag's requirement to install and run out of the box.

PGVectorStore's public sync API (search/add_documents/clean_collection/ close) is unchanged: asyncpg's Pool/Connection are bound to the event loop that creates them, so the store now opens one dedicated background event loop per instance and dispatches every DB coroutine onto it via run_coroutine_threadsafe, bridging back to a plain return value for every caller thread (e.g. query_rag()'s ThreadPoolExecutor workers).

Also fixes a latent ordering bug surfaced while rewriting _configure_connection: register_vector() looks up the `vector` type's OID, which does not exist until `CREATE EXTENSION IF NOT EXISTS vector` has run at least once, but the old code called them in the wrong order.

BREAKING CHANGE: PGVectorStore now raises asyncpg exceptions on database errors (e.g. asyncpg.exceptions.PostgresConnectionError) instead of psycopg ones. `psycopg`/`psycopg_pool` are no longer dependencies of ai4rag; `asyncpg` is required instead.


Assisted-by: Claude Code

## Description
Brief summary of changes

## Motivation
Why is this change needed?

## Changes
- Bullet point list of changes
- Another change

## Testing
How did you test this?

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Code follows style guide
- [ ] All checks passing
